### PR TITLE
Including title of page for all Matomo events

### DIFF
--- a/src/views/common/address-correspondance-selector/address-correspondance-selector.njk
+++ b/src/views/common/address-correspondance-selector/address-correspondance-selector.njk
@@ -55,8 +55,10 @@
         </div>
         <button class="govuk-button" id="save-continue-button">{{ i18n.SaveAndContinue}}</button>
     </form>
-        <script>
-        trackEventBasedOnPageTitle("different-address-id", "select-option", "different-address");
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE");
-        </script>
+
+    <script>
+        trackEventBasedOnPageTitle("different-address-id", "{{title}}", "select-option", "different-address");
+        trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE");
+    </script>
+    
 {% endblock main_content %}

--- a/src/views/common/aml-body-number/aml-body-number.njk
+++ b/src/views/common/aml-body-number/aml-body-number.njk
@@ -47,8 +47,8 @@
         </fieldset>
     </form>
 
-<script>
-    trackEventBasedOnPageTitle("save-continue-button",  "click-button", "SAVE AND CONTINUE - AML number");
-</script>
+    <script>
+        trackEventBasedOnPageTitle("save-continue-button", "{{title}}",  "click-button", "SAVE AND CONTINUE - AML number");
+    </script>
 
 {% endblock %}

--- a/src/views/common/check-aml-details/check-aml-details.njk
+++ b/src/views/common/check-aml-details/check-aml-details.njk
@@ -57,8 +57,8 @@
     }) }}
   </form>
 
-<script>
-  trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - Check AML details");
-</script>
+  <script>
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Check AML details");
+  </script>
 
 {% endblock %}

--- a/src/views/common/correspondence-address-confirm/correspondence-address-confirm.njk
+++ b/src/views/common/correspondence-address-confirm/correspondence-address-confirm.njk
@@ -28,7 +28,9 @@
       id:"save-continue-button"
     }) }}
   </form>
-        <script>
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "CONFIRM AND CONTINUE - address correspondence confirm");
-        </script>
+
+  <script>
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "CONFIRM AND CONTINUE - address correspondence confirm");
+  </script>
+
 {% endblock main_content %}

--- a/src/views/common/correspondence-address-manual/capture-correspondence-address-manual.njk
+++ b/src/views/common/correspondence-address-manual/capture-correspondence-address-manual.njk
@@ -114,7 +114,9 @@
     {% endif %}
     <button class="govuk-button" id="save-continue-button">{{ i18n.SaveAndContinue }}</button>
   </form>
-              <script>
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE");
-      </script>
+
+  <script>
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE");
+  </script>
+
 {% endblock main_content %}

--- a/src/views/common/correspondence-auto-lookup-address/auto-lookup-address.njk
+++ b/src/views/common/correspondence-auto-lookup-address/auto-lookup-address.njk
@@ -52,8 +52,10 @@
       <a href={{correspondenceAddressManualLink}} class="govuk-link" id="manual-address-id">{{ i18n.correspondenceLookUpAddressManuallyBtn }}</a>
     </p>
   </form>
-        <script>
-          trackEventBasedOnPageTitle("find-address-id", "click-button", "FIND ADDRESS");
-        trackEventBasedOnPageTitle("manual-address-id", "click-link", "Enter address manually");
-        </script>
+
+  <script>
+    trackEventBasedOnPageTitle("find-address-id", "{{title}}", "click-button", "FIND ADDRESS");
+    trackEventBasedOnPageTitle("manual-address-id", "{{title}}", "click-link", "Enter address manually");
+  </script>
+
 {% endblock %}

--- a/src/views/common/correspondence-auto-lookup-address/correspondence-address-list.njk
+++ b/src/views/common/correspondence-auto-lookup-address/correspondence-address-list.njk
@@ -54,8 +54,10 @@
     <p>
         <a href= {{ correspondenceAddressManualLink }} class="govuk-link" id ="manual-address-id">{{ i18n.correspondenceLookUpAddressManuallyBtn }}</a>
     </p>
