### PR TITLE
Adding new error message

### DIFF
--- a/locales/cy/correspondence-address-manual.json
+++ b/locales/cy/correspondence-address-manual.json
@@ -18,6 +18,7 @@
     "error-invalidAddressTown": "City or town must only include letters a to z, numbers and common special characters such as hyphens, spaces and apostrophes welsh",
     "error-invalidAddressCounty": "County or region must only include letters a to z welsh",
     "error-invalidAddressCountry": "Country must only include letters a to z welsh",
+    "error-invalidPostcodeFormat": "Postcode must only include letters a to z, numbers and spaces welsh",
     "error-invalidAddressPostcode": "Enter a full UK postcode welsh",
     "error-invalidPropertyDetailsLength": "Property name or number must be 200 characters or less welsh",
     "error-invalidAddressLine1Length": "Address line 1 must be 50 characters or less welsh",

--- a/locales/cy/corresspondence-address-lookUp.json
+++ b/locales/cy/corresspondence-address-lookUp.json
@@ -12,7 +12,8 @@
     "error-correspondenceLookUpAddressNoPostCode" : "Enter a postcode welsh",
     "error-correspondenceLookUpAddressInvalidPropertyDetails" : "Property name or number must only include letters a to z, numbers and common special characters such as hyphens, spaces and apostrophes welsh",
     "error-correspondenceLookUpAddressInvalidAddressPostcode" : "We cannot find this postcode. Enter a different one, or enter the address manually welsh",
-
+    "error-invalidPostcodeFormat": "Postcode must only include letters a to z, numbers and spaces welsh",
+    "error-invalidAddressPostcode": "Enter a full UK postcode welsh",
     "error-correspondenceLookUpAddresListNoRadioBtnSelected" : "Select the correspondence address welsh"
 
 

--- a/locales/en/correspondence-address-manual.json
+++ b/locales/en/correspondence-address-manual.json
@@ -18,6 +18,7 @@
     "error-invalidAddressTown": "City or town must only include letters a to z, numbers and common special characters such as hyphens, spaces and apostrophes",
     "error-invalidAddressCounty": "County or region must only include letters a to z",
     "error-invalidAddressCountry": "Country must only include letters a to z",
+    "error-invalidPostcodeFormat": "Postcode must only include letters a to z, numbers and spaces",
     "error-invalidAddressPostcode": "Enter a full UK postcode",
     "error-invalidPropertyDetailsLength": "Property name or number must be 200 characters or less",
     "error-invalidAddressLine1Length": "Address line 1 must be 50 characters or less",

--- a/locales/en/corresspondence-address-lookUp.json
+++ b/locales/en/corresspondence-address-lookUp.json
@@ -12,6 +12,7 @@
     "error-correspondenceLookUpAddressNoPostCode" : "Enter a postcode",
     "error-correspondenceLookUpAddressInvalidPropertyDetails" : "Property name or number must only include letters a to z, numbers and common special characters such as hyphens, spaces and apostrophes",
     "error-correspondenceLookUpAddressInvalidAddressPostcode" : "We cannot find this postcode. Enter a different one, or enter the address manually",
-
+    "error-invalidPostcodeFormat": "Postcode must only include letters a to z, numbers and spaces",
+    "error-invalidAddressPostcode": "Enter a full UK postcode",
     "error-correspondenceLookUpAddresListNoRadioBtnSelected" : "Select the correspondence address"
 }

