### PR TITLE
Adding new field acsp_type to acspData object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.208",
+        "@companieshouse/api-sdk-node": "^2.0.210",
         "@companieshouse/ch-node-utils": "^1.3.5",
         "@companieshouse/node-session-handler": "^5.1.3",
         "@companieshouse/structured-logging-node": "^1.0.8",
@@ -635,9 +635,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.208",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.208.tgz",
-      "integrity": "sha512-U/8Cp3xmTGqyqB8KUCMeOqYPNh0hTa8v9bEmMJzcsMZLdiVcKPsZ0ibHzQUcubu1FGQNWo6MD/jZHOIcwj0jXw==",
+      "version": "2.0.210",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.210.tgz",
+      "integrity": "sha512-g1r0w2/81TuX/8N+UaRlfhV7Js08AKY39WUKfzAXn4runmwUkC8aTBcCPfATEiqMFj5qbjbaCcbwMqZG+gzP3Q==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.208",
+    "@companieshouse/api-sdk-node": "^2.0.210",
     "@companieshouse/ch-node-utils": "^1.3.5",
     "@companieshouse/node-session-handler": "^5.1.3",
     "@companieshouse/structured-logging-node": "^1.0.8",

--- a/src/model/ACSPData.ts
+++ b/src/model/ACSPData.ts
@@ -5,6 +5,7 @@ import { RoleType } from "./RoleType";
 import { SectorOfWork } from "./BusinessSector";
 import { TypeOfBusiness } from "./TypeOfBusiness";
 import { ApplicantDetails } from "./ApplicantDetails";
+import { AcspType } from "./AcspType";
 
 export interface ACSPData {
     id: string;
@@ -20,4 +21,5 @@ export interface ACSPData {
     companyDetails?: Company;
     companyAuthCodeProvided?: boolean;
     applicantDetails?: ApplicantDetails;
+    acspType?: AcspType;
 }

--- a/src/model/AcspType.ts
+++ b/src/model/AcspType.ts
@@ -1,0 +1,5 @@
+export enum AcspType {
+    REGISTER_ACSP = "register-acsp",
+    UPDATE_ACSP = "update-acsp",
+    DELETE_ACSP = "delete-acsp"
+}

--- a/src/services/acspDataService.ts
+++ b/src/services/acspDataService.ts
@@ -4,6 +4,7 @@ import { APPLICATION_ID, RESUME_APPLICATION_ID, SUBMISSION_ID, USER_DATA } from 
 import { deleteAcspApplication, postAcspRegistration, putAcspRegistration } from "./acspRegistrationService";
 import logger from "../utils/logger";
 import { TypeOfBusinessService } from "./typeOfBusinessService";
+import { AcspType } from "../model/AcspType";
 
 export class AcspDataService {
     async saveAcspData (session: Session, acspData: AcspData, selectedOption?: string): Promise<void> {
@@ -18,8 +19,10 @@ export class AcspDataService {
                 });
             }
             if (acspData === undefined) {
+                // hardcoding acspType to register for now
                 acspData = {
-                    typeOfBusiness: selectedOption
+                    typeOfBusiness: selectedOption,
+                    acspType: AcspType.REGISTER_ACSP
                 };
                 // save data to mongo for the first time
                 const resp = await postAcspRegistration(session, session.getExtraData(SUBMISSION_ID)!, acspData) as unknown;

--- a/src/services/acspDataService.ts
+++ b/src/services/acspDataService.ts
@@ -4,7 +4,6 @@ import { APPLICATION_ID, RESUME_APPLICATION_ID, SUBMISSION_ID, USER_DATA } from 
 import { deleteAcspApplication, postAcspRegistration, putAcspRegistration } from "./acspRegistrationService";
 import logger from "../utils/logger";
 import { TypeOfBusinessService } from "./typeOfBusinessService";
-import { AcspType } from "../model/AcspType";
 
 export class AcspDataService {
     async saveAcspData (session: Session, acspData: AcspData, selectedOption?: string): Promise<void> {
@@ -22,7 +21,7 @@ export class AcspDataService {
                 // hardcoding acspType to register for now
                 acspData = {
                     typeOfBusiness: selectedOption,
-                    acspType: AcspType.REGISTER_ACSP
+                    acspType: "REGISTER_ACSP"
                 };
                 // save data to mongo for the first time
                 const resp = await postAcspRegistration(session, session.getExtraData(SUBMISSION_ID)!, acspData) as unknown;

--- a/test/src/services/acspDataService.test.ts
+++ b/test/src/services/acspDataService.test.ts
@@ -23,6 +23,7 @@ const mockPostTransaction = postTransaction as jest.Mock;
 const mockAcspData: AcspData = {
     id: "1234",
     typeOfBusiness: "SOLE_TRADER",
+    acspType: "register-acsp",
     applicantDetails: {
         firstName: "Test",
         lastName: "User"
@@ -55,6 +56,7 @@ describe("AcspDataService tests", () => {
             mockPostTransaction.mockResolvedValueOnce(validTransaction);
             mockPostAcspRegistration.mockResolvedValueOnce(mockPostResponce);
             await service.saveAcspData(session, undefined!, "SOLE_TRADER");
+            await service.saveAcspData(session, mockAcspData, "register-acsp");
             expect(postAcspRegistration).toHaveBeenCalled();
             expect(session.getExtraData(APPLICATION_ID)).toBe("12345");
         });
@@ -64,6 +66,7 @@ describe("AcspDataService tests", () => {
             mockPostTransaction.mockResolvedValueOnce(validTransaction);
             mockPutAcspRegistration.mockResolvedValue({});
             await service.saveAcspData(session, mockAcspData, "SOLE_TRADER");
+            await service.saveAcspData(session, mockAcspData, "register-acsp");
             expect(putAcspRegistration).toHaveBeenCalled();
         });
 


### PR DESCRIPTION
**Short description outlining key changes/additions**

New field acsp_type added to the acspData object being saved to Mongo DB to store values e.g. register-acsp, update-acsp, delete-acsp. Have hardcoded it to enum 'REGISTER_ACSP' for now but this should be changed later when we work on the Update ACSP Details tickets.

Tested locally appearing in DB as:

<img width="431" alt="Screenshot 2024-11-11 at 16 36 26" src="https://github.com/user-attachments/assets/fd9788c5-f5ed-4f77-879a-15c22061655f">

**JIRA Ticket Number**

[IDVA5-1433](https://companieshouse.atlassian.net/browse/IDVA5-1433)

**Type of change**
 
- [ ] Bug fix
- [X]  New feature
- [ ]  Breaking change
- [ ]  Infrastructure change

**Pull request checklist**

- [X]  I have added unit tests for new code that I have added
- [ ]  I have added/updated functional tests where appropriate
- [X]  The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

**An exhaustive list of peer review checks can be read** [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)

[IDVA5-1433]: https://companieshouse.atlassian.net/browse/IDVA5-1433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