-        <script>
-        trackEventBasedOnPageTitle("manual-address-id", "click-link", "Enter address manually");
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - Address Correspondence");
-        </script>
+
+    <script>
+        trackEventBasedOnPageTitle("manual-address-id", "{{title}}", "click-link", "Enter address manually");
+        trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Address Correspondence");
+    </script>
+
 {% endblock main_content %}

--- a/src/views/common/index/home.njk
+++ b/src/views/common/index/home.njk
@@ -111,14 +111,16 @@
     </p>
   </form>
     
-    <script>
-      function trackStartNowEvent() {
-        trackEventBasedOnPageTitle("start-now", "click-button", "START NOW");
-        _paq.push(['trackGoal', 2]);
-        _paq.push(['trackGoal', 17]);
-      };
-      trackEventBasedOnPageTitle("Read the guidance-id", "click-link", "Read the guidance");
-      trackEventBasedOnPageTitle("guidance-for-authorised-agents-id", "click-link", "Guidance for authorised agents");
-      trackEventBasedOnPageTitle("verify-id", "click-link", "Verify your identity for Companies House");
-    </script>
+  <script>
+    function trackStartNowEvent() {
+      trackEventBasedOnPageTitle("start-now", "{{title}}", "click-button", "START NOW");
+      _paq.push(['trackGoal', 2]);
+      _paq.push(['trackGoal', 17]);
+    };
+    
+    trackEventBasedOnPageTitle("Read the guidance-id", "{{title}}", "click-link", "Read the guidance");
+    trackEventBasedOnPageTitle("guidance-for-authorised-agents-id", "{{title}}", "click-link", "Guidance for authorised agents");
+    trackEventBasedOnPageTitle("verify-id", "{{title}}", "click-link", "Verify your identity for Companies House");
+  </script>
+
 {% endblock %}

--- a/src/views/common/name-registered-with-aml/name-registered-with-aml.njk
+++ b/src/views/common/name-registered-with-aml/name-registered-with-aml.njk
@@ -44,10 +44,12 @@
         id:"save-continue-button"
       }) }}
   </form>
-        <script>
-        trackEventBasedOnPageTitle("name-of-the-business-option-id",  "select-option", "name-of-the-business");
-        trackEventBasedOnPageTitle("your-name-option-id", "select-option", "your-name");
-        trackEventBasedOnPageTitle("both-option-id", "select-option", "both");
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - Name registered with AML");
-      </script>
+
+  <script>
+    trackEventBasedOnPageTitle("name-of-the-business-option-id", "{{title}}", "select-option", "name-of-the-business");
+    trackEventBasedOnPageTitle("your-name-option-id", "{{title}}", "select-option", "your-name");
+    trackEventBasedOnPageTitle("both-option-id", "{{title}}", "select-option", "both");
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Name registered with AML");
+  </script>
+
 {% endblock main_content %}

--- a/src/views/common/name/capture-name.njk
+++ b/src/views/common/name/capture-name.njk
@@ -52,7 +52,9 @@
             id:"save-continue-button"
         }) }}
     </form>
-            <script>
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - NAME");
-      </script>
+
+    <script>
+        trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - NAME");
+    </script>
+
 {% endblock main_content %}

--- a/src/views/common/other-type-of-business/other-type-of-business.njk
+++ b/src/views/common/other-type-of-business/other-type-of-business.njk
@@ -44,6 +44,7 @@
             }
         }) }}
     </form>
+
     <script type="text/javascript">
         function continueOnClick () {
             const selectedOption = document.querySelector('input[name="otherTypeOfBusinessRadio"]:checked');
@@ -65,9 +66,11 @@
             _paq.push(['trackGoal', goalId]);
         }
     </script>
+
     <script>
-    trackEventBasedOnPageTitle("UNINCORPORATED", "select-option", "Unincorporated Entity");
-    trackEventBasedOnPageTitle("CORPORATE_BODY", "select-option", "Corporate Body");
-    trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - OTHER TYPE");
+        trackEventBasedOnPageTitle("UNINCORPORATED", "{{title}}", "select-option", "Unincorporated Entity");
+        trackEventBasedOnPageTitle("CORPORATE_BODY", "{{title}}", "select-option", "Corporate Body");
+        trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - OTHER TYPE");
     </script>
