### PR TITLE
Updating work sector page as selection is now optional

### DIFF
--- a/locales/cy/sector-you-work-in.json
+++ b/locales/cy/sector-you-work-in.json
@@ -1,11 +1,11 @@
 {
     "sectorYouWorkInTitle" : "Ym mha sector ydych chi'n gweithio?",
+    "sectorYouWorkInOptionalHintText" : "This is optional. If you want to skip the question, select the 'Save and continue' button without selecting an option. Welsh",
     "sectorYouWorkInAuditorsInsolvencyPractitionersOption": "Archwilwyr, ymarferwyr ansolfedd, cyfrifwyr allanol a chynghorwyr treth",
     "sectorYouWorkInIndependentLegalProfessionalsOption": "Gweithwyr cyfreithiol annibynnol proffesiynol",
     "sectorYouWorkInTrustOrCompanyServiceProvidersOption": "Ymddiriedolaeth neu ddarparwyr gwasanaeth cwmni",
     "sectorYouWorkInCreditInstitutionsOption": "Sefydliadau credyd",
     "sectorYouWorkInFinancialInstitutionsOption": "Sefydliadau ariannol",
     "sectorYouWorkInOtherOption": "Arall",
-   
-    "error-sectorYouWorkInSelectRadio" : "Dewiswch pa sector rydych chi'n gweithio ynddo"
+    "sectorYouWorkInNotProvided": "Not provided Welsh"
 }

--- a/locales/en/sector-you-work-in.json
+++ b/locales/en/sector-you-work-in.json
@@ -1,10 +1,11 @@
 {
     "sectorYouWorkInTitle" : "Which sector do you work in?",
+    "sectorYouWorkInHintText" : "This is optional. If you want to skip the question, select the 'Save and continue' button without selecting an option.",
     "sectorYouWorkInAuditorsInsolvencyPractitionersOption": "Auditors, insolvency practitioners, external accountants and tax advisers",
     "sectorYouWorkInIndependentLegalProfessionalsOption": "Independent legal professionals",
     "sectorYouWorkInTrustOrCompanyServiceProvidersOption": "Trust or company service providers",
     "sectorYouWorkInCreditInstitutionsOption": "Credit institutions",
     "sectorYouWorkInFinancialInstitutionsOption": "Financial institutions",
     "sectorYouWorkInOtherOption": "Other",
-    "error-sectorYouWorkInSelectRadio" : "Select which sector you work in"
+    "sectorYouWorkInNotProvided": "Not provided"
 }

