### PR TITLE
Fixed Northern Ireland being hyphenated on Check your answers screen

### DIFF
--- a/src/services/where-do-you-live/whereDoYouLive.ts
+++ b/src/services/where-do-you-live/whereDoYouLive.ts
@@ -9,7 +9,7 @@ export class WhereDoYouLivBodyService {
         case "England":
         case "Scotland":
         case "Wales":
-        case "Northern-Ireland":
+        case "Northern Ireland":
             payload = { whereDoYouLiveRadio: ascpData?.countryOfResidence };
             break;
         default:

--- a/src/views/features/sole-trader/where-do-you-live/where-do-you-live.njk
+++ b/src/views/features/sole-trader/where-do-you-live/where-do-you-live.njk
@@ -39,7 +39,7 @@
       text: i18n.whereDoYouLiveText3
     },
     {
-      value: "Northern-Ireland",
+      value: "Northern Ireland",
       text: i18n.whereDoYouLiveText4
     },
     {

--- a/test/src/services/transaction/transaction_service.test.ts
+++ b/test/src/services/transaction/transaction_service.test.ts
@@ -158,7 +158,6 @@ describe("transaction service tests", () => {
             } as ApiResponse<Transaction>);
 
             const url = await closeTransaction(session, TRANSACTION_ID);
-            
             expect(url).toBe(paymentUrl);
         });
 

--- a/test/src/services/where-do-you-live/whereDoYouLive.test.ts
+++ b/test/src/services/where-do-you-live/whereDoYouLive.test.ts
@@ -47,11 +47,11 @@ describe("WhereDoYouLiveBodyService", () => {
         const acspData: AcspData = {
             id: "abc",
             typeOfBusiness: "LIMITED",
-            countryOfResidence: "Northern-Ireland"
+            countryOfResidence: "Northern Ireland"
         };
 
         const { payload, countryInput } = whereDoYouLiveBodyService.getCountryPayload(acspData);
-        expect(payload).toEqual({ whereDoYouLiveRadio: "Northern-Ireland" });
+        expect(payload).toEqual({ whereDoYouLiveRadio: "Northern Ireland" });
         expect(countryInput).toBeUndefined();
     });
 


### PR DESCRIPTION
Removed hyphen from Northern Ireland value in njk file
Updated the service to repopulate the data after removing hyphen