+
 {% endblock main_content %}

--- a/src/views/common/saved-application/saved-application.njk
+++ b/src/views/common/saved-application/saved-application.njk
@@ -34,9 +34,11 @@
     }) }}
     <button class="govuk-button" id="save-continue-button" >{{ i18n.SaveAndContinue }}</button>
   </form>
-      <script>
-        trackEventBasedOnPageTitle("yes-id", "select-option", "savedApplication-yes");
-        trackEventBasedOnPageTitle("no-id", "select-option", "savedApplication-no");
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE");
-      </script>
+
+  <script>
+    trackEventBasedOnPageTitle("yes-id", "{{title}}", "select-option", "savedApplication-yes");
+    trackEventBasedOnPageTitle("no-id", "{{title}}", "select-option", "savedApplication-no");
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE");
+  </script>
+
 {% endblock main_content %}

--- a/src/views/common/sector-you-work-in/sector-you-work-in.njk
+++ b/src/views/common/sector-you-work-in/sector-you-work-in.njk
@@ -86,10 +86,10 @@
     document.getElementById("save-continue-button").addEventListener("click", () => {
       // If no radio button has been selected, then work sector has not been provided
       if (!selectedRadio) {
-        trackEventWorkSector("save-continue-button", "click-button", "SAVE AND CONTINUE - Sector you work in - Not provided");
+        trackEventWorkSector("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Sector you work in - Not provided");
       } else {
         // Else a radio button has been selected and the below function is run
-        trackEventWorkSector("save-continue-button", "click-button", "SAVE AND CONTINUE - Sector you work in");
+        trackEventWorkSector("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Sector you work in");
       }
     });
     </script>

--- a/src/views/common/select-aml-supervisory-bodies/select-aml-supervisory-bodies.njk
+++ b/src/views/common/select-aml-supervisory-bodies/select-aml-supervisory-bodies.njk
@@ -40,10 +40,12 @@
       id: "save-continue-button"
     }) }}
   </form>
+
   <script>
     document.querySelectorAll('input[type="checkbox"][id^="aml"]').forEach(function (checkbox) {
       trackEventBasedOnPageTitle(checkbox.id, "{{title}}","select-option", checkbox.value);
     });
-    trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - Which AML Bodies");
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Which AML Bodies");
   </script>
+
 {% endblock main_content %}

--- a/src/views/common/stop-not-relevant-officer/stop-not-relevant-officer.njk
+++ b/src/views/common/stop-not-relevant-officer/stop-not-relevant-officer.njk
@@ -20,7 +20,9 @@
     <a href="#" class="govuk-link govuk-link--no-visited-state" id= "guidance-link">{{ i18n.guidancePageText }} </a>
     {{ i18n.moreInformation }}
   </p>
-        <script>
-        trackEventBasedOnPageTitle("guidance-link", "click-link", "Read the guidance about applying to register as an authorised agent");
-      </script>
+
+  <script>
+    trackEventBasedOnPageTitle("guidance-link", "{{title}}", "click-link", "Read the guidance about applying to register as an authorised agent");
+  </script>
+
 {% endblock %}

--- a/src/views/common/type-of-business/type-of-business.njk
+++ b/src/views/common/type-of-business/type-of-business.njk
@@ -87,12 +87,12 @@
     }
   </script>
   <script>
