### PR TITLE
Updating work sector implementation

### DIFF
--- a/locales/cy/sector-you-work-in.json
+++ b/locales/cy/sector-you-work-in.json
@@ -1,11 +1,13 @@
 {
     "sectorYouWorkInTitle" : "Ym mha sector ydych chi'n gweithio?",
-    "sectorYouWorkInHintText" : "This is optional. If you want to skip the question, select the 'Save and continue' button without selecting an option. Welsh",
     "sectorYouWorkInAuditorsInsolvencyPractitionersOption": "Archwilwyr, ymarferwyr ansolfedd, cyfrifwyr allanol a chynghorwyr treth",
     "sectorYouWorkInIndependentLegalProfessionalsOption": "Gweithwyr cyfreithiol annibynnol proffesiynol",
     "sectorYouWorkInTrustOrCompanyServiceProvidersOption": "Ymddiriedolaeth neu ddarparwyr gwasanaeth cwmni",
     "sectorYouWorkInCreditInstitutionsOption": "Sefydliadau credyd",
     "sectorYouWorkInFinancialInstitutionsOption": "Sefydliadau ariannol",
-    "sectorYouWorkInOtherOption": "Arall",
-    "sectorYouWorkInNotProvided": "Not provided Welsh"
+    "sectorYouWorkInOtherOption": "Show other sectors welsh",
+    "sectorYouWorkInOrText": "neu",
+    "sectorYouWorkInPreferNotToSayOption": "Prefer not to say welsh",
+
+    "error-sectorYouWorkInSelectRadio" : "Select which sector you work in or if you prefer not to say welsh"
 }

--- a/locales/cy/which-sector-other.json
+++ b/locales/cy/which-sector-other.json
@@ -4,7 +4,6 @@
     "whichSectorOtherHighValueDealersOption": "Delwyr gwerth uchel",
     "whichSectorOtherCasinosOption": "Casinos",
     "whichSectorOtherGoBack": "Ewch yn ôl i’r prif dudalen sector busnes",
-    "sectorYouWorkOtherHintText" : "This is optional. If you want to skip the question, select the 'Save and continue' button without selecting an option. welsh",
 
-    "error-whichSectorOtherSelectRadio" : "Dewiswch pa sector arall rydych chi'n gweithio ynddo"
+    "error-whichSectorOtherSelectRadio" : "Select which sector you work in or if you prefer not to say welsh"
 }

--- a/locales/en/sector-you-work-in.json
+++ b/locales/en/sector-you-work-in.json
@@ -1,11 +1,13 @@
 {
     "sectorYouWorkInTitle" : "Which sector do you work in?",
-    "sectorYouWorkInHintText" : "This is optional. If you want to skip the question, select the 'Save and continue' button without selecting an option.",
     "sectorYouWorkInAuditorsInsolvencyPractitionersOption": "Auditors, insolvency practitioners, external accountants and tax advisers",
     "sectorYouWorkInIndependentLegalProfessionalsOption": "Independent legal professionals",
     "sectorYouWorkInTrustOrCompanyServiceProvidersOption": "Trust or company service providers",
     "sectorYouWorkInCreditInstitutionsOption": "Credit institutions",
     "sectorYouWorkInFinancialInstitutionsOption": "Financial institutions",
-    "sectorYouWorkInOtherOption": "Other",
-    "sectorYouWorkInNotProvided": "Not provided"
+    "sectorYouWorkInOtherOption": "Show other sectors",
+    "sectorYouWorkInOrText": "or",
+    "sectorYouWorkInPreferNotToSayOption": "Prefer not to say",
+
+    "error-sectorYouWorkInSelectRadio" : "Select which sector you work in or if you prefer not to say"
 }

--- a/locales/en/which-sector-other.json
+++ b/locales/en/which-sector-other.json
@@ -4,7 +4,6 @@
     "whichSectorOtherHighValueDealersOption": "High value dealers",
     "whichSectorOtherCasinosOption": "Casinos",
     "whichSectorOtherGoBack": "Go back to main business sector list",
-    "sectorYouWorkOtherHintText" : "This is optional. If you want to skip the question, select the 'Save and continue' button without selecting an option.",
    
-    "error-whichSectorOtherSelectRadio" : "Select which other sector you work in"
+    "error-whichSectorOtherSelectRadio" : "Select which sector you work in or if you prefer not to say"
 }

--- a/src/controllers/features/limited/sectorYouWorkInController.ts
+++ b/src/controllers/features/limited/sectorYouWorkInController.ts
@@ -1,5 +1,7 @@
 import { NextFunction, Request, Response } from "express";
+import { validationResult } from "express-validator";
 import * as config from "../../../config";
+import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { LIMITED_SECTOR_YOU_WORK_IN, LIMITED_WHAT_IS_THE_CORRESPONDENCE_ADDRESS, LIMITED_CORRESPONDENCE_ADDRESS_CONFIRM, BASE_URL, LIMITED_WHICH_SECTOR_OTHER, LIMITED_WHAT_IS_YOUR_EMAIL } from "../../../types/pageURL";
 import { saveDataInSession } from "../../../common/__utils/sessionHelper";
@@ -43,20 +45,27 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 export const post = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
     const locales = getLocalesService();
