### PR TITLE
Fix sonar target in Makefile to run analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint:
 		npm run lint
 
 .PHONY: sonar
-sonar:
+sonar: test
 		npm run sonarqube
 
 .PHONY: test-unit


### PR DESCRIPTION
Updated the `sonar` target in the Makefile to run code coverage checks