-    trackEventBasedOnPageTitle("LC", "select-option", "Limited Company");
-    trackEventBasedOnPageTitle("LP", "select-option", "Limited Partnership");
-    trackEventBasedOnPageTitle("LLP", "select-option", "Limited Liability Partnerships");
-    trackEventBasedOnPageTitle("PARTNERSHIP", "select-option", "Partnership Not Registered With CH");
-    trackEventBasedOnPageTitle("SOLE_TRADER", "select-option", "Sole Trader");
-    trackEventBasedOnPageTitle("OTHER", "select-option", "Other");
-    trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - TYPE");
+    trackEventBasedOnPageTitle("LC", "{{title}}", "select-option", "Limited Company");
+    trackEventBasedOnPageTitle("LP", "{{title}}", "select-option", "Limited Partnership");
+    trackEventBasedOnPageTitle("LLP", "{{title}}", "select-option", "Limited Liability Partnerships");
+    trackEventBasedOnPageTitle("PARTNERSHIP", "{{title}}", "select-option", "Partnership Not Registered With CH");
+    trackEventBasedOnPageTitle("SOLE_TRADER", "{{title}}", "select-option", "Sole Trader");
+    trackEventBasedOnPageTitle("OTHER", "{{title}}", "select-option", "Other");
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - TYPE");
   </script>
 {% endblock main_content %}

--- a/src/views/common/what-is-the-business-name/what-is-the-business-name.njk
+++ b/src/views/common/what-is-the-business-name/what-is-the-business-name.njk
@@ -22,7 +22,9 @@
     
     <button class="govuk-button" id="save-continue-button">{{i18n.SaveAndContinue}}</button>
   </form>
-   <script>
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - Business-name");
-      </script>
+
+  <script>
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Business-name");
+  </script>
+
 {% endblock main_content %}

--- a/src/views/common/what-is-your-email/what-is-your-email.njk
+++ b/src/views/common/what-is-your-email/what-is-your-email.njk
@@ -71,7 +71,9 @@
         id:"save-continue-button"
     }) }}
     </form>
+
     <script>
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - email address");
+        trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - email address");
     </script>
+    
 {% endblock main_content %}

--- a/src/views/common/what-is-your-role/what-is-your-role.njk
+++ b/src/views/common/what-is-your-role/what-is-your-role.njk
@@ -82,30 +82,30 @@
         }) }}
     </form>
 