--- a/src/controllers/features/limited/sectorYouWorkInController.ts
+++ b/src/controllers/features/limited/sectorYouWorkInController.ts
@@ -52,10 +52,10 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         } else {
             if (acspData) {
                 acspData.workSector = req.body.sectorYouWorkIn;
+                // save data to mongodb
+                const acspDataService = new AcspDataService();
+                await acspDataService.saveAcspData(session, acspData);
             }
-            // save data to mongodb
-            const acspDataService = new AcspDataService();
-            await acspDataService.saveAcspData(session, acspData);
             res.redirect(addLangToUrl(BASE_URL + LIMITED_SELECT_AML_SUPERVISOR, lang));
         }
     } catch (err) {

--- a/src/controllers/features/limited/sectorYouWorkInController.ts
+++ b/src/controllers/features/limited/sectorYouWorkInController.ts
@@ -1,7 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import { validationResult } from "express-validator";
 import * as config from "../../../config";
-import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { LIMITED_SECTOR_YOU_WORK_IN, LIMITED_WHAT_IS_THE_CORRESPONDENCE_ADDRESS, LIMITED_CORRESPONDENCE_ADDRESS_CONFIRM, BASE_URL, LIMITED_WHICH_SECTOR_OTHER, LIMITED_SELECT_AML_SUPERVISOR } from "../../../types/pageURL";
 import { saveDataInSession } from "../../../common/__utils/sessionHelper";
@@ -47,28 +45,18 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const locales = getLocalesService();
     const currentUrl = BASE_URL + LIMITED_SECTOR_YOU_WORK_IN;
     try {
-        const errorList = validationResult(req);
         const session: Session = req.session as any as Session;
         const acspData : AcspData = session?.getExtraData(USER_DATA)!;
-        if (!errorList.isEmpty()) {
-            const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
-
-            res.status(400).render(config.SECTOR_YOU_WORK_IN, {
-                previousPage: addLangToUrl(getPreviousPage(acspData), lang),
-                ...getLocaleInfo(locales, lang),
-                currentUrl,
-                ...pageProperties
-            });
+        if (req.body.sectorYouWorkIn === "OTHER") {
+            res.redirect(addLangToUrl(BASE_URL + LIMITED_WHICH_SECTOR_OTHER, lang));
         } else {
-            if (req.body.sectorYouWorkIn === "OTHER") {
-                res.redirect(addLangToUrl(BASE_URL + LIMITED_WHICH_SECTOR_OTHER, lang));
-            } else {
-                //  save data to mongodb
+            if (acspData) {
                 acspData.workSector = req.body.sectorYouWorkIn;
-                const acspDataService = new AcspDataService();
-                await acspDataService.saveAcspData(session, acspData);
-                res.redirect(addLangToUrl(BASE_URL + LIMITED_SELECT_AML_SUPERVISOR, lang));
             }
+            // save data to mongodb
+            const acspDataService = new AcspDataService();
+            await acspDataService.saveAcspData(session, acspData);
+            res.redirect(addLangToUrl(BASE_URL + LIMITED_SELECT_AML_SUPERVISOR, lang));
         }
     } catch (err) {
         logger.error(POST_ACSP_REGISTRATION_DETAILS_ERROR + " " + JSON.stringify(err));

--- a/src/controllers/features/sole-trader/sectorYouWorkInController.ts
+++ b/src/controllers/features/sole-trader/sectorYouWorkInController.ts
@@ -58,10 +58,10 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         } else {
             if (acspData) {
                 acspData.workSector = req.body.sectorYouWorkIn;
+                // save data to mongodb
+                const acspDataService = new AcspDataService();
+                await acspDataService.saveAcspData(session, acspData);
             }
-            // save data to mongodb
-            const acspDataService = new AcspDataService();
-            await acspDataService.saveAcspData(session, acspData);
             res.redirect(addLangToUrl(BASE_URL + SOLE_TRADER_AUTO_LOOKUP_ADDRESS, lang));
         }
     } catch (err) {

--- a/src/controllers/features/sole-trader/sectorYouWorkInController.ts
+++ b/src/controllers/features/sole-trader/sectorYouWorkInController.ts
@@ -1,7 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import { validationResult } from "express-validator";
 import * as config from "../../../config";
-import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { SOLE_TRADER_SECTOR_YOU_WORK_IN, SOLE_TRADER_AUTO_LOOKUP_ADDRESS, BASE_URL, SOLE_TRADER_WHICH_SECTOR_OTHER, SOLE_TRADER_WHAT_IS_THE_BUSINESS_NAME } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
@@ -53,34 +51,18 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const locales = getLocalesService();
     const currentUrl: string = BASE_URL + SOLE_TRADER_SECTOR_YOU_WORK_IN;
     try {
-        const previousPage: string = addLangToUrl(BASE_URL + SOLE_TRADER_WHAT_IS_THE_BUSINESS_NAME, lang);
         const session: Session = req.session as any as Session;
         const acspData: AcspData = session?.getExtraData(USER_DATA)!;
-        const acspType = acspData?.typeOfBusiness;
-        const errorList = validationResult(req);
-        if (!errorList.isEmpty()) {
-            const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
-            res.status(400).render(config.SECTOR_YOU_WORK_IN, {
-                previousPage,
-                ...getLocaleInfo(locales, lang),
-                currentUrl,
-                firstName: acspData?.applicantDetails?.firstName,
-                lastName: acspData?.applicantDetails?.lastName,
-                acspType: acspType,
-                ...pageProperties
-            });
+        if (req.body.sectorYouWorkIn === "OTHER") {
+            res.redirect(addLangToUrl(BASE_URL + SOLE_TRADER_WHICH_SECTOR_OTHER, lang));
         } else {
-            if (req.body.sectorYouWorkIn === "OTHER") {
-                res.redirect(addLangToUrl(BASE_URL + SOLE_TRADER_WHICH_SECTOR_OTHER, lang));
-            } else {
-                if (acspData) {
-                    acspData.workSector = req.body.sectorYouWorkIn;
-                }
-                // save data to mongodb
-                const acspDataService = new AcspDataService();
-                await acspDataService.saveAcspData(session, acspData);
-                res.redirect(addLangToUrl(BASE_URL + SOLE_TRADER_AUTO_LOOKUP_ADDRESS, lang));
+            if (acspData) {
+                acspData.workSector = req.body.sectorYouWorkIn;
             }
+            // save data to mongodb
+            const acspDataService = new AcspDataService();
+            await acspDataService.saveAcspData(session, acspData);
+            res.redirect(addLangToUrl(BASE_URL + SOLE_TRADER_AUTO_LOOKUP_ADDRESS, lang));
         }
     } catch (err) {
         logger.error(POST_ACSP_REGISTRATION_DETAILS_ERROR + " " + JSON.stringify(err));

--- a/src/controllers/features/unincorporated/unincorporatedSectorYouWorkInController.ts
+++ b/src/controllers/features/unincorporated/unincorporatedSectorYouWorkInController.ts
@@ -54,10 +54,10 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         } else {
             if (acspData) {
                 acspData.workSector = req.body.sectorYouWorkIn;
+                // save data to mongodb
+                const acspDataService = new AcspDataService();
+                await acspDataService.saveAcspData(session, acspData);
             }
-            // save data to mongodb
-            const acspDataService = new AcspDataService();
-            await acspDataService.saveAcspData(session, acspData);
             res.redirect(addLangToUrl(BASE_URL + UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP, lang));
         }
     } catch (err) {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -70,7 +70,6 @@ import { dateOfBirthValidator } from "../validation/dateOfBirth";
 import { nameRegisteredWithAmlValidator } from "../validation/nameRegisteredWithAml";
 import { nationalityValidator } from "../validation/nationality";
 import { otherTypeOfBusinessValidator } from "../validation/otherTypeOfBusiness";
-import { sectorYouWorkInValidator } from "../validation/sectorYouWorkIn";
 import { whatIsYourRoleValidator } from "../validation/whatIsYourRole";
 import { typeOfBusinessValidator } from "../validation/typeOfBusiness";
 import { soleTraderWhatIsTheBusinessNameValidator } from "../validation/soleTraderWhatIsTheBusinessName";
@@ -130,7 +129,7 @@ routes.get(urls.SOLE_TRADER_WHAT_IS_YOUR_NAME, soleTraderNameController.get);
 routes.post(urls.SOLE_TRADER_WHAT_IS_YOUR_NAME, nameValidator, soleTraderNameController.post);
 
 routes.get(urls.SOLE_TRADER_SECTOR_YOU_WORK_IN, soleTraderSectorYouWorkInController.get);
-routes.post(urls.SOLE_TRADER_SECTOR_YOU_WORK_IN, sectorYouWorkInValidator, soleTraderSectorYouWorkInController.post);
+routes.post(urls.SOLE_TRADER_SECTOR_YOU_WORK_IN, soleTraderSectorYouWorkInController.post);
 
 routes.get(urls.SOLE_TRADER_WHICH_SECTOR_OTHER, soleTraderWhichSectorOtherController.get);
 routes.post(urls.SOLE_TRADER_WHICH_SECTOR_OTHER, whichSectorOtherValidator, soleTraderWhichSectorOtherController.post);
@@ -176,7 +175,7 @@ routes.get(urls.LIMITED_WHAT_IS_THE_COMPANY_NUMBER, limitedCompanyLookupControll
 routes.post(urls.LIMITED_WHAT_IS_THE_COMPANY_NUMBER, companyNumberValidator, limitedCompanyLookupController.post);
 
 routes.get(urls.LIMITED_SECTOR_YOU_WORK_IN, limitedSectorYouWorkInController.get);
-routes.post(urls.LIMITED_SECTOR_YOU_WORK_IN, sectorYouWorkInValidator, limitedSectorYouWorkInController.post);
+routes.post(urls.LIMITED_SECTOR_YOU_WORK_IN, limitedSectorYouWorkInController.post);
 
 routes.get(urls.LIMITED_WHICH_SECTOR_OTHER, limitedWhichSectorOtherController.get);
 routes.post(urls.LIMITED_WHICH_SECTOR_OTHER, whichSectorOtherValidator, limitedWhichSectorOtherController.post);
@@ -223,7 +222,7 @@ routes.get(urls.UNINCORPORATED_WHAT_IS_YOUR_ROLE, unincorporatedWhatIsYourRoleCo
 routes.post(urls.UNINCORPORATED_WHAT_IS_YOUR_ROLE, whatIsYourRoleValidator, unincorporatedWhatIsYourRoleController.post);
 
 routes.get(urls.UNINCORPORATED_WHICH_SECTOR, unincorporatedSectorYouWorkInController.get);
-routes.post(urls.UNINCORPORATED_WHICH_SECTOR, sectorYouWorkInValidator, unincorporatedSectorYouWorkInController.post);
+routes.post(urls.UNINCORPORATED_WHICH_SECTOR, unincorporatedSectorYouWorkInController.post);
 
 routes.get(urls.UNINCORPORATED_WHICH_SECTOR_OTHER, unincorporatedWhichSectorOtherController.get);
 routes.post(urls.UNINCORPORATED_WHICH_SECTOR_OTHER, whichSectorOtherValidator, unincorporatedWhichSectorOtherController.post);

--- a/src/services/checkYourAnswersService.ts
+++ b/src/services/checkYourAnswersService.ts
@@ -67,6 +67,8 @@ const sectorTranslated = (sector: string, i18n: any): string => {
         return i18n.whichSectorOtherHighValueDealersOption;
     case "CASINOS":
         return i18n.whichSectorOtherCasinosOption;
+    case "Not provided":
+        return i18n.sectorYouWorkInNotProvided;
     default:
         return sector;
     }
@@ -89,7 +91,12 @@ export const getAnswers = (req: Request, acspData: AcspData, i18n: any): Answers
     let answers: Answers = {};
     answers.typeOfBusiness = typeOfBusinessTranslated(acspData.typeOfBusiness!, i18n);
     answers.roleType = roleTranslated(acspData.roleType!, i18n);
-    answers.workSector = sectorTranslated(acspData.workSector!, i18n);
+    if (acspData.workSector !== null) {
+        answers.workSector = sectorTranslated(acspData.workSector!, i18n);
+    } else {
+        const notProvidedText = "Not provided";
+        answers.workSector = sectorTranslated(notProvidedText, i18n);
+    }
     if (acspData.typeOfBusiness === "LC" || acspData.typeOfBusiness === "LLP" || acspData.typeOfBusiness === "CORPORATE_BODY") {
         answers = limitedAnswers(req, answers, acspData);
     } else if (acspData.typeOfBusiness === "SOLE_TRADER") {

--- a/src/services/checkYourAnswersService.ts
+++ b/src/services/checkYourAnswersService.ts
@@ -91,8 +91,8 @@ export const getAnswers = (req: Request, acspData: AcspData, i18n: any): Answers
     let answers: Answers = {};
     answers.typeOfBusiness = typeOfBusinessTranslated(acspData.typeOfBusiness!, i18n);
     answers.roleType = roleTranslated(acspData.roleType!, i18n);
-    if (acspData.workSector !== null) {
-        answers.workSector = sectorTranslated(acspData.workSector!, i18n);
+    if (acspData.workSector != null) {
+        answers.workSector = sectorTranslated(acspData.workSector, i18n);
     } else {
         const notProvidedText = "Not provided";
         answers.workSector = sectorTranslated(notProvidedText, i18n);

--- a/src/validation/sectorYouWorkIn.ts
+++ b/src/validation/sectorYouWorkIn.ts
@@ -1,5 +1,5 @@
 import { body } from "express-validator";
 
 export const sectorYouWorkInValidator = [
-    body("sectorYouWorkIn", "sectorYouWorkInSelectRadio").notEmpty()
+    body("sectorYouWorkIn", "sectorYouWorkInSelectRadio").optional({ nullable: true, checkFalsy: true })
 ];

--- a/src/validation/sectorYouWorkIn.ts
+++ b/src/validation/sectorYouWorkIn.ts
@@ -1,5 +1,0 @@
-import { body } from "express-validator";
-
-export const sectorYouWorkInValidator = [
-    body("sectorYouWorkIn", "sectorYouWorkInSelectRadio").optional({ nullable: true, checkFalsy: true })
-];

--- a/src/views/common/sector-you-work-in/sector-you-work-in.njk
+++ b/src/views/common/sector-you-work-in/sector-you-work-in.njk
@@ -20,6 +20,11 @@
           classes: "govuk-fieldset__legend--l"
         }
       },
+      hint: {
+        text: i18n.sectorYouWorkInHintText,
+        id: "what-sector-hint",
+        classes: "govuk-hint govuk-!-padding-bottom-2"
+      },
       value: workSector,
       items: [
         {
@@ -61,13 +66,34 @@
   </form>
 
 <script>
-  trackEventBasedOnPageTitle("AIA-id",  "select-option", "Auditors, insolvency practitioners, external accountants and tax advisers");
-  trackEventBasedOnPageTitle("ILP-id", "select-option", "Independent-legal-professionals");
-  trackEventBasedOnPageTitle("TCSP-id", "select-option", "Trust-or-company-service-providers");
-  trackEventBasedOnPageTitle("CI-id", "select-option", "Credit-institutions");
-  trackEventBasedOnPageTitle("FI-id", "select-option", "Financial-institutions");
-  trackEventBasedOnPageTitle("OTHER-id", "select-option", "Other");
-  trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - Sector you work in");
+let selectedRadio = null;
+
+// Function to track Matomo analytics based on the selected radio button
+function trackRadioSelection() {
+  const radioButtons = document.querySelectorAll('input[name="sectorYouWorkIn"]'); 
+  radioButtons.forEach((radio) => {
+    radio.addEventListener("click", (event) => {
+      // Set selectedRadio to the capture the properties of the selected radio button 
+      selectedRadio = event.target;
+      // Capture the text content of the selected radio button
+      const labelText = document.querySelector(`label[for="${selectedRadio.id}"]`).textContent.trim();     
+      // Track event based on the selected radio button id and text content
+      trackEventBasedOnRadioId(selectedRadio.id, "{{title}}", "select-option", labelText);
+      trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - Sector you work in");
+    });
+  });
+}
+
+// Run trackRadioSelection function
+trackRadioSelection();
+
+// EventListener to track the value of selectedRadio when save and continue button is clicked
+document.getElementById("save-continue-button").addEventListener("click", () => {
+  // If no radio button has been selected then work sector has not been provided
+  if (!selectedRadio) {
+    trackEventWorkSectorNotProvided("save-continue-button", "click-button", "SAVE AND CONTINUE - Sector you work in - Not provided");
+  }
+});
 </script>
 
 {% endblock main_content %}

--- a/src/views/partials/piwik.njk
+++ b/src/views/partials/piwik.njk
@@ -31,5 +31,20 @@ function trackEventBasedOnPageTitle(elementId, eventCategory, eventAction, event
         _paq.push(["trackEvent", eventCategory, eventAction, eventName]);
     });
 }
+
+// Matomo function for use on Work Sector page when page is skipped
+function trackEventWorkSectorNotProvided(elementId, eventCategory, eventAction, eventName) {
+  document.getElementById(elementId);
+        _paq.push(["trackEvent", eventCategory, eventAction, eventName]);
+}
+
+// Matomo function to capture radio button selection
+function trackEventBasedOnRadioId(elementId, eventCategory, eventAction) {
+    const radioButton = document.getElementById(elementId);
+    if (radioButton) {
+      const labelText = document.querySelector(`label[for="${radioButton.id}"]`).textContent.trim();
+      _paq.push(["trackEvent", eventCategory, eventAction, labelText]);
+    }
+}
 </script>
 <!-- Matomo Ends -->

--- a/test/mocks/check_your_answers.mock.ts
+++ b/test/mocks/check_your_answers.mock.ts
@@ -67,11 +67,55 @@ export const mockSoleTraderAcspData: AcspData = {
     },
     businessName: "Test Business 123"
 };
+export const mockSoleTraderAcspDataWorkSectorNotProvided: AcspData = {
+    id: "1234",
+    typeOfBusiness: "SOLE_TRADER",
+    roleType: "SOLE_TRADER",
+    workSector: undefined,
+    applicantDetails: {
+        correspondenceAddress: {
+            premises: "premises",
+            addressLine1: "addressLine1",
+            addressLine2: "addressLine2",
+            locality: "locality",
+            region: "region",
+            postalCode: "postalcode"
+        },
+        firstName: "Unit",
+        middleName: "Test",
+        lastName: "User",
+        dateOfBirth: new Date(1990, 10, 15),
+        nationality: {
+            firstNationality: "British"
+        },
+        countryOfResidence: "England"
+    },
+    businessName: "Test Business 123"
+};
 export const mockSoleTrader2AcspData: AcspData = {
     id: "1234",
     typeOfBusiness: "SOLE_TRADER",
     roleType: "MEMBER_OF_GOVERNING_BODY",
     workSector: "CASINOS",
+    applicantDetails: {
+        firstName: "Unit",
+        middleName: "Test",
+        lastName: "User",
+        dateOfBirth: new Date(1990, 10, 15),
+        nationality: {
+            firstNationality: "British",
+            secondNationality: "German",
+            thirdNationality: "Irish"
+        },
+        countryOfResidence: "England"
+    },
+    businessName: "Test Business 123"
+};
+export const mockSoleTrader3AcspData: AcspData = {
+    id: "1234",
+    typeOfBusiness: "SOLE_TRADER",
+    roleType: "MEMBER_OF_GOVERNING_BODY",
+    workSector: "EA",
     applicantDetails: {
         firstName: "Unit",
         middleName: "Test",

--- a/test/src/controllers/limited/sectorYouWorkInController.test.ts
+++ b/test/src/controllers/limited/sectorYouWorkInController.test.ts
@@ -88,11 +88,11 @@ describe("POST" + LIMITED_SECTOR_YOU_WORK_IN, () => {
         expect(res.header.location).toBe(BASE_URL + LIMITED_WHICH_SECTOR_OTHER + "?lang=en");
     });
 
-    // Test for incorrect form details entered, will return 400.
-    it("should return status 400 after incorrect data entered", async () => {
+    // Test for no value selected, it will return 302 and redirect to the next page when no work sector is selected.
+    it("should return status 302 after no work sector selected", async () => {
         const res = await router.post(BASE_URL + LIMITED_SECTOR_YOU_WORK_IN).send({ sectorYouWorkIn: "" });
-        expect(res.status).toBe(400);
-        expect(res.text).toContain("Select which sector you work in");
+        expect(res.status).toBe(302);
+        expect(res.header.location).toBe(BASE_URL + LIMITED_SELECT_AML_SUPERVISOR + "?lang=en");
     });
 
     it("should show the error page if an error occurs during PUT request", async () => {

--- a/test/src/controllers/soleTrader/sectorYouWorkInController.test.ts
+++ b/test/src/controllers/soleTrader/sectorYouWorkInController.test.ts
@@ -90,8 +90,8 @@ describe("POST" + SOLE_TRADER_SECTOR_YOU_WORK_IN, () => {
         expect(res.header.location).toBe(BASE_URL + SOLE_TRADER_WHICH_SECTOR_OTHER + "?lang=en");
     });
 
-    // Test for incorrect form details entered, will return 400.
-    it("should return status 400 after incorrect data entered", async () => {
+    // Test for no value selected, it will return 302 and redirect to the next page when no work sector is selected.
+    it("should return status 302 after no work sector selected", async () => {
         const formData = {
             sectorYouWorkIn: "",
             typeOfBusiness: "SOLE_TRADER",
@@ -102,8 +102,8 @@ describe("POST" + SOLE_TRADER_SECTOR_YOU_WORK_IN, () => {
             }
         };
         const res = await router.post(BASE_URL + SOLE_TRADER_SECTOR_YOU_WORK_IN).send(formData);
-        expect(res.status).toBe(400);
-        expect(res.text).toContain("Select which sector you work in");
+        expect(res.status).toBe(302);
+        expect(res.header.location).toBe(BASE_URL + SOLE_TRADER_AUTO_LOOKUP_ADDRESS + "?lang=en");
     });
 
     it("should show the error page if an error occurs during PUT request", async () => {

--- a/test/src/controllers/unincorporated/sectorYouWorkInController.test.ts
+++ b/test/src/controllers/unincorporated/sectorYouWorkInController.test.ts
@@ -50,11 +50,11 @@ describe("POST" + UNINCORPORATED_WHICH_SECTOR, () => {
         expect(res.header.location).toBe(BASE_URL + UNINCORPORATED_WHICH_SECTOR_OTHER + "?lang=en");
     });
 
-    // Test for incorrect form details entered, will return 400.
-    it("should return status 400 after incorrect data entered", async () => {
+    // Test for no value selected, it will return 302 and redirect to the next page when no work sector is selected.
+    it("should return status 302 after no work sector selected", async () => {
         const res = await router.post(BASE_URL + UNINCORPORATED_WHICH_SECTOR).send({ sectorYouWorkIn: "" });
-        expect(res.status).toBe(400);
-        expect(res.text).toContain("Select which sector you work in");
+        expect(res.status).toBe(302);
+        expect(res.header.location).toBe(BASE_URL + UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP + "?lang=en");
     });
 
     it("should show the error page if an error occurs during PUT request", async () => {

--- a/test/src/services/checkYourAnswersService.test.ts
+++ b/test/src/services/checkYourAnswersService.test.ts
@@ -5,7 +5,7 @@ import { getAnswers } from "../../../src/services/checkYourAnswersService";
 import { getLocalesService } from "../../../src/utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
 import { COMPANY_DETAILS } from "../../../src/common/__utils/constants";
-import { mockCompany, mockCorporateBodyAcspData, mockLimitedAcspData, mockLLPAcspData, mockLPAcspData, mockPartnershipAcspData, mockSoleTrader2AcspData, mockSoleTraderAcspData, mockUnincorporatedAcspData } from "../../mocks/check_your_answers.mock";
+import { mockCompany, mockCorporateBodyAcspData, mockLimitedAcspData, mockLLPAcspData, mockLPAcspData, mockPartnershipAcspData, mockSoleTrader2AcspData, mockSoleTrader3AcspData, mockSoleTraderAcspData, mockSoleTraderAcspDataWorkSectorNotProvided, mockUnincorporatedAcspData } from "../../mocks/check_your_answers.mock";
 
 describe("CheckYourAnswersService", () => {
     let req: MockRequest<Request>;
@@ -73,6 +73,22 @@ describe("CheckYourAnswersService", () => {
         });
     });
 
+    it("should return answers for sole trader journey with work sector not provided", () => {
+        const soleTraderAnswers = getAnswers(req, mockSoleTraderAcspDataWorkSectorNotProvided, locales.i18nCh.resolveNamespacesKeys(req.query.lang));
+
+        expect(soleTraderAnswers).toStrictEqual({
+            businessName: "Test Business 123",
+            correspondenceAddress: "premises addressLine1<br>addressLine2<br>locality<br>region<br>postalcode",
+            roleType: "I am the sole trader",
+            typeOfBusiness: "Sole trader",
+            workSector: "Not provided",
+            countryOfResidence: "England",
+            dateOfBirth: "15 November 1990",
+            name: "Unit Test User",
+            nationality: "British"
+        });
+    });
+
     it("should return answers for sole trader journey with multiple nationalities", () => {
         const soleTraderAnswers = getAnswers(req, mockSoleTrader2AcspData, locales.i18nCh.resolveNamespacesKeys(req.query.lang));
 
@@ -82,6 +98,22 @@ describe("CheckYourAnswersService", () => {
             roleType: "I am a member of the governing body",
             typeOfBusiness: "Sole trader",
             workSector: "Casinos",
+            countryOfResidence: "England",
+            dateOfBirth: "15 November 1990",
+            name: "Unit Test User",
+            nationality: "British, German, Irish"
+        });
+    });
+
+    it("should return answers for sole trader journey with Estate agents work sector", () => {
+        const soleTraderAnswers = getAnswers(req, mockSoleTrader3AcspData, locales.i18nCh.resolveNamespacesKeys(req.query.lang));
+
+        expect(soleTraderAnswers).toStrictEqual({
+            businessName: "Test Business 123",
+            correspondenceAddress: "",
+            roleType: "I am a member of the governing body",
+            typeOfBusiness: "Sole trader",
+            workSector: "Estate agents",
             countryOfResidence: "England",
             dateOfBirth: "15 November 1990",
             name: "Unit Test User",


### PR DESCRIPTION
- Work sector page is now optional and can be skipped.
- Removed validation text.
- Deleted validator file and all references to this from the code base.
- Removed relevant error handling from POST requests on controllers for each journey.
- Added hint text to page.
- Added Matomo function to listen for changes in radio button selections and track the selected radio button.
- Updated Matomo analytics to capture based on if the user has selected a radio option or skipped the page, when pressing the save and continue button.
- Updating check your answers page to set work sector as 'Not provided' if work sector has been skipped
- Updated tests and code coverage