### PR TITLE
Small fix for Matomo event tracking and text update

### DIFF
--- a/locales/cy/application-submitted.json
+++ b/locales/cy/application-submitted.json
@@ -1,7 +1,7 @@
 {
     "applicationSubmittedTitle": "Application submitted welsh",
     "applicationSubmittedReference": "Your application reference welsh:",
-    "applicationSubmittedText1": "We have sent you a confirmation email to welsh ",
+    "applicationSubmittedText1": "We have sent a confirmation email to welsh ",
     "applicationSubmittedHeading1": "Helpwch ni i wella'r gwasanaeth hwn",
     "applicationSubmittedText2": "Mae hwn yn wasanaeth newydd.",
     "applicationSubmittedLink1": "Cwblhewch ein harolwg cyflym (yn agor mewn tab newydd)",

--- a/locales/cy/start-page.json
+++ b/locales/cy/start-page.json
@@ -1,7 +1,7 @@
 {
     "startPageTitle": "Apply to register as a Companies House authorised agent welsh",
     "useThisService": "Use this service to register your business as an authorised agent with Companies House. Authorised agents are also known as Authorised Corporate Service Providers (ACSPs). welsh",
-    "youllNeedToRegister": "You'll need to register your businesses as an authorised agent to be able to welsh",
+    "youllNeedToRegister": "You'll need to register your business as an authorised agent to be able to welsh",
     "verifyClientsIdentityLink": "verify your clients' identities for Companies House welsh",
     "startFromDate": "From XX DATE, businesses will also need to register to be able to file on behalf of clients. welsh",
     "whoCanApplyHeading": "Who can apply welsh",

--- a/locales/en/application-submitted.json
+++ b/locales/en/application-submitted.json
@@ -1,7 +1,7 @@
 {
     "applicationSubmittedTitle": "Application submitted",
     "applicationSubmittedReference": "Your application reference:",
-    "applicationSubmittedText1": "We have sent you a confirmation email to ",
+    "applicationSubmittedText1": "We have sent a confirmation email to ",
     "applicationSubmittedHeading1": "Help us to improve this service",
     "applicationSubmittedText2": "This is a new service.",
     "applicationSubmittedLink1": "Complete our quick survey (opens in a new tab)",

--- a/locales/en/start-page.json
+++ b/locales/en/start-page.json
@@ -1,7 +1,7 @@
 {
     "startPageTitle": "Apply to register as a Companies House authorised agent",
     "useThisService": "Use this service to register your business as an authorised agent with Companies House. Authorised agents are also known as Authorised Corporate Service Providers (ACSPs).",
-    "youllNeedToRegister": "You'll need to register your businesses as an authorised agent to be able to ",
+    "youllNeedToRegister": "You'll need to register your business as an authorised agent to be able to ",
     "verifyClientsIdentityLink": "verify your clients' identities for Companies House",
     "startFromDate": "From XX DATE, businesses will also need to register to be able to file on behalf of clients.",
     "whoCanApplyHeading": "Who can apply",

--- a/src/views/common/correspondence-address-confirm/correspondence-address-confirm.njk
+++ b/src/views/common/correspondence-address-confirm/correspondence-address-confirm.njk
@@ -21,7 +21,7 @@
       <li>{{ correspondenceAddress.postalCode }}</li>
     </ul>
     <p class="govuk-body">
-      <a href={{editPage}} class="govuk-link govuk-link--no-visited-state">{{ i18n.EditAddress }}</a>
+      <a href={{editPage}} class="govuk-link govuk-link--no-visited-state" id="edit-address-link">{{ i18n.EditAddress }}</a>
     </p>
     {{ govukButton({
       text: i18n.ConfirmAndContinue,
@@ -31,6 +31,7 @@
 
   <script>
     trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "CONFIRM AND CONTINUE - address correspondence confirm");
+    trackEventBasedOnPageTitle("edit-address-link", "{{title}}", "click-link", "EDIT ADDRESS - edit correspondence address");
   </script>
 
 {% endblock main_content %}

--- a/src/views/features/unincorporated/confirm-your-business-address/confirm-your-business-address.njk
+++ b/src/views/features/unincorporated/confirm-your-business-address/confirm-your-business-address.njk
@@ -16,7 +16,7 @@
       <li>{{ businessAddress.postalCode }}</li>
     </ul>
     <p class="govuk-body">
-      <a href={{editAddress}} class="govuk-link govuk-link--no-visited-state">{{ i18n.EditAddress }}</a>
+      <a href={{editAddress}} class="govuk-link govuk-link--no-visited-state" id="edit-address-link">{{ i18n.EditAddress }}</a>
     </p>
     {{ govukButton({
       text: i18n.ConfirmAndContinue,
@@ -26,6 +26,7 @@
 
   <script>
     trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "CONFIRM AND CONTINUE - address business confirm");
+    trackEventBasedOnPageTitle("edit-address-link", "{{title}}", "click-link", "EDIT ADDRESS - edit business address");
   </script>
 
 {% endblock main_content %}


### PR DESCRIPTION
- Added Matomo function to gather analytics for 'Edit address' link on 'Confirm the correspondence address' and 'Confirm the business address' pages.
- Small text change on home page and application submitted page to match prototype 14 