-{# If/Else Logic to call specific Matomo event script based on the value of acspType (specific script runs depending on what busniess type the user had selected previously) #}
-{% if acspType == "PARTNERSHIP" %}
-  <script> trackEventBasedOnPageTitle("member-of-partnership", "select-option", "I am a member of partnership"); </script>
-{% elif acspType == "SOLE_TRADER" %}
-  <script> trackEventBasedOnPageTitle("sole-trader", "select-option", "I am the sole trader"); </script>
-{% elif acspType == "UNINCORPORATED" %}
-  <script> trackEventBasedOnPageTitle("member-of-governing-body", "select-option", "I am a member of the governing body of"); </script>
-{% elif acspType == "CORPORATE_BODY" %}
-  <script> trackEventBasedOnPageTitle("director-equivalent", "select-option", "I am the equivalent of a director of"); </script>
-{% elif acspType == "LC" %}
-  <script> trackEventBasedOnPageTitle("I-am-director", "select-option", "I am a director of"); </script>
-{% elif acspType == "LLP" %}
-  <script> trackEventBasedOnPageTitle("member-of-llp", "select-option", "I am a member of llp"); </script>
-{% elif acspType == "LP" %}
-  <script> trackEventBasedOnPageTitle("general-partner", "select-option", "I am a general partner of"); </script>
-{% endif %}
+    {# If/Else Logic to call specific Matomo event script based on the value of acspType (specific script runs depending on what busniess type the user had selected previously) #}
+    {% if acspType == "PARTNERSHIP" %}
+      <script> trackEventBasedOnPageTitle("member-of-partnership", "{{title}}", "select-option", "I am a member of partnership"); </script>
+    {% elif acspType == "SOLE_TRADER" %}
+      <script> trackEventBasedOnPageTitle("sole-trader", "{{title}}", "select-option", "I am the sole trader"); </script>
+    {% elif acspType == "UNINCORPORATED" %}
+      <script> trackEventBasedOnPageTitle("member-of-governing-body", "{{title}}", "select-option", "I am a member of the governing body of"); </script>
+    {% elif acspType == "CORPORATE_BODY" %}
+      <script> trackEventBasedOnPageTitle("director-equivalent", "{{title}}", "select-option", "I am the equivalent of a director of"); </script>
+    {% elif acspType == "LC" %}
+      <script> trackEventBasedOnPageTitle("I-am-director", "{{title}}", "select-option", "I am a director of"); </script>
+    {% elif acspType == "LLP" %}
+      <script> trackEventBasedOnPageTitle("member-of-llp", "{{title}}", "select-option", "I am a member of llp"); </script>
+    {% elif acspType == "LP" %}
+      <script> trackEventBasedOnPageTitle("general-partner", "{{title}}", "select-option", "I am a general partner of"); </script>
+    {% endif %}
 
-{% if acspType == "UNINCORPORATED" or acspType == "CORPORATE_BODY" %}
-  <script> trackEventBasedOnPageTitle("member-of-entity", "select-option", "I am a member of entity"); </script>
-{% endif %}
+    {% if acspType == "UNINCORPORATED" or acspType == "CORPORATE_BODY" %}
+      <script> trackEventBasedOnPageTitle("member-of-entity", "{{title}}", "select-option", "I am a member of entity"); </script>
+    {% endif %}
 
-<script>
-    trackEventBasedOnPageTitle("someone-else", "select-option", "I am someone else");
-    trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - ROLE ");
-</script>
+    <script>
+        trackEventBasedOnPageTitle("someone-else", "{{title}}", "select-option", "I am someone else");
+        trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - ROLE");
+    </script>
 
 {% endblock main_content %}

--- a/src/views/common/which-sector-other/which-sector-other.njk
+++ b/src/views/common/which-sector-other/which-sector-other.njk
@@ -59,34 +59,39 @@
             </a>
         </div>
     </form>
-     <script>
-let selectedRadio = null;
 
-// Function to track Matomo analytics based on the selected radio button
-function trackRadioSelection() {
-  const radioButtons = document.querySelectorAll('input[name="whichSectorOther"]'); 
-  radioButtons.forEach((radio) => {
-    radio.addEventListener("click", (event) => {
-      // Set selectedRadio to the capture the properties of the selected radio button 
-      selectedRadio = event.target;
-      // Capture the text content of the selected radio button
-      const labelText = document.querySelector(`label[for="${selectedRadio.id}"]`).textContent.trim();     
-      // Track event based on the selected radio button id and text content
-      trackEventBasedOnRadioId(selectedRadio.id, "{{title}}", "select-option", labelText);
-      trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - OTHER SECTOR");
-    });
-  });
-}
+    <script>
+      let selectedRadio = null;
 
-// Run trackRadioSelection function
-trackRadioSelection();
+      // Function to track Matomo analytics based on the selected radio button
+      function trackRadioSelection() {
+        const radioButtons = document.querySelectorAll('input[name="whichSectorOther"]'); 
+        radioButtons.forEach((radio) => {
+          radio.addEventListener("click", (event) => {
+            // Set selectedRadio to the capture the properties of the selected radio button 
+            selectedRadio = event.target;
+            // Capture the text content of the selected radio button
+            const labelText = document.querySelector(`label[for="${selectedRadio.id}"]`).textContent.trim();     
+            // Track event based on the selected radio button id and text content
+            trackEventBasedOnRadioId(selectedRadio.id, "{{title}}", "select-option", labelText);
+          });
+        });
+      }
 
-// EventListener to track the value of selectedRadio when save and continue button is clicked
-document.getElementById("save-continue-button").addEventListener("click", () => {
-  // If no radio button has been selected then work sector has not been provided
-  if (!selectedRadio) {
-    trackEventWorkSectorNotProvided("save-continue-button", "click-button", "SAVE AND CONTINUE - OTHER SECTOR - Not provided");
-  }
-});
-</script>
+      // Run trackRadioSelection function
+      trackRadioSelection();
+
+
+      // EventListener to track the value of selectedRadio when the save and continue button is clicked
+      document.getElementById("save-continue-button").addEventListener("click", () => {
+        // If no radio button has been selected, then work sector has not been provided
+        if (!selectedRadio) {
+          trackEventWorkSector("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - OTHER SECTOR - Not provided");
+        } else {
+          // Else a radio button has been selected and the below function is run
+          trackEventWorkSector("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - OTHER SECTOR");
+        }
+      });
+    </script>
+
 {% endblock main_content %}

--- a/src/views/common/your-responsibilities/your-responsibilities.njk
+++ b/src/views/common/your-responsibilities/your-responsibilities.njk
@@ -34,6 +34,6 @@
     <button class="govuk-button" id="accept-continue-id">{{ i18n.AcceptAndContinue }}</button>
   </form>
             <script>
-        trackEventBasedOnPageTitle("accept-continue-id", "click-button", "accept-continue");
+        trackEventBasedOnPageTitle("accept-continue-id", "{{title}}", "click-button", "accept-continue");
       </script>
 {% endblock main_content %}

--- a/src/views/features/limited/business-mustbe-aml-registered/business-mustbe-aml-registered.njk
+++ b/src/views/features/limited/business-mustbe-aml-registered/business-mustbe-aml-registered.njk
@@ -25,8 +25,10 @@
             </a>
         </p>
     </form>
-        <script>
-        trackEventBasedOnPageTitle("register-company-link", "click-link", "Register company");
-        trackEventBasedOnPageTitle("apply-sole-trader-link", "click-link", "Apply sole trader");
-      </script>
+
+    <script>
+        trackEventBasedOnPageTitle("register-company-link", "{{title}}", "click-link", "Register company");
+        trackEventBasedOnPageTitle("apply-sole-trader-link", "{{title}}", "click-link", "Apply sole trader");
+    </script>
+    
 {% endblock main_content %}

--- a/src/views/features/limited/company-number/company-number.njk
+++ b/src/views/features/limited/company-number/company-number.njk
@@ -48,8 +48,10 @@
       id : "save-continue-button"
     }) }}
     </form>
