### PR TITLE
Remove section break border when back button is hidden

### DIFF
--- a/src/views/common/stop-not-relevant-officer/stop-not-relevant-officer.njk
+++ b/src/views/common/stop-not-relevant-officer/stop-not-relevant-officer.njk
@@ -3,6 +3,10 @@
 {% block backLink %}
   {# Remove back button on this page by replacing it with nothing #}
 {% endblock %}
+{% block signoutBar %}
+  {% include "partials/signout-bar.njk" %}
+  <hr class="govuk-section-break">
+{% endblock %}
 {% set title = i18n.cannotUseServiceTitle %}
 {% block main_content %}
   <h1 class="govuk-fieldset__heading">

--- a/src/views/features/limited/business-mustbe-aml-registered/business-mustbe-aml-registered.njk
+++ b/src/views/features/limited/business-mustbe-aml-registered/business-mustbe-aml-registered.njk
@@ -6,6 +6,10 @@
 {% block backLink %}
   {# Remove back button on this page by replacing it with nothing #}
 {% endblock %}
+{% block signoutBar %}
+  {% include "partials/signout-bar.njk" %}
+  <hr class="govuk-section-break">
+{% endblock %}
 {% set title = i18n.amlInterruptTitle %}
 {% block main_content %}
     <form action="" method="POST">

--- a/src/views/features/limited/company-inactive/company-inactive.njk
+++ b/src/views/features/limited/company-inactive/company-inactive.njk
@@ -3,7 +3,10 @@
 {% block backLink %}
   {# Remove back button on this page by replacing it with nothing #}
 {% endblock %}
-
+{% block signoutBar %}
+  {% include "partials/signout-bar.njk" %}
+  <hr class="govuk-section-break">
+{% endblock %}
 {% set title = i18n.companyInactiveTitle %}
 {% block main_content %}
   <h1 class="govuk-heading-l">{{ i18n.companyInactiveTitle }}</h1>


### PR DESCRIPTION
**Short description outlining key changes/additions**

Override signoutBar component to remove 'govuk-section-break--visible' border from section break when back button is disabled for following kickout screens:

- /cannot-use-service
- /limited/your-business-must-be-aml-registered
- /limited/company-inactive

**JIRA Ticket Number**

[IDVA5-1328](https://companieshouse.atlassian.net/browse/IDVA5-1328)

**Type of change**
 
- [X] Bug fix
- [ ]  New feature
- [ ]  Breaking change
- [ ]  Infrastructure change

**Pull request checklist**

- [ ]  I have added unit tests for new code that I have added
- [ ]  I have added/updated functional tests where appropriate
- [X]  The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

**An exhaustive list of peer review checks can be read** [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)

[IDVA5-1328]: https://companieshouse.atlassian.net/browse/IDVA5-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