-    const currentUrl = BASE_URL + LIMITED_SECTOR_YOU_WORK_IN;
+    const currentUrl: string = BASE_URL + LIMITED_SECTOR_YOU_WORK_IN;
     try {
+        const errorList = validationResult(req);
         const session: Session = req.session as any as Session;
         const acspData : AcspData = session?.getExtraData(USER_DATA)!;
-        if (req.body.sectorYouWorkIn === "OTHER") {
+        if (!errorList.isEmpty()) {
+            const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
+            res.status(400).render(config.SECTOR_YOU_WORK_IN, {
+                previousPage: addLangToUrl(getPreviousPage(acspData), lang),
+                ...getLocaleInfo(locales, lang),
+                currentUrl,
+                ...pageProperties
+            });
+        } else if (req.body.sectorYouWorkIn === "OTHER") {
             res.redirect(addLangToUrl(BASE_URL + LIMITED_WHICH_SECTOR_OTHER, lang));
         } else {
-            if (acspData) {
-                acspData.workSector = req.body.sectorYouWorkIn;
-                // save data to mongodb
-                const acspDataService = new AcspDataService();
-                await acspDataService.saveAcspData(session, acspData);
-                res.redirect(addLangToUrl(BASE_URL + LIMITED_WHAT_IS_YOUR_EMAIL, lang));
-            }
+            // save data to mongodb
+            acspData.workSector = req.body.sectorYouWorkIn;
+            const acspDataService = new AcspDataService();
+            await acspDataService.saveAcspData(session, acspData);
+            res.redirect(addLangToUrl(BASE_URL + LIMITED_WHAT_IS_YOUR_EMAIL, lang));
         }
     } catch (err) {
         logger.error(POST_ACSP_REGISTRATION_DETAILS_ERROR + " " + JSON.stringify(err));

--- a/src/controllers/features/sole-trader/sectorYouWorkInController.ts
+++ b/src/controllers/features/sole-trader/sectorYouWorkInController.ts
@@ -1,5 +1,7 @@
 import { NextFunction, Request, Response } from "express";
+import { validationResult } from "express-validator";
 import * as config from "../../../config";
+import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { SOLE_TRADER_SECTOR_YOU_WORK_IN, SOLE_TRADER_AUTO_LOOKUP_ADDRESS, BASE_URL, SOLE_TRADER_WHICH_SECTOR_OTHER, SOLE_TRADER_WHAT_IS_THE_BUSINESS_NAME } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
@@ -51,17 +53,29 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const locales = getLocalesService();
     const currentUrl: string = BASE_URL + SOLE_TRADER_SECTOR_YOU_WORK_IN;
     try {
+        const previousPage: string = addLangToUrl(BASE_URL + SOLE_TRADER_WHAT_IS_THE_BUSINESS_NAME, lang);
         const session: Session = req.session as any as Session;
         const acspData: AcspData = session?.getExtraData(USER_DATA)!;
-        if (req.body.sectorYouWorkIn === "OTHER") {
+        const acspType = acspData?.typeOfBusiness;
+        const errorList = validationResult(req);
+        if (!errorList.isEmpty()) {
+            const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
+            res.status(400).render(config.SECTOR_YOU_WORK_IN, {
+                previousPage,
+                ...getLocaleInfo(locales, lang),
+                currentUrl,
+                firstName: acspData?.applicantDetails?.firstName,
+                lastName: acspData?.applicantDetails?.lastName,
+                acspType: acspType,
+                ...pageProperties
+            });
+        } else if (req.body.sectorYouWorkIn === "OTHER") {
             res.redirect(addLangToUrl(BASE_URL + SOLE_TRADER_WHICH_SECTOR_OTHER, lang));
         } else {
-            if (acspData) {
-                acspData.workSector = req.body.sectorYouWorkIn;
-                // save data to mongodb
-                const acspDataService = new AcspDataService();
-                await acspDataService.saveAcspData(session, acspData);
-            }
+            // save data to mongodb
+            acspData.workSector = req.body.sectorYouWorkIn;
+            const acspDataService = new AcspDataService();
+            await acspDataService.saveAcspData(session, acspData);
             res.redirect(addLangToUrl(BASE_URL + SOLE_TRADER_AUTO_LOOKUP_ADDRESS, lang));
         }
     } catch (err) {

--- a/src/controllers/features/unincorporated/unincorporatedSectorYouWorkInController.ts
+++ b/src/controllers/features/unincorporated/unincorporatedSectorYouWorkInController.ts
@@ -1,5 +1,7 @@
 import { NextFunction, Request, Response } from "express";
+import { validationResult } from "express-validator";
 import * as config from "../../../config";
+import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { UNINCORPORATED_WHICH_SECTOR, UNINCORPORATED_WHAT_IS_YOUR_ROLE, BASE_URL, UNINCORPORATED_WHICH_SECTOR_OTHER, UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP } from "../../../types/pageURL";
 import { GET_ACSP_REGISTRATION_DETAILS_ERROR, POST_ACSP_REGISTRATION_DETAILS_ERROR, SUBMISSION_ID, USER_DATA } from "../../../common/__utils/constants";
@@ -49,15 +51,22 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const session: Session = req.session as any as Session;
         const acspData: AcspData = session?.getExtraData(USER_DATA)!;
-        if (req.body.sectorYouWorkIn === "OTHER") {
+        const errorList = validationResult(req);
+        if (!errorList.isEmpty()) {
+            const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
+            res.status(400).render(config.SECTOR_YOU_WORK_IN, {
+                title: locales.i18nCh.resolveNamespacesKeys(lang).sectorYouWorkInTitle,
+                ...getLocaleInfo(locales, lang),
+                currentUrl,
+                ...pageProperties
+            });
+        } else if (req.body.sectorYouWorkIn === "OTHER") {
             res.redirect(addLangToUrl(BASE_URL + UNINCORPORATED_WHICH_SECTOR_OTHER, lang));
         } else {
-            if (acspData) {
-                acspData.workSector = req.body.sectorYouWorkIn;
-                // save data to mongodb
-                const acspDataService = new AcspDataService();
-                await acspDataService.saveAcspData(session, acspData);
-            }
+            // save data to mongodb
+            acspData.workSector = req.body.sectorYouWorkIn;
+            const acspDataService = new AcspDataService();
+            await acspDataService.saveAcspData(session, acspData);
             res.redirect(addLangToUrl(BASE_URL + UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP, lang));
         }
     } catch (err) {

--- a/src/model/BusinessSector.ts
+++ b/src/model/BusinessSector.ts
@@ -1,5 +1,5 @@
 export enum SectorOfWork {
-    AIA = "Auditors, insolvency practitioners, external accountants and tax advisers",
+    AIP = "Auditors, insolvency practitioners, external accountants and tax advisers",
     ILP = "Independent legal professionals",
     TCSP = "Trust or company service providers",
     CI = "Credit institutions",
@@ -7,4 +7,5 @@ export enum SectorOfWork {
     EA = "Estate agents",
     HVD = "High value dealers",
     CASINOS = "Casinos",
+    PNTS = "Prefer not to say"
 }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -70,6 +70,7 @@ import { businessAddressListValidator } from "../validation/businessAddressList"
 import { companyNumberValidator } from "../validation/companyLookup";
 import { correspondenceAddressListValidator } from "../validation/correspondanceAddressList";
 import { correspondenceAddressAutoLookupValidator } from "../validation/correspondenceAddressAutoLookup";
+import { sectorYouWorkInValidator } from "../validation/sectorYouWorkIn";
 import { manualAddressValidator } from "../validation/commonAddressManual";
 import { dateOfBirthValidator } from "../validation/dateOfBirth";
 import { nameRegisteredWithAmlValidator } from "../validation/nameRegisteredWithAml";
@@ -81,6 +82,7 @@ import { soleTraderWhatIsTheBusinessNameValidator } from "../validation/soleTrad
 import { unicorporatedWhatIsTheBusinessNameValidator } from "../validation/unicorporatedWhatIsTheBusinessName";
 import { nameValidator } from "../validation/whatIsYourName";
 import { whereDoYouLiveValidator } from "../validation/whereDoYouLive";
+import { whichSectorOtherValidator } from "../validation/whichSectorOther";
 import { companyAuthenticationMiddleware } from "../middleware/company_authentication_middleware";
 import { addressCorrespondanceSelectorValidator } from "../validation/addressCorrespondanceSelector";
 import { selectAmlSupervisorValidator } from "../validation/selectAmlSupervisor";
@@ -138,10 +140,10 @@ routes.get(urls.SOLE_TRADER_WHAT_IS_YOUR_NAME, soleTraderNameController.get);
 routes.post(urls.SOLE_TRADER_WHAT_IS_YOUR_NAME, nameValidator, soleTraderNameController.post);
 
 routes.get(urls.SOLE_TRADER_SECTOR_YOU_WORK_IN, soleTraderSectorYouWorkInController.get);
-routes.post(urls.SOLE_TRADER_SECTOR_YOU_WORK_IN, soleTraderSectorYouWorkInController.post);
+routes.post(urls.SOLE_TRADER_SECTOR_YOU_WORK_IN, sectorYouWorkInValidator, soleTraderSectorYouWorkInController.post);
 
 routes.get(urls.SOLE_TRADER_WHICH_SECTOR_OTHER, soleTraderWhichSectorOtherController.get);
-routes.post(urls.SOLE_TRADER_WHICH_SECTOR_OTHER, soleTraderWhichSectorOtherController.post);
+routes.post(urls.SOLE_TRADER_WHICH_SECTOR_OTHER, whichSectorOtherValidator, soleTraderWhichSectorOtherController.post);
 
 routes.get(urls.SOLE_TRADER_WHERE_DO_YOU_LIVE, soleTraderWhereDoYouLiveController.get);
 routes.post(urls.SOLE_TRADER_WHERE_DO_YOU_LIVE, whereDoYouLiveValidator, soleTraderWhereDoYouLiveController.post);
@@ -187,10 +189,10 @@ routes.get(urls.LIMITED_WHAT_IS_THE_COMPANY_NUMBER, limitedCompanyLookupControll
 routes.post(urls.LIMITED_WHAT_IS_THE_COMPANY_NUMBER, companyNumberValidator, limitedCompanyLookupController.post);
 
 routes.get(urls.LIMITED_SECTOR_YOU_WORK_IN, limitedSectorYouWorkInController.get);
-routes.post(urls.LIMITED_SECTOR_YOU_WORK_IN, limitedSectorYouWorkInController.post);
+routes.post(urls.LIMITED_SECTOR_YOU_WORK_IN, sectorYouWorkInValidator, limitedSectorYouWorkInController.post);
 
 routes.get(urls.LIMITED_WHICH_SECTOR_OTHER, limitedWhichSectorOtherController.get);
-routes.post(urls.LIMITED_WHICH_SECTOR_OTHER, limitedWhichSectorOtherController.post);
+routes.post(urls.LIMITED_WHICH_SECTOR_OTHER, whichSectorOtherValidator, limitedWhichSectorOtherController.post);
 
 routes.get(urls.LIMITED_IS_THIS_YOUR_COMPANY, limitedIsThisYourCompanyController.get);
 routes.post(urls.LIMITED_IS_THIS_YOUR_COMPANY, limitedIsThisYourCompanyController.post);
@@ -237,10 +239,10 @@ routes.get(urls.UNINCORPORATED_WHAT_IS_YOUR_ROLE, unincorporatedWhatIsYourRoleCo
 routes.post(urls.UNINCORPORATED_WHAT_IS_YOUR_ROLE, whatIsYourRoleValidator, unincorporatedWhatIsYourRoleController.post);
 
 routes.get(urls.UNINCORPORATED_WHICH_SECTOR, unincorporatedSectorYouWorkInController.get);
-routes.post(urls.UNINCORPORATED_WHICH_SECTOR, unincorporatedSectorYouWorkInController.post);
+routes.post(urls.UNINCORPORATED_WHICH_SECTOR, sectorYouWorkInValidator, unincorporatedSectorYouWorkInController.post);
 
 routes.get(urls.UNINCORPORATED_WHICH_SECTOR_OTHER, unincorporatedWhichSectorOtherController.get);
-routes.post(urls.UNINCORPORATED_WHICH_SECTOR_OTHER, unincorporatedWhichSectorOtherController.post);
+routes.post(urls.UNINCORPORATED_WHICH_SECTOR_OTHER, whichSectorOtherValidator, unincorporatedWhichSectorOtherController.post);
 
 routes.get(urls.UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP, unincorporatedBusinessAddressAutoLookupController.get);
 routes.post(urls.UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP, correspondenceAddressAutoLookupValidator, unincorporatedBusinessAddressAutoLookupController.post);

--- a/src/services/checkYourAnswersService.ts
+++ b/src/services/checkYourAnswersService.ts
@@ -51,7 +51,7 @@ const roleTranslated = (role: string, i18n: any): string => {
 
 const sectorTranslated = (sector: string, i18n: any): string => {
     switch (sector) {
-    case "AIA":
+    case "AIP":
         return i18n.sectorYouWorkInAuditorsInsolvencyPractitionersOption;
     case "ILP":
         return i18n.sectorYouWorkInIndependentLegalProfessionalsOption;
@@ -67,8 +67,8 @@ const sectorTranslated = (sector: string, i18n: any): string => {
         return i18n.whichSectorOtherHighValueDealersOption;
     case "CASINOS":
         return i18n.whichSectorOtherCasinosOption;
-    case "Not provided":
-        return i18n.sectorYouWorkInNotProvided;
+    case "PNTS":
+        return i18n.sectorYouWorkInPreferNotToSayOption;
     default:
         return sector;
     }
@@ -92,12 +92,7 @@ export const getAnswers = (req: Request, acspData: AcspData, i18n: any): Answers
     answers.typeOfBusiness = typeOfBusinessTranslated(acspData.typeOfBusiness!, i18n);
     answers.roleType = roleTranslated(acspData.roleType!, i18n);
     answers.correspondenceEmail = acspData.applicantDetails?.correspondenceEmail;
-    if (acspData.workSector != null) {
-        answers.workSector = sectorTranslated(acspData.workSector, i18n);
-    } else {
-        const notProvidedText = "Not provided";
-        answers.workSector = sectorTranslated(notProvidedText, i18n);
-    }
+    answers.workSector = sectorTranslated(acspData.workSector!, i18n);
     if (acspData.typeOfBusiness === "LC" || acspData.typeOfBusiness === "LLP" || acspData.typeOfBusiness === "CORPORATE_BODY") {
         answers = limitedAnswers(req, answers, acspData);
     } else if (acspData.typeOfBusiness === "SOLE_TRADER") {

--- a/src/validation/sectorYouWorkIn.ts
+++ b/src/validation/sectorYouWorkIn.ts
@@ -1,0 +1,5 @@
+import { body } from "express-validator";
+
+export const sectorYouWorkInValidator = [
+    body("sectorYouWorkIn", "sectorYouWorkInSelectRadio").notEmpty()
+];

--- a/src/validation/whichSectorOther.ts
+++ b/src/validation/whichSectorOther.ts
@@ -1,0 +1,5 @@
+import { body } from "express-validator";
+
+export const whichSectorOtherValidator = [
+    body("whichSectorOther", "whichSectorOtherSelectRadio").notEmpty()
+];

--- a/src/views/common/sector-you-work-in/sector-you-work-in.njk
+++ b/src/views/common/sector-you-work-in/sector-you-work-in.njk
@@ -9,6 +9,7 @@
       {% include "partials/user_name.njk" %}
     {% endif %}
     {{ govukRadios({
+      errorMessage: errors.sectorYouWorkIn if errors,
       classes: "govuk-radios",
       id: "sector-you-work-in-radios",
       name: "sectorYouWorkIn",
@@ -19,17 +20,12 @@
           classes: "govuk-fieldset__legend--l"
         }
       },
-      hint: {
-        text: i18n.sectorYouWorkInHintText,
-        id: "what-sector-hint",
-        classes: "govuk-hint govuk-!-padding-bottom-2"
-      },
       value: workSector,
       items: [
         {
-          value: "AIA",
+          value: "AIP",
           text: i18n.sectorYouWorkInAuditorsInsolvencyPractitionersOption,
-          id:"AIA-id"
+          id:"AIP-id"
         },
         {
           value: "ILP",
@@ -55,6 +51,14 @@
           value: "OTHER",
           text: i18n.sectorYouWorkInOtherOption,
           id:"OTHER-id"
+        },
+        {
+          divider: i18n.sectorYouWorkInOrText
+        },
+        {
+          value: "PNTS",
+          text: i18n.sectorYouWorkInPreferNotToSayOption,
+          id:"prefer-not-to-say-id"
         }
       ]
     }) }}
@@ -66,7 +70,7 @@
 
   <script>
     let selectedRadio = null;
-    
+
     // Function to track Matomo analytics based on the selected radio button
     function trackRadioSelection() {
       const radioButtons = document.querySelectorAll('input[name="sectorYouWorkIn"]');
@@ -81,17 +85,7 @@
     
     // Run trackRadioSelection function
     trackRadioSelection();
-    
-    // EventListener to track the value of selectedRadio when the save and continue button is clicked
-    document.getElementById("save-continue-button").addEventListener("click", () => {
-      // If no radio button has been selected, then work sector has not been provided
-      if (!selectedRadio) {
-        trackEventWorkSector("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Sector you work in - Not provided");
-      } else {
-        // Else a radio button has been selected and the below function is run
-        trackEventWorkSector("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Sector you work in");
-      }
-    });
+    trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - Sector you work in");
     </script>
 
 {% endblock main_content %}

--- a/src/views/common/which-sector-other/which-sector-other.njk
+++ b/src/views/common/which-sector-other/which-sector-other.njk
@@ -10,6 +10,7 @@
         {% endif %}
         <div class="govuk-form-group">
             {{ govukRadios({
+                errorMessage: errors.sectorYouWorkIn if errors,
                 classes: "govuk-radios",
                 id: "which-sector-other-radios",
                 name: "whichSectorOther",
@@ -19,11 +20,6 @@
                         isPageHeading: true,
                         classes: "govuk-fieldset__legend--l"
                     }
-                },
-                hint: {
-                    text: i18n.sectorYouWorkOtherHintText,
-                    id: "what-sector-other-hint",
-                    classes: "govuk-hint govuk-!-padding-bottom-2"
                 },
                 value: workSector,
                 items: [
@@ -78,24 +74,9 @@
         });
       }
 
-      // Run trackRadioSelection function
       trackRadioSelection();
-
-
-      // EventListener to track the value of selectedRadio when the save and continue button is clicked
-      document.getElementById("save-continue-button").addEventListener("click", () => {
-        // If no radio button has been selected, then work sector has not been provided
-        if (!selectedRadio) {
-          trackEventWorkSector("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - OTHER SECTOR - Not provided");
-        } else {
-          // Else a radio button has been selected and the below function is run
-          trackEventWorkSector("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - OTHER SECTOR");
-        }
-      });
+      trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE - OTHER SECTOR");
+      trackEventBasedOnPageTitle("back-link-id", "{{title}}", "click-link", "Back to main business sector");
     </script>
-    <script>
-    trackEventBasedOnPageTitle("back-link-id", "{{title}}", "click-link", "Back to main business sector");
-    </script>
-
 
 {% endblock main_content %}

--- a/test/mocks/check_your_answers.mock.ts
+++ b/test/mocks/check_your_answers.mock.ts
@@ -21,7 +21,7 @@ export const mockLimitedAcspData: AcspData = {
     id: "1234",
     typeOfBusiness: "LC",
     roleType: "DIRECTOR",
-    workSector: "AIA",
+    workSector: "AIP",
     applicantDetails: {
         correspondenceAddress: {
             premises: "premises",
@@ -72,34 +72,6 @@ export const mockSoleTraderAcspData: AcspData = {
     },
     businessName: "Test Business 123"
 };
-export const mockSoleTraderAcspDataWorkSectorNotProvided: AcspData = {
-    id: "1234",
-    typeOfBusiness: "SOLE_TRADER",
-    roleType: "SOLE_TRADER",
-    workSector: undefined,
-    applicantDetails: {
-        correspondenceAddress: {
-            premises: "premises",
-            addressLine1: "addressLine1",
-            addressLine2: "addressLine2",
-            locality: "locality",
-            region: "region",
-            postalCode: "postalcode"
-        },
-        correspondenceEmail: "test@email.com",
-        firstName: "Unit",
-        middleName: "Test",
-        lastName: "User",
-        dateOfBirth: new Date(1990, 10, 15),
-        nationality: {
-            firstNationality: "British",
-            secondNationality: "",
-            thirdNationality: ""
-        },
-        countryOfResidence: "England"
-    },
-    businessName: "Test Business 123"
-};
 export const mockSoleTrader2AcspData: AcspData = {
     id: "1234",
     typeOfBusiness: "SOLE_TRADER",
@@ -123,7 +95,7 @@ export const mockSoleTrader3AcspData: AcspData = {
     id: "1234",
     typeOfBusiness: "SOLE_TRADER",
     roleType: "MEMBER_OF_GOVERNING_BODY",
-    workSector: "EA",
+    workSector: "PNTS",
     applicantDetails: {
         firstName: "Unit",
         middleName: "Test",

--- a/test/src/controllers/common/amlBodyMembershipNumberController.test.ts
+++ b/test/src/controllers/common/amlBodyMembershipNumberController.test.ts
@@ -59,7 +59,7 @@ describe("POST" + AML_MEMBERSHIP_NUMBER, () => {
         membershipNumber_1: "ABC",
         membershipNumber_2: "CBA",
         membershipNumber__3: "Finance",
-        sectorYouWorkIn: "AIA",
+        sectorYouWorkIn: "AIP",
         typeOfBusiness: "SOLE_TRADER",
         applicantDetails: {
             firstName: "John",

--- a/test/src/controllers/limited/sectorYouWorkInController.test.ts
+++ b/test/src/controllers/limited/sectorYouWorkInController.test.ts
@@ -14,7 +14,7 @@ const mockPutAcspRegistration = putAcspRegistration as jest.Mock;
 const acspData: AcspData = {
     id: "abc",
     typeOfBusiness: "LIMITED",
-    workSector: "AIA",
+    workSector: "AIP",
     applicantDetails: {
         firstName: "John",
         lastName: "Doe"
@@ -52,7 +52,7 @@ describe("GET" + LIMITED_SECTOR_YOU_WORK_IN, () => {
 
 describe("POST" + LIMITED_SECTOR_YOU_WORK_IN, () => {
     it("should return status 302 after redirect", async () => {
-        const res = await router.post(BASE_URL + LIMITED_SECTOR_YOU_WORK_IN).send({ sectorYouWorkIn: "AIA" });
+        const res = await router.post(BASE_URL + LIMITED_SECTOR_YOU_WORK_IN).send({ sectorYouWorkIn: "AIP" });
         expect(res.status).toBe(302);
         expect(res.header.location).toBe(BASE_URL + LIMITED_WHAT_IS_YOUR_EMAIL + "?lang=en");
     });
@@ -88,16 +88,16 @@ describe("POST" + LIMITED_SECTOR_YOU_WORK_IN, () => {
         expect(res.header.location).toBe(BASE_URL + LIMITED_WHICH_SECTOR_OTHER + "?lang=en");
     });
 
-    // Test for no value selected, it will return 302 and redirect to the next page when no work sector is selected.
-    it("should return status 302 after no work sector selected", async () => {
+    // Test for incorrect form details entered, will return 400.
+    it("should return status 400 after no radio selected", async () => {
         const res = await router.post(BASE_URL + LIMITED_SECTOR_YOU_WORK_IN).send({ sectorYouWorkIn: "" });
-        expect(res.status).toBe(302);
-        expect(res.header.location).toBe(BASE_URL + LIMITED_WHAT_IS_YOUR_EMAIL + "?lang=en");
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("Select which sector you work in or if you prefer not to say");
     });
 
     it("should show the error page if an error occurs during PUT request", async () => {
         mockPutAcspRegistration.mockRejectedValueOnce(new Error("Error PUTting data"));
-        const res = await router.post(BASE_URL + LIMITED_SECTOR_YOU_WORK_IN).send({ sectorYouWorkIn: "AIA" });
+        const res = await router.post(BASE_URL + LIMITED_SECTOR_YOU_WORK_IN).send({ sectorYouWorkIn: "AIP" });
         expect(res.status).toBe(500);
         expect(res.text).toContain("Sorry we are experiencing technical difficulties");
     });

--- a/test/src/controllers/limited/whatIsYourEmailAddressController.test.ts
+++ b/test/src/controllers/limited/whatIsYourEmailAddressController.test.ts
@@ -14,7 +14,7 @@ const mockPutAcspRegistration = putAcspRegistration as jest.Mock;
 const acspData: AcspData = {
     id: "abc",
     typeOfBusiness: "LIMITED",
-    workSector: "AIA"
+    workSector: "AIP"
 };
 
 describe("GET" + LIMITED_WHAT_IS_YOUR_EMAIL, () => {

--- a/test/src/controllers/limited/whichSectorOtherController.test.ts
+++ b/test/src/controllers/limited/whichSectorOtherController.test.ts
@@ -14,7 +14,7 @@ const mockPutAcspRegistration = putAcspRegistration as jest.Mock;
 const acspData: AcspData = {
     id: "abc",
     typeOfBusiness: "LIMITED",
-    workSector: "AIA"
+    workSector: "AIP"
 };
 
 describe("GET" + LIMITED_WHICH_SECTOR_OTHER, () => {
@@ -67,20 +67,20 @@ describe("POST" + LIMITED_WHICH_SECTOR_OTHER, () => {
         const formData = {
             id: "abc",
             typeOfBusiness: "LIMITED",
-            workSector: "AIA"
+            workSector: "AIP"
         };
         mockGetAcspRegistration.mockResolvedValueOnce(formData);
         mockPutAcspRegistration.mockResolvedValueOnce(formData);
-        const res = await router.post(BASE_URL + LIMITED_WHICH_SECTOR_OTHER).send({ whichSectorOther: "AIA" });
+        const res = await router.post(BASE_URL + LIMITED_WHICH_SECTOR_OTHER).send({ whichSectorOther: "AIP" });
         expect(res.status).toBe(302);
         expect(res.header.location).toBe(BASE_URL + LIMITED_WHAT_IS_YOUR_EMAIL + "?lang=en");
     });
 
-    // Test for no option selected should return status 302 and redirect.
-    it("should return status 302 after no radio selected", async () => {
+    // Test for incorrect form details entered, will return 400.
+    it("should return status 400 after no radio selected", async () => {
         const res = await router.post(BASE_URL + LIMITED_WHICH_SECTOR_OTHER).send({ whichSectorOther: "" });
-        expect(res.status).toBe(302);
-        expect(res.header.location).toBe(BASE_URL + LIMITED_WHAT_IS_YOUR_EMAIL + "?lang=en");
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("Select which sector you work in or if you prefer not to say");
     });
 
     it("should show the error page if an error occurs during PUT request", async () => {

--- a/test/src/controllers/soleTrader/sectorYouWorkInController.test.ts
+++ b/test/src/controllers/soleTrader/sectorYouWorkInController.test.ts
@@ -52,7 +52,7 @@ describe("POST" + SOLE_TRADER_SECTOR_YOU_WORK_IN, () => {
     // Test for correct form details entered, will return 302 after redirecting to the next page.
     it("should return status 302 after redirect", async () => {
         const formData = {
-            sectorYouWorkIn: "AIA",
+            sectorYouWorkIn: "AIP",
             typeOfBusiness: "SOLE_TRADER",
             applicantDetails: {
                 firstName: "John",
@@ -67,7 +67,7 @@ describe("POST" + SOLE_TRADER_SECTOR_YOU_WORK_IN, () => {
 
     it("should return status 302 without applicantDetails", async () => {
         const formData = {
-            sectorYouWorkIn: "AIA",
+            sectorYouWorkIn: "AIP",
             typeOfBusiness: "SOLE_TRADER"
         };
         const res = await router.post(BASE_URL + SOLE_TRADER_SECTOR_YOU_WORK_IN).send(formData);
@@ -90,8 +90,8 @@ describe("POST" + SOLE_TRADER_SECTOR_YOU_WORK_IN, () => {
         expect(res.header.location).toBe(BASE_URL + SOLE_TRADER_WHICH_SECTOR_OTHER + "?lang=en");
     });
 
-    // Test for no value selected, it will return 302 and redirect to the next page when no work sector is selected.
-    it("should return status 302 after no work sector selected", async () => {
+    // Test for incorrect form details entered, will return 400.
+    it("should return status 400 after no work sector selected", async () => {
         const formData = {
             sectorYouWorkIn: "",
             typeOfBusiness: "SOLE_TRADER",
@@ -102,13 +102,13 @@ describe("POST" + SOLE_TRADER_SECTOR_YOU_WORK_IN, () => {
             }
         };
         const res = await router.post(BASE_URL + SOLE_TRADER_SECTOR_YOU_WORK_IN).send(formData);
-        expect(res.status).toBe(302);
-        expect(res.header.location).toBe(BASE_URL + SOLE_TRADER_AUTO_LOOKUP_ADDRESS + "?lang=en");
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("Select which sector you work in or if you prefer not to say");
     });
 
     it("should show the error page if an error occurs during PUT request", async () => {
         const formData = {
-            sectorYouWorkIn: "AIA",
+            sectorYouWorkIn: "AIP",
             typeOfBusiness: "SOLE_TRADER",
             applicantDetails: {
                 firstName: "John",

--- a/test/src/controllers/soleTrader/whatIsYourEmailAddressController.test.ts
+++ b/test/src/controllers/soleTrader/whatIsYourEmailAddressController.test.ts
@@ -14,7 +14,7 @@ const mockPutAcspRegistration = putAcspRegistration as jest.Mock;
 const acspData: AcspData = {
     id: "abc",
     typeOfBusiness: "LIMITED",
-    workSector: "AIA"
+    workSector: "AIP"
 };
 
 describe("GET" + SOLE_TRADER_WHAT_IS_YOUR_EMAIL, () => {

--- a/test/src/controllers/soleTrader/whatIsYourRoleController.test.ts
+++ b/test/src/controllers/soleTrader/whatIsYourRoleController.test.ts
@@ -19,7 +19,7 @@ const mockPutAcspRegistration = putAcspRegistration as jest.Mock;
 const acspData: AcspData = {
     id: "abc",
     typeOfBusiness: "LIMITED",
-    workSector: "AIA",
+    workSector: "AIP",
     applicantDetails: {
         firstName: "John",
         lastName: "Doe"

--- a/test/src/controllers/soleTrader/whichSectorOtherController.test.ts
+++ b/test/src/controllers/soleTrader/whichSectorOtherController.test.ts
@@ -55,7 +55,7 @@ describe("GET" + SOLE_TRADER_WHICH_SECTOR_OTHER, () => {
 describe("POST" + SOLE_TRADER_WHICH_SECTOR_OTHER, () => {
     const formData = {
         whichSectorOther: "EA",
-        sectorYouWorkIn: "AIA",
+        sectorYouWorkIn: "AIP",
         typeOfBusiness: "SOLE_TRADER",
         applicantDetails: {
             firstName: "John",
@@ -70,11 +70,11 @@ describe("POST" + SOLE_TRADER_WHICH_SECTOR_OTHER, () => {
         expect(res.header.location).toBe(BASE_URL + SOLE_TRADER_AUTO_LOOKUP_ADDRESS + "?lang=en");
     });
 
-    // Test for no option selected should return 302 after redirect.
-    it("should return status 302 after redirect no sector selected", async () => {
+    // Test for incorrect form details entered, will return 400.
+    it("should return status 400 after no radio selected", async () => {
         const res = await router.post(BASE_URL + SOLE_TRADER_WHICH_SECTOR_OTHER).send({ whichSectorOther: "" });
-        expect(res.status).toBe(302);
-        expect(res.header.location).toBe(BASE_URL + SOLE_TRADER_AUTO_LOOKUP_ADDRESS + "?lang=en");
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("Select which sector you work in or if you prefer not to say");
     });
 
     it("should show the error page if an error occurs during PUT request", async () => {

--- a/test/src/controllers/unincorporated/sectorYouWorkInController.test.ts
+++ b/test/src/controllers/unincorporated/sectorYouWorkInController.test.ts
@@ -38,7 +38,7 @@ describe("GET" + UNINCORPORATED_WHICH_SECTOR, () => {
 describe("POST" + UNINCORPORATED_WHICH_SECTOR, () => {
     // Test for not "Other" radio button will return 302 after redirect to business address lookup page .
     it("should return status 302 after redirect", async () => {
-        const res = await router.post(BASE_URL + UNINCORPORATED_WHICH_SECTOR).send({ sectorYouWorkIn: "AIA" });
+        const res = await router.post(BASE_URL + UNINCORPORATED_WHICH_SECTOR).send({ sectorYouWorkIn: "AIP" });
         expect(res.status).toBe(302);
         expect(res.header.location).toBe(BASE_URL + UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP + "?lang=en");
     });
@@ -50,16 +50,16 @@ describe("POST" + UNINCORPORATED_WHICH_SECTOR, () => {
         expect(res.header.location).toBe(BASE_URL + UNINCORPORATED_WHICH_SECTOR_OTHER + "?lang=en");
     });
 
-    // Test for no value selected, it will return 302 and redirect to the next page when no work sector is selected.
-    it("should return status 302 after no work sector selected", async () => {
+    // Test for incorrect form details entered, will return 400.
+    it("should return status 400 after no radio selected", async () => {
         const res = await router.post(BASE_URL + UNINCORPORATED_WHICH_SECTOR).send({ sectorYouWorkIn: "" });
-        expect(res.status).toBe(302);
-        expect(res.header.location).toBe(BASE_URL + UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP + "?lang=en");
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("Select which sector you work in or if you prefer not to say");
     });
 
     it("should show the error page if an error occurs during PUT request", async () => {
         mockPutAcspRegistration.mockRejectedValueOnce(new Error("Error PUTting data"));
-        const res = await router.post(BASE_URL + UNINCORPORATED_WHICH_SECTOR).send({ sectorYouWorkIn: "AIA" });
+        const res = await router.post(BASE_URL + UNINCORPORATED_WHICH_SECTOR).send({ sectorYouWorkIn: "AIP" });
         expect(res.status).toBe(500);
         expect(res.text).toContain("Sorry we are experiencing technical difficulties");
     });

--- a/test/src/controllers/unincorporated/sectorYouWorkInOtherController.test.ts
+++ b/test/src/controllers/unincorporated/sectorYouWorkInOtherController.test.ts
@@ -42,11 +42,11 @@ describe("POST" + UNINCORPORATED_WHICH_SECTOR_OTHER, () => {
         expect(res.header.location).toBe(BASE_URL + UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP + "?lang=en");
     });
 
-    // Test for no option selected should return status 302 and redirect.
-    it("should return status 302 after no radio selected", async () => {
+    // Test for incorrect form details entered, will return 400.
+    it("should return status 400 after no radio selected", async () => {
         const res = await router.post(BASE_URL + UNINCORPORATED_WHICH_SECTOR_OTHER).send({ whichSectorOther: "" });
-        expect(res.status).toBe(302);
-        expect(res.header.location).toBe(BASE_URL + UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP + "?lang=en");
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("Select which sector you work in or if you prefer not to say");
     });
 
     it("should show the error page if an error occurs during PUT request", async () => {

--- a/test/src/controllers/unincorporated/whatIsYourEmailAddressController.test.ts
+++ b/test/src/controllers/unincorporated/whatIsYourEmailAddressController.test.ts
@@ -14,7 +14,7 @@ const mockPutAcspRegistration = putAcspRegistration as jest.Mock;
 const acspData: AcspData = {
     id: "abc",
     typeOfBusiness: "LIMITED",
-    workSector: "AIA"
+    workSector: "AIP"
 };
 
 describe("GET" + UNINCORPORATED_WHAT_IS_YOUR_EMAIL, () => {

--- a/test/src/services/checkYourAnswersService.test.ts
+++ b/test/src/services/checkYourAnswersService.test.ts
@@ -5,7 +5,7 @@ import { getAnswers } from "../../../src/services/checkYourAnswersService";
 import { getLocalesService } from "../../../src/utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
 import { COMPANY_DETAILS } from "../../../src/common/__utils/constants";
-import { mockCompany, mockLimitedAcspData, mockLLPAcspData, mockLPAcspData, mockPartnershipAcspData, mockSoleTrader2AcspData, mockSoleTrader3AcspData, mockSoleTraderAcspData, mockSoleTraderAcspDataWorkSectorNotProvided, mockUnincorporatedAcspData } from "../../mocks/check_your_answers.mock";
+import { mockCompany, mockLimitedAcspData, mockLLPAcspData, mockLPAcspData, mockPartnershipAcspData, mockSoleTrader2AcspData, mockSoleTrader3AcspData, mockSoleTraderAcspData, mockUnincorporatedAcspData } from "../../mocks/check_your_answers.mock";
 
 describe("CheckYourAnswersService", () => {
     let req: MockRequest<Request>;
@@ -76,23 +76,6 @@ describe("CheckYourAnswersService", () => {
         });
     });
 
-    it("should return answers for sole trader journey with work sector not provided", () => {
-        const soleTraderAnswers = getAnswers(req, mockSoleTraderAcspDataWorkSectorNotProvided, locales.i18nCh.resolveNamespacesKeys(req.query.lang));
-
-        expect(soleTraderAnswers).toStrictEqual({
-            businessName: "Test Business 123",
-            correspondenceAddress: "premises addressLine1<br>addressLine2<br>locality<br>region<br>postalcode",
-            roleType: "I am the sole trader",
-            typeOfBusiness: "Sole trader",
-            workSector: "Not provided",
-            countryOfResidence: "England",
-            dateOfBirth: "15 November 1990",
-            name: "Unit Test User",
-            nationality: "British",
-            correspondenceEmail: "test@email.com"
-        });
-    });
-
     it("should return answers for sole trader journey with multiple nationalities", () => {
         const soleTraderAnswers = getAnswers(req, mockSoleTrader2AcspData, locales.i18nCh.resolveNamespacesKeys(req.query.lang));
 
@@ -110,7 +93,7 @@ describe("CheckYourAnswersService", () => {
         });
     });
 
-    it("should return answers for sole trader journey with Estate agents work sector", () => {
+    it("should return answers for sole trader journey with Prefer not to say work sector", () => {
         const soleTraderAnswers = getAnswers(req, mockSoleTrader3AcspData, locales.i18nCh.resolveNamespacesKeys(req.query.lang));
 
         expect(soleTraderAnswers).toStrictEqual({
@@ -118,7 +101,7 @@ describe("CheckYourAnswersService", () => {
             correspondenceAddress: "",
             roleType: "I am a member of the governing body",
             typeOfBusiness: "Sole trader",
-            workSector: "Estate agents",
+            workSector: "Prefer not to say",
             countryOfResidence: "England",
             dateOfBirth: "15 November 1990",
             name: "Unit Test User",


### PR DESCRIPTION
**Short description outlining key changes/additions**

Includes changes against 2 tickets.

**Ticket 1: IDVA5-1316**

- Added Radio button validation to both Work Sector and Other Work Sector pages as they can no longer be skipped
- Removed hint text on both work sector pages
- Updated text for 'Other' radio option on work sector page
- Added additional Radio button 'Prefer not to say'
- Updated Matomo analytics implementation for both work sector pages - now tracks new radio option and removed analytics if page was skipped (page can no longer be skipped)
- Updated Controller Post requests on all journeys to capture radio button validation
- Updated check your answers implementation to match new Radio option (previously Work Sector would display as 'Not provided' if page was skipped)
- Updated BusinessSector model to include new enum
- Updated tests

**Ticket 2: IDVA5-1457**

- Updated "Auditors, insolvency practitioners, external accountants and tax advisers" work sector enum to AIP to match CHIPS mapping
- Replicated changes on work sector front end view
- Updated tests

**JIRA Ticket Number**
Includes changes made against tickets:

[IDVA5-1316](https://companieshouse.atlassian.net/browse/IDVA5-1316)
[IDVA5-1457](https://companieshouse.atlassian.net/browse/IDVA5-1457)

**Type of change**
 
- [x] Bug fix
- [x]  New feature
- [ ]  Breaking change
- [ ]  Infrastructure change

**Pull request checklist**

- [x]  I have added unit tests for new code that I have added
- [ ]  I have added/updated functional tests where appropriate
- [ ]  The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

**An exhaustive list of peer review checks can be read** [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)

[IDVA5-1316]: https://companieshouse.atlassian.net/browse/IDVA5-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