+
     <script>
-      trackEventBasedOnPageTitle("find-company-number-link","What is the company number?", "click-link", 'How do I find the company number');
-      trackEventBasedOnPageTitle("save-continue-button","click-button", 'SAVE AND CONTINUE - Company Number');
+      trackEventBasedOnPageTitle("find-company-number-link", "{{title}}", "click-link", 'How do I find the company number');
+      trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", 'SAVE AND CONTINUE - Company Number');
     </script>
+
   {% endblock %}

--- a/src/views/features/limited/is-this-your-company/is-this-your-company.njk
+++ b/src/views/features/limited/is-this-your-company/is-this-your-company.njk
@@ -55,8 +55,10 @@
       </a>
     </p>
   </form>
-        <script>
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "CONFIRM AND CONTINUE - Is this your company");
-        trackEventBasedOnPageTitle("choose-company-link", "click-link", "Chose a different company");
-      </script>
+
+  <script>
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "CONFIRM AND CONTINUE - Is this your company");
+    trackEventBasedOnPageTitle("choose-company-link", "{{title}}", "click-link", "Choose a different company");
+  </script>
+  
 {% endblock main_content %}

--- a/src/views/features/sole-trader/nationality/nationality.njk
+++ b/src/views/features/sole-trader/nationality/nationality.njk
@@ -68,7 +68,9 @@
             }) }}
         </fieldset>
     </form>
-         <script>
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - Nationality");
-      </script>
+
+    <script>
+        trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Nationality");
+    </script>
+
 {% endblock main_content %}

--- a/src/views/features/sole-trader/what-is-the-business-name/what-is-the-business-name.njk
+++ b/src/views/features/sole-trader/what-is-the-business-name/what-is-the-business-name.njk
@@ -55,9 +55,9 @@
     }) }}
   </form>
 
-<script>
-  trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - Business name");
-  trackEventBasedOnPageTitle("save-a-different-name-radio-button", "click-radio", "A different name");
-</script>
+  <script>
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Business name");
+    trackEventBasedOnPageTitle("save-a-different-name-radio-button", "{{title}}", "click-radio", "A different name");
+  </script>
 
 {% endblock main_content %}

