### PR TITLE
pageurls - fix context path

### DIFF
--- a/src/main/router.dispatch.ts
+++ b/src/main/router.dispatch.ts
@@ -1,9 +1,10 @@
 // Do Router dispatch here, i.e. map incoming routes to appropriate router
 import { Application, Request, Response } from "express";
 import routes from "./routes";
+import { BASE_URL } from "./types/pageURL";
 
 const routerDispatch = (app: Application) => {
-    app.use("/register-acsp", routes);
+    app.use(BASE_URL, routes);
     app.use("*", (req: Request, res: Response) => {
         res.status(404).render("partials/error_400");
     });

--- a/src/main/types/pageURL.ts
+++ b/src/main/types/pageURL.ts
@@ -16,7 +16,7 @@ export const COMPANY_NUMBER_URL = `${HOME_URL}/${COMPANY_NUMBER_PAGE}`;
 
 export const HEALTHCHECK = "/healthcheck";
 
-export const BASE_URL = "/register-acsp";
+export const BASE_URL = "/register-as-companies-house-authorised-agent";
 
 export const SOLE_TRADER = "/sole-trader";
 

--- a/src/main/views/partials/__footer.njk
+++ b/src/main/views/partials/__footer.njk
@@ -14,7 +14,7 @@
             <a class="govuk-footer__link" data-track-category="footerClicked" data-track-action="supportLink" data-track-label="/help/cookies" data-track-options="{&quot;dimension29&quot;:&quot;Cookies&quot;}" href="/cookies">Cookies</a>
           </li>
           <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" data-track-category="footerClicked" data-track-action="supportLink" data-track-label="/accessibility-statement" data-track-options="{&quot;dimension29&quot;:&quot;Accessibility statement&quot;}" href="/register-acsp/accessibility-statement">Accessibility statement</a>
+            <a class="govuk-footer__link" data-track-category="footerClicked" data-track-action="supportLink" data-track-label="/accessibility-statement" data-track-options="{&quot;dimension29&quot;:&quot;Accessibility statement&quot;}" href="/register-as-companies-house-authorised-agent/accessibility-statement">Accessibility statement</a>
           </li>
           <li class="govuk-footer__inline-list-item">
             <a class="govuk-footer__link" data-track-category="footerClicked" data-track-action="supportLink" data-track-label="/contact" data-track-options="{&quot;dimension29&quot;:&quot;Contact&quot;}" href="/contact">Contact</a>

--- a/src/main/views/partials/__header.njk
+++ b/src/main/views/partials/__header.njk
@@ -3,7 +3,7 @@
 {{ govukHeader({
     homepageUrl: "https://www.gov.uk/",
     serviceName: "Apply to register as a Companies House authorised agent",
-    serviceUrl: "/register-acsp/home"
+    serviceUrl: "/register-as-companies-house-authorised-agent/home"
   })
 }}
 </div>

--- a/src/test/e2e/features/stopnotrelevantofficerRouter.ts
+++ b/src/test/e2e/features/stopnotrelevantofficerRouter.ts
@@ -1,10 +1,11 @@
 import assert from "assert";
 import supertest from "supertest";
 import app from "../../../main/app";
+import { BASE_URL, STOP_NOT_RELEVANT_OFFICER } from "../../../main/types/pageURL";
 
 describe("E2E Test", () => {
     it("should render stop-not-relevant-officer page", async () => {
-        const response = await supertest(app).get("/register-as-companies-house-authorised-agent/sole-trader/stop-not-relevant-officer");
+        const response = await supertest(app).get(BASE_URL + STOP_NOT_RELEVANT_OFFICER);
         assert(response.text.includes("Stop Not Relevant Officer"));
     });
 

--- a/src/test/e2e/features/stopnotrelevantofficerRouter.ts
+++ b/src/test/e2e/features/stopnotrelevantofficerRouter.ts
@@ -4,7 +4,7 @@ import app from "../../../main/app";
 
 describe("E2E Test", () => {
     it("should render stop-not-relevant-officer page", async () => {
-        const response = await supertest(app).get("/register-acsp/sole-trader/stop-not-relevant-officer");
+        const response = await supertest(app).get("/register-as-companies-house-authorised-agent/sole-trader/stop-not-relevant-officer");
         assert(response.text.includes("Stop Not Relevant Officer"));
     });
 

--- a/src/test/src/controllers/indexController.test.ts
+++ b/src/test/src/controllers/indexController.test.ts
@@ -1,13 +1,12 @@
 import supertest from "supertest";
 import app from "../../../main/app";
-import { BASE_URL } from "../../../main/types/pageURL";
+import { BASE_URL, HOME_URL } from "../../../main/types/pageURL";
 const router = supertest(app);
 
 describe("Home Page tests -", () => {
-"GET " + BASE_URL +
-    describe("GET /register-as-companies-house-authorised-agent/home", () => {
+    describe("GET " + HOME_URL, () => {
         it("should return status 200", async () => {
-            await router.get("/register-as-companies-house-authorised-agent/home");
+            await router.get(BASE_URL + HOME_URL);
             expect(200);
         });
     });

--- a/src/test/src/controllers/indexController.test.ts
+++ b/src/test/src/controllers/indexController.test.ts
@@ -4,10 +4,10 @@ import { BASE_URL } from "../../../main/types/pageURL";
 const router = supertest(app);
 
 describe("Home Page tests -", () => {
-
-    describe("GET /register-acsp/home", () => {
+"GET " + BASE_URL +
+    describe("GET /register-as-companies-house-authorised-agent/home", () => {
         it("should return status 200", async () => {
-            await router.get("/register-acsp/home");
+            await router.get("/register-as-companies-house-authorised-agent/home");
             expect(200);
         });
     });

--- a/src/test/src/controllers/otherTypeOfBusinessController.test.ts
+++ b/src/test/src/controllers/otherTypeOfBusinessController.test.ts
@@ -9,7 +9,7 @@ const router = supertest(app);
 
 describe("GET " + OTHER_TYPE_OF_BUSINESS, () => {
     it("should return status 200", async () => {
-        await router.get("/register-acsp/" + OTHER_TYPE_OF_BUSINESS).expect(200);
+        await router.get("/register-as-companies-house-authorised-agent/" + OTHER_TYPE_OF_BUSINESS).expect(200);
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
         expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
     });

--- a/src/test/src/controllers/otherTypeOfBusinessController.test.ts
+++ b/src/test/src/controllers/otherTypeOfBusinessController.test.ts
@@ -9,7 +9,7 @@ const router = supertest(app);
 
 describe("GET " + OTHER_TYPE_OF_BUSINESS, () => {
     it("should return status 200", async () => {
-        await router.get("/register-as-companies-house-authorised-agent/" + OTHER_TYPE_OF_BUSINESS).expect(200);
+        await router.get(BASE_URL + OTHER_TYPE_OF_BUSINESS).expect(200);
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
         expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
     });

--- a/src/test/src/controllers/soleTradercorrespondenceAddressConfirmController.test.ts
+++ b/src/test/src/controllers/soleTradercorrespondenceAddressConfirmController.test.ts
@@ -25,6 +25,6 @@ describe("GET" + SOLE_TRADER_CORRESPONDENCE_ADDRESS_CONFIRM, () => {
 
 describe("POST SOLE_TRADER_CORRESPONDENCE_ADDRESS_CONFIRM", () => {
     xit("should redirect to /type-of-acsp with status 302", async () => {
-        await router.post(BASE_URL + SOLE_TRADER_CORRESPONDENCE_ADDRESS_CONFIRM).expect(302).expect("Location", "/register-acsp/type-of-acsp");
+        await router.post(BASE_URL + SOLE_TRADER_CORRESPONDENCE_ADDRESS_CONFIRM).expect(302).expect("Location", "/register-as-companies-house-authorised-agent/type-of-acsp");
     });
 });

--- a/src/test/src/controllers/soleTradercorrespondenceAddressConfirmController.test.ts
+++ b/src/test/src/controllers/soleTradercorrespondenceAddressConfirmController.test.ts
@@ -2,7 +2,7 @@ import mocks from "../../mocks/all_middleware_mock";
 import supertest from "supertest";
 import app from "../../../main/app";
 
-import { SOLE_TRADER_CORRESPONDENCE_ADDRESS_CONFIRM, BASE_URL } from "../../../main/types/pageURL";
+import { SOLE_TRADER_CORRESPONDENCE_ADDRESS_CONFIRM, BASE_URL, TYPE_OF_BUSINESS } from "../../../main/types/pageURL";
 
 jest.mock("@companieshouse/api-sdk-node");
 const router = supertest(app);
@@ -25,6 +25,6 @@ describe("GET" + SOLE_TRADER_CORRESPONDENCE_ADDRESS_CONFIRM, () => {
 
 describe("POST SOLE_TRADER_CORRESPONDENCE_ADDRESS_CONFIRM", () => {
     xit("should redirect to /type-of-acsp with status 302", async () => {
-        await router.post(BASE_URL + SOLE_TRADER_CORRESPONDENCE_ADDRESS_CONFIRM).expect(302).expect("Location", "/register-as-companies-house-authorised-agent/type-of-acsp");
+        await router.post(BASE_URL + SOLE_TRADER_CORRESPONDENCE_ADDRESS_CONFIRM).expect(302).expect("Location", BASE_URL + TYPE_OF_BUSINESS);
     });
 });


### PR DESCRIPTION
changes context path.
footer.njk and header.njk still uses hardcoded urls, as every controller need to be updated if we want to use reference which is a big job.