### PR TITLE
Cleared session data when user selects a new type of business

### DIFF
--- a/src/controllers/features/common/savedApplicationController.ts
+++ b/src/controllers/features/common/savedApplicationController.ts
@@ -26,8 +26,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const locales = getLocalesService();
     const session: Session = req.session as any as Session;
     const currentUrl = BASE_URL + SAVED_APPLICATION;
-    // eslint-disable-next-line camelcase
-    const userId = session?.data?.signin_info?.user_profile?.id!;
     try {
         const errorList = validationResult(req);
         if (!errorList.isEmpty()) {

--- a/src/controllers/features/common/typeOfBusinessController.ts
+++ b/src/controllers/features/common/typeOfBusinessController.ts
@@ -83,30 +83,30 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 currentUrl,
                 ...pageProperties
             });
-        } else {
-            if (selectedOption !== "OTHER") {
-                const acspDataService = new AcspDataService();
-                await acspDataService.saveAcspData(session, acspData, selectedOption);
-                saveDataInSession(req, "resume_application", true);
+        } else if (selectedOption !== "OTHER") {
 
-                switch (selectedOption) {
-                case "LC":
-                case "LLP":
-                    res.redirect(addLangToUrl(BASE_URL + LIMITED_WHAT_IS_THE_COMPANY_NUMBER, lang));
-                    break;
-                case "PARTNERSHIP":
-                case "LP":
-                    res.redirect(addLangToUrl(BASE_URL + UNINCORPORATED_NAME_REGISTERED_WITH_AML, lang));
-                    break;
-                case "SOLE_TRADER":
-                    res.redirect(addLangToUrl(BASE_URL + SOLE_TRADER_WHAT_IS_YOUR_ROLE, lang));
-                    break;
-                }
+            const acspDataService = new AcspDataService();
+            await acspDataService.saveAcspData(session, acspData, selectedOption);
+            saveDataInSession(req, "resume_application", true);
 
-            } else {
-                res.redirect(addLangToUrl(BASE_URL + OTHER_TYPE_OF_BUSINESS, lang));
+            switch (selectedOption) {
+            case "LC":
+            case "LLP":
+                res.redirect(addLangToUrl(BASE_URL + LIMITED_WHAT_IS_THE_COMPANY_NUMBER, lang));
+                break;
+            case "PARTNERSHIP":
+            case "LP":
+                res.redirect(addLangToUrl(BASE_URL + UNINCORPORATED_NAME_REGISTERED_WITH_AML, lang));
+                break;
+            case "SOLE_TRADER":
+                res.redirect(addLangToUrl(BASE_URL + SOLE_TRADER_WHAT_IS_YOUR_ROLE, lang));
+                break;
             }
+
+        } else {
+            res.redirect(addLangToUrl(BASE_URL + OTHER_TYPE_OF_BUSINESS, lang));
         }
+
     } catch (err) {
         logger.error(POST_ACSP_REGISTRATION_DETAILS_ERROR + " " + JSON.stringify(err));
         const error = new ErrorService();

--- a/src/controllers/features/unincorporated/unincorporatedNameRegisteredWithAmlController.ts
+++ b/src/controllers/features/unincorporated/unincorporatedNameRegisteredWithAmlController.ts
@@ -6,7 +6,6 @@ import { formatValidationError, getPageProperties } from "../../../validation/va
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { UNINCORPORATED_NAME_REGISTERED_WITH_AML, UNINCORPORATED_WHAT_IS_THE_BUSINESS_NAME, UNINCORPORATED_WHAT_IS_YOUR_NAME, BASE_URL, TYPE_OF_BUSINESS } from "../../../types/pageURL";
 import { GET_ACSP_REGISTRATION_DETAILS_ERROR, SUBMISSION_ID, UNINCORPORATED_AML_SELECTED_OPTION, USER_DATA, POST_ACSP_REGISTRATION_DETAILS_ERROR } from "../../../common/__utils/constants";
-import { Answers } from "../../../model/Answers";
 import { saveDataInSession } from "../../../common/__utils/sessionHelper";
 import { getAcspRegistration } from "../../../services/acspRegistrationService";
 import logger from "../../../utils/logger";

--- a/src/middleware/common_variables_middleware.ts
+++ b/src/middleware/common_variables_middleware.ts
@@ -1,5 +1,4 @@
 /* eslint-disable camelcase */
-import { Session } from "@companieshouse/node-session-handler";
 import { APPLICATION_ID } from "../common/__utils/constants";
 import { Handler } from "express";
 

--- a/src/services/acspDataService.ts
+++ b/src/services/acspDataService.ts
@@ -1,13 +1,11 @@
 import { AcspData, AcspDataDto } from "@companieshouse/api-sdk-node/dist/services/acsp";
 import { Session } from "@companieshouse/node-session-handler";
-import { APPLICATION_ID, SUBMISSION_ID } from "../common/__utils/constants";
+import { APPLICATION_ID, SUBMISSION_ID, USER_DATA } from "../common/__utils/constants";
 import { postAcspRegistration, putAcspRegistration } from "./acspRegistrationService";
 import logger from "../utils/logger";
 
 export class AcspDataService {
     async saveAcspData (session: Session, acspData: AcspData, selectedOption?: string): Promise<void> {
-        // eslint-disable-next-line camelcase
-        const userId = session?.data?.signin_info?.user_profile?.id!;
         try {
             if (acspData === undefined) {
                 acspData = {
@@ -19,7 +17,7 @@ export class AcspDataService {
                 session.setExtraData(APPLICATION_ID, response.id);
             } else {
                 if (selectedOption !== undefined) {
-                    acspData.typeOfBusiness = selectedOption;
+                    acspData = this.typeOfBusinessChange(session, acspData, selectedOption);
                 }
                 // save data to mongodb
                 await putAcspRegistration(session, session.getExtraData(SUBMISSION_ID)!, acspData);
@@ -28,5 +26,29 @@ export class AcspDataService {
             logger.error("Error saving ACSP data " + JSON.stringify(error));
             return Promise.reject(error);
         }
+    }
+
+    typeOfBusinessChange (session:Session, acspData: AcspData, selectedOption: string): AcspData {
+        if (acspData.typeOfBusiness !== selectedOption) {
+            session.deleteExtraData(USER_DATA);
+            const clearedAcspData: AcspData = {
+                ...acspData,
+                typeOfBusiness: selectedOption,
+                registeredOfficeAddress: undefined,
+                roleType: undefined,
+                verified: undefined,
+                businessName: undefined,
+                workSector: undefined,
+                amlSupervisoryBodies: undefined,
+                companyDetails: undefined,
+                companyAuthCodeProvided: undefined,
+                howAreYouRegisteredWithAml: undefined,
+                applicantDetails: undefined
+            };
+            acspData = clearedAcspData;
+        } else {
+            acspData.typeOfBusiness = selectedOption;
+        }
+        return acspData;
     }
 }

--- a/src/services/acspDataService.ts
+++ b/src/services/acspDataService.ts
@@ -46,8 +46,6 @@ export class AcspDataService {
                 applicantDetails: undefined
             };
             acspData = clearedAcspData;
-        } else {
-            acspData.typeOfBusiness = selectedOption;
         }
         return acspData;
     }

--- a/test/src/services/acspDataService.test.ts
+++ b/test/src/services/acspDataService.test.ts
@@ -3,10 +3,16 @@ import { Session } from "@companieshouse/node-session-handler";
 import { AcspDataService } from "../../../src/services/acspDataService";
 import { getSessionRequestWithPermission } from "../../mocks/session.mock";
 import { createRequest, MockRequest } from "node-mocks-http";
-import { USER_DATA } from "../../../src/common/__utils/constants";
+import { APPLICATION_ID, USER_DATA } from "../../../src/common/__utils/constants";
 import { AcspData } from "@companieshouse/api-sdk-node/dist/services/acsp";
+import { postAcspRegistration, putAcspRegistration } from "../../../src/services/acspRegistrationService";
+
+jest.mock("../../../src/services/acspRegistrationService");
 
 const service = new AcspDataService();
+
+const mockPutAcspRegistration = putAcspRegistration as jest.Mock;
+const mockPostAcspRegistration = postAcspRegistration as jest.Mock;
 
 const mockAcspData: AcspData = {
     id: "1234",
@@ -17,7 +23,11 @@ const mockAcspData: AcspData = {
     }
 };
 
-describe("typeOfBusinessChange tests", () => {
+const mockPostResponce = {
+    id: "12345"
+};
+
+describe("AcspDataService tests", () => {
     let req: MockRequest<Request>;
     beforeEach(() => {
         req = createRequest({
@@ -27,31 +37,56 @@ describe("typeOfBusinessChange tests", () => {
         const session = getSessionRequestWithPermission();
         req.session = session;
     });
-    it("should return acspData if typeOfBusiness is the same", () => {
-        const session: Session = req.session as any as Session;
-        session.setExtraData(USER_DATA, mockAcspData);
-        const retunredAcspData = service.typeOfBusinessChange(session, mockAcspData, "SOLE_TRADER");
-        expect(retunredAcspData).toEqual(mockAcspData);
+
+    describe("saveAcspData tests", () => {
+        it("should call POST registration if acspData is undefined", () => {
+            const session: Session = req.session as any as Session;
+            const acspData: AcspData | undefined = undefined;
+            mockPostAcspRegistration.mockResolvedValueOnce(mockPostResponce);
+            service.saveAcspData(session, acspData!, "SOLE_TRADER");
+            expect(mockPostAcspRegistration).toHaveBeenCalled();
+        });
+
+        it("should call PUT registration if acspData is not undefined", () => {
+            const session: Session = req.session as any as Session;
+            service.saveAcspData(session, mockAcspData, "SOLE_TRADER");
+            expect(mockPutAcspRegistration).toHaveBeenCalled();
+        });
+
+        it("should call PUT registration if acspData is not undefined", () => {
+            const session: Session = req.session as any as Session;
+            service.saveAcspData(session, mockAcspData);
+            expect(mockPutAcspRegistration).toHaveBeenCalled();
+        });
     });
 
-    it("should clear USER_DATA and update acspData if typeOfBusiness changes", () => {
-        const session: Session = req.session as any as Session;
-        session.setExtraData(USER_DATA, mockAcspData);
-        const retunredAcspData = service.typeOfBusinessChange(session, mockAcspData, "PARTNERSHIP");
-        expect(retunredAcspData).toEqual({
-            id: "1234",
-            typeOfBusiness: "PARTNERSHIP",
-            amlSupervisoryBodies: undefined,
-            applicantDetails: undefined,
-            businessName: undefined,
-            companyAuthCodeProvided: undefined,
-            companyDetails: undefined,
-            howAreYouRegisteredWithAml: undefined,
-            registeredOfficeAddress: undefined,
-            roleType: undefined,
-            verified: undefined,
-            workSector: undefined
+    describe("typeOfBusinessChange tests", () => {
+        it("should return acspData if typeOfBusiness is the same", () => {
+            const session: Session = req.session as any as Session;
+            session.setExtraData(USER_DATA, mockAcspData);
+            const retunredAcspData = service.typeOfBusinessChange(session, mockAcspData, "SOLE_TRADER");
+            expect(retunredAcspData).toEqual(mockAcspData);
         });
-        expect(session.getExtraData(USER_DATA)).toEqual(undefined);
+
+        it("should clear USER_DATA and update acspData if typeOfBusiness changes", () => {
+            const session: Session = req.session as any as Session;
+            session.setExtraData(USER_DATA, mockAcspData);
+            const retunredAcspData = service.typeOfBusinessChange(session, mockAcspData, "PARTNERSHIP");
+            expect(retunredAcspData).toEqual({
+                id: "1234",
+                typeOfBusiness: "PARTNERSHIP",
+                amlSupervisoryBodies: undefined,
+                applicantDetails: undefined,
+                businessName: undefined,
+                companyAuthCodeProvided: undefined,
+                companyDetails: undefined,
+                howAreYouRegisteredWithAml: undefined,
+                registeredOfficeAddress: undefined,
+                roleType: undefined,
+                verified: undefined,
+                workSector: undefined
+            });
+            expect(session.getExtraData(USER_DATA)).toEqual(undefined);
+        });
     });
 });

--- a/test/src/services/acspDataService.test.ts
+++ b/test/src/services/acspDataService.test.ts
@@ -39,24 +39,26 @@ describe("AcspDataService tests", () => {
     });
 
     describe("saveAcspData tests", () => {
-        it("should call POST registration if acspData is undefined", () => {
+        it("should call POST registration if acspData is undefined", async () => {
             const session: Session = req.session as any as Session;
-            const acspData: AcspData | undefined = undefined;
             mockPostAcspRegistration.mockResolvedValueOnce(mockPostResponce);
-            service.saveAcspData(session, acspData!, "SOLE_TRADER");
-            expect(mockPostAcspRegistration).toHaveBeenCalled();
+            await service.saveAcspData(session, undefined!, "SOLE_TRADER");
+            expect(postAcspRegistration).toHaveBeenCalled();
+            expect(session.getExtraData(APPLICATION_ID)).toBe("12345");
         });
 
-        it("should call PUT registration if acspData is not undefined", () => {
+        it("should call PUT registration if acspData is not undefined", async () => {
             const session: Session = req.session as any as Session;
-            service.saveAcspData(session, mockAcspData, "SOLE_TRADER");
-            expect(mockPutAcspRegistration).toHaveBeenCalled();
+            mockPutAcspRegistration.mockResolvedValue({});
+            await service.saveAcspData(session, mockAcspData, "SOLE_TRADER");
+            expect(putAcspRegistration).toHaveBeenCalled();
         });
 
-        it("should call PUT registration if acspData is not undefined", () => {
+        it("should call PUT registration if acspData is not undefined", async () => {
             const session: Session = req.session as any as Session;
-            service.saveAcspData(session, mockAcspData);
-            expect(mockPutAcspRegistration).toHaveBeenCalled();
+            mockPutAcspRegistration.mockResolvedValue({});
+            await service.saveAcspData(session, mockAcspData);
+            expect(putAcspRegistration).toHaveBeenCalled();
         });
     });
 

--- a/test/src/services/acspDataService.test.ts
+++ b/test/src/services/acspDataService.test.ts
@@ -1,0 +1,57 @@
+import { Request } from "express";
+import { Session } from "@companieshouse/node-session-handler";
+import { AcspDataService } from "../../../src/services/acspDataService";
+import { getSessionRequestWithPermission } from "../../mocks/session.mock";
+import { createRequest, MockRequest } from "node-mocks-http";
+import { USER_DATA } from "../../../src/common/__utils/constants";
+import { AcspData } from "@companieshouse/api-sdk-node/dist/services/acsp";
+
+const service = new AcspDataService();
+
+const mockAcspData: AcspData = {
+    id: "1234",
+    typeOfBusiness: "SOLE_TRADER",
+    applicantDetails: {
+        firstName: "Test",
+        lastName: "User"
+    }
+};
+
+describe("typeOfBusinessChange tests", () => {
+    let req: MockRequest<Request>;
+    beforeEach(() => {
+        req = createRequest({
+            method: "POST",
+            url: "/"
+        });
+        const session = getSessionRequestWithPermission();
+        req.session = session;
+    });
+    it("should return acspData if typeOfBusiness is the same", () => {
+        const session: Session = req.session as any as Session;
+        session.setExtraData(USER_DATA, mockAcspData);
+        const retunredAcspData = service.typeOfBusinessChange(session, mockAcspData, "SOLE_TRADER");
+        expect(retunredAcspData).toEqual(mockAcspData);
+    });
+
+    it("should clear USER_DATA and update acspData if typeOfBusiness changes", () => {
+        const session: Session = req.session as any as Session;
+        session.setExtraData(USER_DATA, mockAcspData);
+        const retunredAcspData = service.typeOfBusinessChange(session, mockAcspData, "PARTNERSHIP");
+        expect(retunredAcspData).toEqual({
+            id: "1234",
+            typeOfBusiness: "PARTNERSHIP",
+            amlSupervisoryBodies: undefined,
+            applicantDetails: undefined,
+            businessName: undefined,
+            companyAuthCodeProvided: undefined,
+            companyDetails: undefined,
+            howAreYouRegisteredWithAml: undefined,
+            registeredOfficeAddress: undefined,
+            roleType: undefined,
+            verified: undefined,
+            workSector: undefined
+        });
+        expect(session.getExtraData(USER_DATA)).toEqual(undefined);
+    });
+});


### PR DESCRIPTION
Clearing USER_DATA session variable when user selects a new type of business.
USER_DATA also includes links and acsp-data-submission details which must be kept, so adding those back to USER_DATA once its has been cleared.