--- a/src/views/features/sole-trader/what-is-your-date-of-birth/what-is-your-date-of-birth.njk
+++ b/src/views/features/sole-trader/what-is-your-date-of-birth/what-is-your-date-of-birth.njk
@@ -71,7 +71,9 @@
       }) }}
     </form>
   </div>
-     <script>
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - DOB");
-      </script>
+
+  <script>
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - DOB");
+  </script>
+
 {% endblock main_content %}

--- a/src/views/features/sole-trader/where-do-you-live/where-do-you-live.njk
+++ b/src/views/features/sole-trader/where-do-you-live/where-do-you-live.njk
@@ -57,7 +57,9 @@
       id:"save-continue-button"
     }) }}
   </form>
-          <script>
-        trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - Location lives");
-        </script>
+
+  <script>
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Location lives");
+  </script>
+
 {% endblock main_content %}

--- a/src/views/features/unincorporated/business-address-auto-lookup/auto-lookup-address.njk
+++ b/src/views/features/unincorporated/business-address-auto-lookup/auto-lookup-address.njk
@@ -52,8 +52,10 @@
       </p>
     </form>
   </div>
-          <script>
-          trackEventBasedOnPageTitle("find-address-id", "click-button", "FIND ADDRESS");
-        trackEventBasedOnPageTitle("manual-address-id", "click-link", "Enter address manually");
-        </script>
+
+  <script>
+    trackEventBasedOnPageTitle("find-address-id", "{{title}}", "click-button", "FIND ADDRESS");
+    trackEventBasedOnPageTitle("manual-address-id", "{{title}}", "click-link", "Enter address manually");
+  </script>
+
 {% endblock %}

--- a/src/views/features/unincorporated/business-address-auto-lookup/business-address-list.njk
+++ b/src/views/features/unincorporated/business-address-auto-lookup/business-address-list.njk
@@ -51,8 +51,8 @@
     </p>
 
 <script>
-    trackEventBasedOnPageTitle("manual-address-id", "click-link", "Enter address manually");
-    trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE - Address business");
+    trackEventBasedOnPageTitle("manual-address-id", "{{title}}", "click-link", "Enter address manually");
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Address business");
 </script>
 
 {% endblock main_content %}

--- a/src/views/features/unincorporated/business-address-manual-entry/business-address-manual-entry.njk
+++ b/src/views/features/unincorporated/business-address-manual-entry/business-address-manual-entry.njk
@@ -107,8 +107,8 @@
     <button class="govuk-button" id="save-continue-button">{{ i18n.SaveAndContinue }}</button>
   </form>
 
-<script>
-  trackEventBasedOnPageTitle("save-continue-button", "click-button", "SAVE AND CONTINUE");
-</script>
+  <script>
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE");
+  </script>
 
 {% endblock main_content %}

--- a/src/views/features/unincorporated/confirm-your-business-address/confirm-your-business-address.njk
+++ b/src/views/features/unincorporated/confirm-your-business-address/confirm-your-business-address.njk
@@ -24,8 +24,8 @@
     }) }}
   </form>
 
-<script>
-  trackEventBasedOnPageTitle("save-continue-button", "click-button", "CONFIRM AND CONTINUE - address business confirm");
-</script>
+  <script>
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "CONFIRM AND CONTINUE - address business confirm");
+  </script>
 
 {% endblock main_content %}

--- a/src/views/partials/piwik.njk
+++ b/src/views/partials/piwik.njk
@@ -32,7 +32,7 @@ function trackEventBasedOnPageTitle(elementId, eventCategory, eventAction, event
     });
 }
 
-// Matomo function for use on Work Sector page when page is skipped
+// Matomo function for use on Work Sector page as it is now optional
 function trackEventWorkSector(elementId, eventCategory, eventAction, eventName) {
   document.getElementById(elementId);
         _paq.push(["trackEvent", eventCategory, eventAction, eventName]);


### PR DESCRIPTION
- Updating the Matomo trackEventBasedOnPageTitle() function calls on each page to include the title of the page, against the event action that is being performed.
- Updating Matomo function on 'Work Sector Other' page to capture analytics for when user does/does not select a radio option and presses 'save and continue' button.