### PR TITLE
fixing ui issue on payment failed screen

### DIFF
--- a/locales/en/payment-failed.json
+++ b/locales/en/payment-failed.json
@@ -7,5 +7,5 @@
     "paymenFailedBulletPoint4": "there was an error (for example, a technical error)",
     "paymentFailedSavedToFilings": "Your application has been saved in Your Filings. To submit the application, you will need to",
     "paymentFailedYourFilingsLink": "find the application in Your Filings",
-    "paymentFailedCompletePayment": "and complete payment"
+    "paymentFailedCompletePayment": "and complete payment."
 }

--- a/src/views/common/payment-failed/payment-failed.njk
+++ b/src/views/common/payment-failed/payment-failed.njk
@@ -14,7 +14,7 @@
     </ul>
     <p>
         {{ i18n.paymentFailedSavedToFilings }}
-        <a id="your-filings-link-id" href={{yourFilingsUrl}}>{{ i18n.paymentFailedYourFilingsLink }}</a>.
+        <a id="your-filings-link-id" href={{yourFilingsUrl}}>{{ i18n.paymentFailedYourFilingsLink }}</a>
         {{ i18n.paymentFailedCompletePayment }}
     </p>
 


### PR DESCRIPTION
Removing additional full stop after web link and adding full stop to end of sentence on payment failed screen