### PR TITLE
IDVA5-1311 Fixed wrong page being displayed after an application is rejected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.207",
+        "@companieshouse/api-sdk-node": "^2.0.208",
         "@companieshouse/ch-node-utils": "^1.3.5",
         "@companieshouse/node-session-handler": "^5.1.3",
         "@companieshouse/structured-logging-node": "^1.0.8",
@@ -635,9 +635,10 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.207",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.207.tgz",
-      "integrity": "sha512-uZMrLOm7ZrTCoEfwLTbi9TLgth371T01tSZa+ntezBhpi+Eqy6Jk1h1hy+gxF2Xnhzg5sfDqcAOq9DdzmvNICg==",
+      "version": "2.0.208",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.208.tgz",
+      "integrity": "sha512-U/8Cp3xmTGqyqB8KUCMeOqYPNh0hTa8v9bEmMJzcsMZLdiVcKPsZ0ibHzQUcubu1FGQNWo6MD/jZHOIcwj0jXw==",
+      "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",
         "camelcase-keys": "~6.2.2",
@@ -647,16 +648,17 @@
       }
     },
     "node_modules/@companieshouse/ch-node-utils": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@companieshouse/ch-node-utils/-/ch-node-utils-1.3.6.tgz",
-      "integrity": "sha512-usGFE2YrX9cHP+Uva4YvMw3QbGHUa8jZZqEZzGxkKHsqGiEd1wnTBuaS6xG2YtAc7pOnmMbz4i4C0m7JJTHedA==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@companieshouse/ch-node-utils/-/ch-node-utils-1.3.11.tgz",
+      "integrity": "sha512-rwUA9D3i1cpKwJ6lP1bw0AMSj1exqxRVA3ltOBVKUkseRSyKScHEXf/67k8Sv1HOQVr8939J0HZlLkwf47vgnA==",
       "license": "MIT",
       "dependencies": {
         "@companieshouse/node-session-handler": "^5.0.1",
         "express": "^4.18.3",
         "i18next": "^23.10.1",
         "i18next-fs-backend": "^2.3.1",
-        "iso-639-1": "^3.1.2"
+        "iso-639-1": "^3.1.2",
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/@companieshouse/node-session-handler": {
@@ -3653,9 +3655,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3672,6 +3674,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
@@ -5207,15 +5218,6 @@
       },
       "engines": {
         "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.207",
+    "@companieshouse/api-sdk-node": "^2.0.208",
     "@companieshouse/ch-node-utils": "^1.3.5",
     "@companieshouse/node-session-handler": "^5.1.3",
     "@companieshouse/structured-logging-node": "^1.0.8",

--- a/src/controllers/features/common/checkSavedApplicationController.ts
+++ b/src/controllers/features/common/checkSavedApplicationController.ts
@@ -4,30 +4,29 @@ import { BASE_URL, CHECK_SAVED_APPLICATION, TYPE_OF_BUSINESS } from "../../../ty
 import { Session } from "@companieshouse/node-session-handler";
 import logger from "../../../utils/logger";
 import { ErrorService } from "../../../services/errorService";
-import { Resource } from "@companieshouse/api-sdk-node";
-import { ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
-import { TransactionList } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
 import { getSavedApplication } from "../../../services/transactions/transaction_service";
 import { getRedirectionUrl } from "../../../services/checkSavedApplicationService";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
-    const session: Session = req.session as any as Session;
-    const savedApplication : Resource<TransactionList> | ApiErrorResponse = await getSavedApplication(session, res.locals.userId);
-    logger.debug("savedApplication: " + savedApplication);
     const lang = selectLang(req.query.lang);
     const locales = getLocalesService();
+    const session: Session = req.session as any as Session;
+    try {
+        const savedApplication = await getSavedApplication(session, res.locals.userId);
 
-    if (savedApplication.httpStatusCode === 200) {
-        logger.debug("saved application exists");
-        const transactionlistResource = savedApplication as Resource<TransactionList>;
-        const redirectionUrl = getRedirectionUrl(transactionlistResource, session, res, locales, lang);
-        res.redirect(addLangToUrl(await redirectionUrl, lang));
-    } else if (savedApplication.httpStatusCode === 404) {
-        logger.debug("its a new application");
-        res.redirect(addLangToUrl(BASE_URL + TYPE_OF_BUSINESS, lang));
-    } else {
-        logger.error("internal server error: " + savedApplication.httpStatusCode);
-        const error = new ErrorService();
-        error.renderErrorPage(res, locales, lang, BASE_URL + CHECK_SAVED_APPLICATION);
+        logger.debug("savedApplication: " + savedApplication);
+
+        if (savedApplication.httpStatusCode === 200) {
+            logger.debug("saved application exists");
+            const redirectionUrl = await getRedirectionUrl(savedApplication, session);
+            res.redirect(addLangToUrl(redirectionUrl, lang));
+        } else if (savedApplication.httpStatusCode === 404) {
+            logger.debug("its a new application");
+            res.redirect(addLangToUrl(BASE_URL + TYPE_OF_BUSINESS, lang));
+        }
+    } catch (error) {
+        logger.error(JSON.stringify(error));
+        const exception = new ErrorService();
+        exception.renderErrorPage(res, locales, lang, BASE_URL + CHECK_SAVED_APPLICATION);
     }
 };

--- a/src/controllers/features/common/savedApplicationController.ts
+++ b/src/controllers/features/common/savedApplicationController.ts
@@ -9,7 +9,7 @@ import { deleteAcspApplication } from "../../../services/acspRegistrationService
 import logger from "../../../utils/logger";
 import { ErrorService } from "../../../services/errorService";
 import { Session } from "@companieshouse/node-session-handler";
-import { APPLICATION_ID, RESUME_APPLICATION_ID, USER_DATA } from "../../../common/__utils/constants";
+import { APPLICATION_ID, RESUME_APPLICATION_ID, SUBMISSION_ID, USER_DATA } from "../../../common/__utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
@@ -46,8 +46,9 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 res.redirect((YOUR_FILINGS));
             } else {
                 saveDataInSession(req, "resume_application", false);
+                await deleteAcspApplication(session, session.getExtraData(SUBMISSION_ID)!, resumeApplicationId);
                 session.deleteExtraData(USER_DATA);
-                await deleteAcspApplication(session, resumeApplicationId);
+                session.deleteExtraData(SUBMISSION_ID);
                 res.redirect((BASE_URL + TYPE_OF_BUSINESS));
             }
         }