--- a/src/main/validation/correspondenceAddressAutoLookup.ts
+++ b/src/main/validation/correspondenceAddressAutoLookup.ts
@@ -4,12 +4,16 @@ import { getUKAddressesFromPostcode } from "../services/postcode-lookup-service"
 import { UKAddress } from "@companieshouse/api-sdk-node/dist/services/postcode-lookup";
 
 const addressDetailsFormat: RegExp = /^[A-Za-z0-9\-',\s]*$/;
-const addressUKPostcodeFormat: RegExp = /^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$/;
+const addressUKPostcodeFormat:RegExp = /^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$/;
+const addressPostcodevaild:RegExp = /^[A-Za-z0-9\s]*$/;
 
 export const correspondenceAddressAutoLookupValidator = [
 
     body("postCode").trim().notEmpty().withMessage("correspondenceLookUpAddressNoPostCode").bail()
-        .matches(addressUKPostcodeFormat).withMessage("correspondenceLookUpAddressInvalidAddressPostcode").bail()
+        .matches(addressPostcodevaild).withMessage("invalidPostcodeFormat").bail()
+        .matches(addressUKPostcodeFormat).withMessage("invalidAddressPostcode").bail()
+        .isLength({ min: 5, max: 50 }).withMessage("invalidAddressPostcode")
+
         .custom(async (postcode) => {
             postcode = postcode.replace(/\s/g, "");
             const ukAddresses: UKAddress[] = await getUKAddressesFromPostcode(POSTCODE_ADDRESSES_LOOKUP_URL, postcode);

--- a/src/main/validation/correspondenceAddressManual.ts
+++ b/src/main/validation/correspondenceAddressManual.ts
@@ -4,6 +4,7 @@ const otherAddressDetailsFormat:RegExp = /^[A-Za-z0-9\-',\s]*$/;
 const addressTownFormat:RegExp = /^[A-Za-z0-9\-',\s!]*$/;
 const addressCountyAndCountryFormat:RegExp = /^[A-Za-z\s]*$/;
 const addressUKPostcodeFormat:RegExp = /^(([A-Z]{1,2}[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA) ?[0-9][A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1)$/;
+const addressPostcodevaild:RegExp = /^[A-Za-z0-9\s]*$/;
 
 export const correspondenceAddressManualValidator = [
 
@@ -29,6 +30,7 @@ export const correspondenceAddressManualValidator = [
         .isLength({ max: 50 }).withMessage("invalidAddressCountryLength"),
 
     body("addressPostcode").trim().toUpperCase().notEmpty().withMessage("noPostCode").bail()
+        .matches(addressPostcodevaild).withMessage("invalidPostcodeFormat").bail()
         .matches(addressUKPostcodeFormat).withMessage("invalidAddressPostcode").bail()
         .isLength({ min: 5, max: 50 }).withMessage("invalidAddressPostcode")
 ];

--- a/src/test/src/validation/correspondenceAddressLookUp.test.ts
+++ b/src/test/src/validation/correspondenceAddressLookUp.test.ts
@@ -1,40 +1,68 @@
 import supertest from "supertest";
 import app from "../../../main/app";
-import { response } from "express";
+import { correspondenceAddressAutoLookupValidator } from "../../../main/validation/correspondenceAddressAutoLookup";
+import { validationResult } from "express-validator";
+
 const router = supertest(app);
 
-describe("POST /sole-trader/correspondenceAddressAutoLookup", () => {
+describe("Correspondence Address Auto Lookup Validator", () => {
+    it("Valid Address Data Should Pass Validation", async () => {
+        jest.mock("../../../main/services/postcode-lookup-service", () => ({
+            getUKAddressesFromPostcode: jest.fn(async (url, postcode) => {
+                if (postcode === "ValidPostcode") {
+                    return [{
+                        postcode: "ST63LJ",
+                        premise: "10",
+                        addressLine1: "DOWN STREET",
+                        addressLine2: "",
+                        postTown: "LONDON",
+                        country: "UNITED KINGDOM"
+                    }];
+                } else {
+                    return [];
+                }
+            })
+        }));
 
-    it("should return status 400 for incorrect data entered", async () => {
-        const formData = {
-            postCode: "",
-            premise: ""
-        };
-
-        const response = await router.post("/register-acsp/sole-trader/correspondenceAddressAutoLookup").send(formData);
-        expect(response.status).toBe(400);
-        expect(response.text).toContain("Enter a postcode");
-    });
-
-    it("should return status 400 for no postcode entered", async () => {
-        const formData = {
-            postCode: "ST6",
-            premise: "4"
-        };
-
-        const response = await router.post("/register-acsp/sole-trader/correspondenceAddressAutoLookup").send(formData);
-        expect(response.status).toBe(400);
-        expect(response.text).toContain("We cannot find this postcode. Enter a different one, or enter the address manually");
-    });
-
-    it("should return status 400 for no postcode entered", async () => {
-        const formData = {
+        const validAddressData = {
             postCode: "ST63LJ",
-            premise: "6$££kasu"
+            premise: "10 "
         };
 
-        const response = await router.post("/register-acsp/sole-trader/correspondenceAddressAutoLookup").send(formData);
-        expect(response.status).toBe(400);
-        expect(response.text).toContain("Property name or number must only include letters a to z, numbers and common special characters such as hyphens, spaces and apostrophes");
+        const req = { body: validAddressData };
+        const res = { locals: {} };
+
+        for (const validationChain of correspondenceAddressAutoLookupValidator) {
+            await validationChain(req, res, () => {});
+        }
+
+        const errors = validationResult(req);
+        console.log(errors);
+        expect(errors.isEmpty()).toBe(true);
+    });
+
+    it("Invalid Address Data Should Fail Validation", async () => {
+        jest.mock("../../../main/services/postcode-lookup-service", () => ({
+            getUKAddressesFromPostcode: jest.fn(async (url, postcode) => {
+                return [];
+            })
+        }));
+
+        const invalidAddressData = {
+            postCode: "InvalidPostcode",
+            premise: "Invalid Property Details",
+        };
+
+        const req = { body: invalidAddressData };
+        const res = { locals: {} };
+
+        for (const validationChain of correspondenceAddressAutoLookupValidator) {
+            await validationChain(req, res, () => {});
+        }
+
+        const errors = validationResult(req);
+
+        expect(errors.isEmpty()).toBe(false);
+        expect(errors.array()).toHaveLength(1);
     });
 });

--- a/src/test/src/validation/correspondenceAddressManual.test.ts
+++ b/src/test/src/validation/correspondenceAddressManual.test.ts
@@ -40,7 +40,7 @@ describe("Correspondence Address Manual Validator", () => {
             addressTown: "",
             addressCounty: "Invalid County Name!@#",
             addressCountry: "Invalid Country Name!@#",
-            addressPostcode: "Invalid_Postcode"
+            addressPostcode: "INVALID_POSTCODE"
         };
 
         const req = { body: invalidAddressData };
@@ -54,7 +54,15 @@ describe("Correspondence Address Manual Validator", () => {
 
         const errors = validationResult(req);
 
-        expect(errors.isEmpty()).toBe(false);
-        expect(errors.array()).toHaveLength(6);
+        const expectedErrors = [
+            { location: "body", msg: "noPropertyDetails", param: "addressPropertyDetails", value: "" },
+            { location: "body", msg: "invalidAddressLine1", param: "addressLine1", value: "Invalid!@#" },
+            { location: "body", msg: "noCityOrTown", param: "addressTown", value: "" },
+            { location: "body", msg: "invalidAddressCounty", param: "addressCounty", value: "Invalid County Name!@#" },
+            { location: "body", msg: "invalidAddressCountry", param: "addressCountry", value: "Invalid Country Name!@#" },
+            { location: "body", msg: "invalidPostcodeFormat", param: "addressPostcode", value: "INVALID_POSTCODE" }
+        ];
+
+        expect(errors.array()).toMatchObject(expectedErrors);
     });
 });

--- a/src/test/src/validation/correspondenceAddressManual.test.ts
+++ b/src/test/src/validation/correspondenceAddressManual.test.ts
@@ -1,0 +1,60 @@
+import supertest from "supertest";
+import app from "../../../main/app";
+import { correspondenceAddressManualValidator } from "../../../main/validation/correspondenceAddressManual";
+import { validationResult } from "express-validator";
+
+const router = supertest(app);
+
+describe("Correspondence Address Manual Validator", () => {
+    it("Valid Address Data Should Pass Validation", () => {
+        const validAddressData = {
+            addressPropertyDetails: "Valid Property Details",
+            addressLine1: "Valid Address Line 1",
+            addressLine2: "Valid Address Line 2",
+            addressTown: "Valid City Or Town",
+            addressCounty: "Valid County",
+            addressCountry: "Valid Country",
+            addressPostcode: "Valid1234",
+        };
+
+        const req = { body: validAddressData };
+        const res = { locals: {} };
+
+        for (const validationChain of correspondenceAddressManualValidator) {
+
+            if (typeof validationChain === "function") {
+                validationChain(req, res, () => {});
+            }
+        }
+
+        const errors = validationResult(req);
+
+        expect(errors.isEmpty()).toBe(true);
+    });
+
+    it("Invalid Address Data Should Fail Validation", async () => {
+        const invalidAddressData = {
+            addressPropertyDetails: "",
+            addressLine1: "Invalid!@#",
+            addressLine2: "Invalid Address Line 2",
+            addressTown: "",
+            addressCounty: "Invalid County Name!@#",
+            addressCountry: "Invalid Country Name!@#",
+            addressPostcode: "Invalid_Postcode"
+        };
+
+        const req = { body: invalidAddressData };
+        const res = { locals: {} };
+
+        for (const validationChain of correspondenceAddressManualValidator) {
+            if (typeof validationChain === "function") {
+                await validationChain(req, res, () => {});
+            }
+        }
+
+        const errors = validationResult(req);
+
+        expect(errors.isEmpty()).toBe(false);
+        expect(errors.array()).toHaveLength(6);
+    });
+});


### PR DESCRIPTION
Adding new error message for What is your correspondence address screens. When user put half post code they will get this error "Enter a full UK postcode" and when user give a input rather than letters from a to z, numbers and spaces they will get this error message "Postcode must only include letters a to z, numbers and spaces". In this PR I have added both error message with welsh translation and unit tests.