--- a/src/controllers/features/common/typeOfBusinessController.ts
+++ b/src/controllers/features/common/typeOfBusinessController.ts
@@ -22,7 +22,17 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     const session: Session = req.session as any as Session;
     const previousPage: string = addLangToUrl(BASE_URL, lang);
     const currentUrl: string = BASE_URL + TYPE_OF_BUSINESS;
+    const typeOfBusinessService = new TypeOfBusinessService();
+    const existingTransactionId = session?.getExtraData(SUBMISSION_ID);
     try {
+        // create transaction record
+        if (existingTransactionId === undefined || JSON.stringify(existingTransactionId) === "{}") {
+            await typeOfBusinessService.createTransaction(req, res).then((transactionId) => {
+                // get transaction record data
+                saveDataInSession(req, SUBMISSION_ID, transactionId);
+            });
+        }
+
         let typeOfBusiness = "";
         if (session?.getExtraData("resume_application")) {
             // get data from mongo and save to session
@@ -62,16 +72,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const previousPage: string = addLangToUrl(BASE_URL, lang);
     const session: Session = req.session as any as Session;
     const acspData: AcspData = session?.getExtraData(USER_DATA)!;
-    const typeOfBusinessService = new TypeOfBusinessService();
-    const existingTransactionId = session?.getExtraData(SUBMISSION_ID);
     try {
-        // create transaction record
-        if (existingTransactionId === undefined || JSON.stringify(existingTransactionId) === "{}") {
-            await typeOfBusinessService.createTransaction(req, res).then((transactionId) => {
-                // get transaction record data
-                saveDataInSession(req, SUBMISSION_ID, transactionId);
-            });
-        }
 
         if (!errorList.isEmpty()) {
             const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));

--- a/src/services/acspRegistrationService.ts
+++ b/src/services/acspRegistrationService.ts
@@ -114,11 +114,11 @@ export const putAcspRegistration = async (session: Session, transactionId: strin
  * @param userId The user ID of for the document of be delete.
  * @returns The AcspResponse contains the submission ID for the updated registration
  */
-export const deleteAcspApplication = async (session: Session, acspApplicationId: string): Promise<HttpResponse> => {
+export const deleteAcspApplication = async (session: Session, transactionId: string, acspApplicationId: string): Promise<HttpResponse> => {
     const apiClient: ApiClient = createPublicOAuthApiClient(session);
 
     logger.debug(`Deleting acsp registration for user ${acspApplicationId}`);
-    const sdkResponse: HttpResponse = await apiClient.acsp.deleteSavedApplication(acspApplicationId);
+    const sdkResponse: HttpResponse = await apiClient.acsp.deleteSavedApplication(transactionId, acspApplicationId);
 
     if (!sdkResponse) {
         logger.error(`acsp registration DELETE request returned no response for user ${acspApplicationId}`);

--- a/src/services/checkSavedApplicationService.ts
+++ b/src/services/checkSavedApplicationService.ts
@@ -1,39 +1,29 @@
-import { Response } from "express";
 import Resource from "@companieshouse/api-sdk-node/dist/services/resource";
 import { TransactionData, TransactionList } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
 import { Session } from "@companieshouse/node-session-handler";
-import { APPROVED, CLOSED, REJECTED, RESUME_APPLICATION_ID } from "../common/__utils/constants";
-import { BASE_URL, CANNOT_REGISTER_AGAIN, CANNOT_SUBMIT_ANOTHER_APPLICATION, CHECK_SAVED_APPLICATION, SAVED_APPLICATION, TYPE_OF_BUSINESS } from "../types/pageURL";
+import { APPROVED, CLOSED, REJECTED, RESUME_APPLICATION_ID, SUBMISSION_ID } from "../common/__utils/constants";
+import { BASE_URL, CANNOT_REGISTER_AGAIN, CANNOT_SUBMIT_ANOTHER_APPLICATION, SAVED_APPLICATION, TYPE_OF_BUSINESS } from "../types/pageURL";
 import logger from "../utils/logger";
-import { deleteAcspApplication } from "./acspRegistrationService";
-import { ErrorService } from "./errorService";
 
-export const getRedirectionUrl = async (transactionlistResource: Resource<TransactionList>, session: Session, res: Response, locales:any, lang:string): Promise<string> => {
-    const transactionList = transactionlistResource.resource;
-    const length = transactionList!.items.length;
-    for (let i = 0; i < length; i++) {
-        logger.debug("element------>" + transactionList!.items[i].id);
-    }
-    const transaction: TransactionData = transactionList!.items[0];
-    logger.debug("transactionId: " + transaction?.id);
-    const applicationId = getApplicationId(transaction);
+/*
+* We are not deleting the old rejected application on the acsp Mongo collection.
+* This is because we are filtering out the rejected applications to prevent
+* the wrong page being shown after user comes back from a rejected application.
+*/
 
-    var url = "";
-    if (transaction?.status !== CLOSED) {
-        logger.debug("application is open");
-        session.setExtraData(RESUME_APPLICATION_ID, applicationId);
-        url = BASE_URL + SAVED_APPLICATION;
-    } else if (transaction.filings![transaction.id + "-1"]?.status === REJECTED) {
+export const getRedirectionUrl = async (savedApplications: Resource<TransactionList>, session: Session): Promise<string> => {
+    const transactions = filterRejectedApplications(savedApplications.resource!.items);
+
+    let url = "";
+    if (!transactions.length) {
         logger.debug("application is rejected");
-        try {
-            await deleteAcspApplication(session, applicationId);
-            url = BASE_URL + TYPE_OF_BUSINESS;
-        } catch (error) {
-            logger.error("Error deleting ACSP application ");
-            const exception = new ErrorService();
-            exception.renderErrorPage(res, locales, lang, BASE_URL + CHECK_SAVED_APPLICATION);
-        }
-    } else if (transaction.filings![transaction.id + "-1"]?.status === APPROVED) {
+        url = BASE_URL + TYPE_OF_BUSINESS;
+    } else if (transactions[0].status !== CLOSED) {
+        logger.debug("application is open");
+        session.setExtraData(RESUME_APPLICATION_ID, getApplicationId(transactions[0]));
+        session.setExtraData(SUBMISSION_ID, transactions[0].id);
+        url = BASE_URL + SAVED_APPLICATION;
+    } else if (transactions[0].filings![transactions[0].id + "-1"]?.status === APPROVED) {
         logger.debug("application is approved");
         url = BASE_URL + CANNOT_REGISTER_AGAIN;
     } else {
@@ -46,4 +36,17 @@ export const getRedirectionUrl = async (transactionlistResource: Resource<Transa
 const getApplicationId = (transaction:TransactionData): string => {
     const acspId = transaction.resumeJourneyUri!.match(/acspId=([^\s]+)/);
     return acspId![1];
+};
+
+const filterRejectedApplications = (transactions: TransactionData []) => {
+    return transactions.filter((transaction) => {
+        if (!transaction.filings) {
+            return true;
+        }
+
+        if (transaction.filings[transaction.id + "-1"].status === REJECTED) {
+            return false;
+        }
+        return true;
+    });
 };

--- a/test/src/controllers/common/checkSavedApplicationController.test.ts
+++ b/test/src/controllers/common/checkSavedApplicationController.test.ts
@@ -29,7 +29,7 @@ const errorSavedApplication = {
 describe("GET " + CHECK_SAVED_APPLICATION, () => {
 
     it("should show the error screen if getSavedApplication fails", async () => {
-        mockGetSavedApplication.mockResolvedValueOnce(errorSavedApplication);
+        mockGetSavedApplication.mockRejectedValueOnce(errorSavedApplication);
         const response = await router.get(BASE_URL + CHECK_SAVED_APPLICATION);
         expect(response.status).toBe(500);
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();

--- a/test/src/controllers/common/typeOfBusinessController.test.ts
+++ b/test/src/controllers/common/typeOfBusinessController.test.ts
@@ -109,7 +109,6 @@ describe("POST for acspData = null" + TYPE_OF_BUSINESS, () => {
     // Test for calling POST endpoint if acspData is null.
     it("should return status 302 after calling POST endpoint", async () => {
         mockPostAcspRegistration.mockResolvedValueOnce(acspData);
-        mockPostTransaction.mockResolvedValueOnce({ id: "123456789" });
         const res = await router.post(BASE_URL + TYPE_OF_BUSINESS).send({ typeOfBusinessRadio: "LC" });
         expect(mockPostAcspRegistration).toHaveBeenCalledTimes(1);
         expect(mockPutAcspRegistration).toHaveBeenCalledTimes(0);
@@ -120,7 +119,6 @@ describe("POST for acspData = null" + TYPE_OF_BUSINESS, () => {
     // Test for calling POST endpoint failure.
     it("should return status 500 after calling POST endpoint and failing", async () => {
         mockPostAcspRegistration.mockRejectedValueOnce(new Error("Error saving data"));
-        mockPostTransaction.mockResolvedValueOnce({ id: "123456789" });
         const res = await router.post(BASE_URL + TYPE_OF_BUSINESS).send({ typeOfBusinessRadio: "LC" });
         expect(mockPostAcspRegistration).toHaveBeenCalledTimes(1);
         expect(res.status).toBe(500);

--- a/test/src/controllers/common/typeOfBusinessController.test.ts
+++ b/test/src/controllers/common/typeOfBusinessController.test.ts
@@ -7,7 +7,7 @@ import { AcspData } from "@companieshouse/api-sdk-node/dist/services/acsp/types"
 import { sessionMiddleware } from "../../../../src/middleware/session_middleware";
 import { getSessionRequestWithPermission } from "../../../mocks/session.mock";
 import { Request, Response, NextFunction } from "express";
-import { USER_DATA } from "../../../../src/common/__utils/constants";
+import { SUBMISSION_ID, USER_DATA } from "../../../../src/common/__utils/constants";
 import { postTransaction } from "../../../../src/services/transactions/transaction_service";
 
 jest.mock("@companieshouse/api-sdk-node");
@@ -126,10 +126,25 @@ describe("POST for acspData = null" + TYPE_OF_BUSINESS, () => {
     });
 });
 
+describe("GET for SUBMISSION_ID = null" + TYPE_OF_BUSINESS, () => {
+    beforeEach(() => {
+        createMockSessionMiddleware();
+    });
+    it("should return status 200 and create a transaction", async () => {
+        mockPostTransaction.mockResolvedValueOnce({ id: "12345" });
+        const res = await router.get(BASE_URL + TYPE_OF_BUSINESS);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        expect(res.text).toContain("What type of business are you registering?");
+    });
+});
+
 function createMockSessionMiddleware () {
     customMockSessionMiddleware = sessionMiddleware as jest.Mock;
     const session = getSessionRequestWithPermission();
     session.setExtraData(USER_DATA, undefined);
+    session.setExtraData(SUBMISSION_ID, undefined);
     customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
         req.session = session;
         next();

--- a/test/src/services/acspRegistrationService.test.ts
+++ b/test/src/services/acspRegistrationService.test.ts
@@ -213,7 +213,7 @@ describe("acsp service tests", () => {
 
             mockDeleteSavedApplication.mockResolvedValueOnce({ status: 204 });
 
-            const acspData = await deleteAcspApplication(session, EMAIL_ID);
+            const acspData = await deleteAcspApplication(session, TRANSACTION_ID, EMAIL_ID);
 
             expect(acspData).toStrictEqual(dummySuccessResponce);
         });
@@ -221,7 +221,7 @@ describe("acsp service tests", () => {
         it("Should throw an error when no acsp api response", async () => {
             mockDeleteSavedApplication.mockResolvedValueOnce(undefined);
 
-            await expect(deleteAcspApplication(session, EMAIL_ID)).rejects.toBe(undefined);
+            await expect(deleteAcspApplication(session, TRANSACTION_ID, EMAIL_ID)).rejects.toBe(undefined);
         });
 
         it("Should throw an error when acsp api returns a status greater than 400", async () => {
@@ -229,7 +229,7 @@ describe("acsp service tests", () => {
                 httpStatusCode: 404
             });
 
-            await expect(deleteAcspApplication(session, EMAIL_ID)).rejects.toEqual({ httpStatusCode: StatusCodes.NOT_FOUND });
+            await expect(deleteAcspApplication(session, TRANSACTION_ID, EMAIL_ID)).rejects.toEqual({ httpStatusCode: StatusCodes.NOT_FOUND });
         });
     });
 });

--- a/test/src/services/checkSavedApplicationService.test.ts
+++ b/test/src/services/checkSavedApplicationService.test.ts
@@ -1,16 +1,13 @@
 import { Response } from "express";
 import { Resource } from "@companieshouse/api-sdk-node";
 import { Session } from "@companieshouse/node-session-handler";
-import {
-    deleteAcspApplication
-} from "../../../src/services/acspRegistrationService";
+import { deleteAcspApplication } from "../../../src/services/acspRegistrationService";
 import { getRedirectionUrl } from "../../../src/services/checkSavedApplicationService";
 import { TransactionList } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
 import { BASE_URL, CANNOT_REGISTER_AGAIN, CANNOT_SUBMIT_ANOTHER_APPLICATION, SAVED_APPLICATION, TYPE_OF_BUSINESS } from "../../../src/types/pageURL";
 import { APPROVED, IN_PROGRESS, REJECTED } from "../../../src/common/__utils/constants";
 import { HttpResponse } from "@companieshouse/api-sdk-node/dist/http";
 import { createResponse, MockResponse } from "node-mocks-http";
-import { getLocalesService } from "../../../src/utils/localise";
 
 jest.mock("@companieshouse/api-sdk-node");
 jest.mock("../../../src/services/acspRegistrationService");
@@ -79,36 +76,27 @@ describe("check saved application service tests", () => {
     });
 
     it("Should redirect to correct url when the application is open", async () => {
-        const redirectionUrl = await getRedirectionUrl(hasOpenApplication, session, res, "", "en");
+        const redirectionUrl = await getRedirectionUrl(hasOpenApplication, session);
         url = BASE_URL + SAVED_APPLICATION;
         expect(redirectionUrl).toEqual(url);
     });
 
     it("Should redirect to correct url when the application is approved", async () => {
-        const redirectionUrl = await getRedirectionUrl(hasApprovedApplication, session, res, "", "en");
+        const redirectionUrl = await getRedirectionUrl(hasApprovedApplication, session);
         url = BASE_URL + CANNOT_REGISTER_AGAIN;
         expect(redirectionUrl).toEqual(url);
     });
 
     it("Should redirect to correct url when the application is in progress", async () => {
-        const redirectionUrl = await getRedirectionUrl(hasApplicationInProgress, session, res, "", "en");
+        const redirectionUrl = await getRedirectionUrl(hasApplicationInProgress, session);
         url = BASE_URL + CANNOT_SUBMIT_ANOTHER_APPLICATION;
         expect(redirectionUrl).toEqual(url);
     });
 
     it("Should redirect to correct url when the application is in rejected", async () => {
         mockDeleteSavedApplication.mockResolvedValueOnce("200");
-        const redirectionUrl = await getRedirectionUrl(hasRejectedApplication, session, res, "", "en");
+        const redirectionUrl = await getRedirectionUrl(hasRejectedApplication, session);
         url = BASE_URL + TYPE_OF_BUSINESS;
         expect(redirectionUrl).toEqual(url);
     });
-
-    it("Should error when the application deletion is failed", async () => {
-        mockDeleteSavedApplication.mockRejectedValueOnce(new Error("Error deleting data"));
-        const locales = getLocalesService();
-        const redirectionUrl = await getRedirectionUrl(hasRejectedApplication, session, res, locales, "en");
-        expect(mockDeleteSavedApplication).toHaveBeenCalledTimes(1);
-        expect(redirectionUrl).toEqual("");
-    });
-
 });

--- a/test/src/services/transaction/transaction_service.test.ts
+++ b/test/src/services/transaction/transaction_service.test.ts
@@ -180,14 +180,50 @@ describe("transaction service tests", () => {
     });
 
     describe("getSavedApplication tests", () => {
-        it("Should return status 404", async () => {
-            mockGetTransactionForResourceKind.mockResolvedValueOnce({
+        it("Should return resolved responce for 200 status code", async () => {
+            const mockSuccessResponce = {
+                httpStatusCode: 200,
+                resource: { items: [[Object]] }
+            };
+            mockGetTransactionForResourceKind.mockResolvedValueOnce(mockSuccessResponce);
+
+            const httpResponse = await getSavedApplication(session, USER_ID);
+            expect(httpResponse.httpStatusCode).toStrictEqual(200);
+        });
+
+        it("Should return resolved responce for 404 status code", async () => {
+            const mockSuccessResponce = {
                 httpStatusCode: 404,
                 resource: { items: [[Object]] }
-            });
+            };
+            mockGetTransactionForResourceKind.mockResolvedValueOnce(mockSuccessResponce);
 
             const httpResponse = await getSavedApplication(session, USER_ID);
             expect(httpResponse.httpStatusCode).toStrictEqual(404);
+        });
+
+        it("Should throw an error when no transaction api response", async () => {
+            mockGetTransactionForResourceKind.mockResolvedValueOnce(undefined);
+
+            await expect(getSavedApplication(session, USER_ID)).rejects.toBe(undefined);
+        });
+
+        it("Should throw an error when status code is >=400 and not 404", async () => {
+            const mockFailedResponce = {
+                httpStatusCode: 500,
+                resource: { items: [[Object]] }
+            };
+            mockGetTransactionForResourceKind.mockResolvedValueOnce(mockFailedResponce);
+
+            await expect(getSavedApplication(session, USER_ID)).rejects.toBe(mockFailedResponce);
+        });
+        it("Should throw an error when no status code", async () => {
+            const mockFailedResponce = {
+                resource: { items: [[Object]] }
+            };
+            mockGetTransactionForResourceKind.mockResolvedValueOnce(mockFailedResponce);
+
+            await expect(getSavedApplication(session, USER_ID)).rejects.toBe(mockFailedResponce);
         });
     });
 });


### PR DESCRIPTION
- Filtered out rejected applications to prevent the wrong page being displayed when a user attempts to create a new application after a rejected one.
- Updated delete application to also delete the transaction associated with when when user selects to create a new application and not continue an old one.
- Moved calling POST transaction back to the get request in what type of business controller