### PR TITLE
Adding update acsp details base url to authentication middleware

### DIFF
--- a/src/middleware/authentication_middleware.ts
+++ b/src/middleware/authentication_middleware.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { AuthOptions, authMiddleware, acspProfileCreateAuthMiddleware } from "@companieshouse/web-security-node";
 import { isActiveFeature } from "../utils/feature.flag";
 import { CHS_URL, FEATURE_FLAG_VERIFY_SOLE_TRADER_ONLY } from "../utils/properties";
-import { BASE_URL, CHECK_SAVED_APPLICATION } from "../types/pageURL";
+import { BASE_URL, CHECK_SAVED_APPLICATION, UPDATE_ACSP_DETAILS_BASE_URL } from "../types/pageURL";
 import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
 import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
 import { ISignInInfo } from "@companieshouse/node-session-handler/lib/session/model/SessionInterfaces";
@@ -15,9 +15,15 @@ export const authenticationMiddleware = (req: Request, res: Response, next: Next
     let authMiddlewareConfig: AuthOptions;
 
     if (!signedIn) {
+        let returnUrl = "";
+        if (req.originalUrl === UPDATE_ACSP_DETAILS_BASE_URL) {
+            returnUrl = req.originalUrl;
+        } else {
+            returnUrl = BASE_URL + CHECK_SAVED_APPLICATION;
+        };
         authMiddlewareConfig = {
             chsWebUrl: CHS_URL,
-            returnUrl: BASE_URL + CHECK_SAVED_APPLICATION
+            returnUrl: returnUrl
         };
     } else {
         authMiddlewareConfig = {

--- a/test/src/middleware/authentication_middleware.test.ts
+++ b/test/src/middleware/authentication_middleware.test.ts
@@ -4,7 +4,7 @@ process.env.FEATURE_FLAG_VERIFY_SOLE_TRADER_ONLY = "false";
 import { acspProfileCreateAuthMiddleware, authMiddleware, AuthOptions } from "@companieshouse/web-security-node";
 import { Request, Response } from "express";
 import { authenticationMiddleware } from "../../../src/middleware/authentication_middleware";
-import { BASE_URL, CHECK_SAVED_APPLICATION, LIMITED_WHAT_IS_YOUR_ROLE } from "../../../src/types/pageURL";
+import { BASE_URL, CHECK_SAVED_APPLICATION, LIMITED_WHAT_IS_YOUR_ROLE, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../src/types/pageURL";
 import { getSessionRequestWithPermission } from "../../mocks/session.mock";
 import { USER_DATA, COMPANY_NUMBER } from "../../../src/common/__utils/constants";
 import { Session } from "@companieshouse/node-session-handler";
@@ -29,6 +29,11 @@ const expectedAuthMiddlewareConfig: AuthOptions = {
     returnUrl: BASE_URL + CHECK_SAVED_APPLICATION
 };
 
+const expectedAuthMiddlewareConfigWithUpdateAcspDetailsURL: AuthOptions = {
+    chsWebUrl: "http://chs.local",
+    returnUrl: UPDATE_ACSP_DETAILS_BASE_URL
+};
+
 const expectedAuthMiddlewareConfigWithWhatisRoleURL: AuthOptions = {
     chsWebUrl: "http://chs.local",
     returnUrl: BASE_URL + LIMITED_WHAT_IS_YOUR_ROLE
@@ -41,7 +46,18 @@ describe("authentication middleware tests", () => {
         expect(mockAuthReturnedFunctionAcspProfileCreateAuthMiddleware).toHaveBeenCalledWith(req, res, next);
     });
 
-    it("should call CH authentication library with Limited URL when session is available ", () => {
+    it("should call CH authentication library with Update ACSP Details URL when session is available", () => {
+        let request = {} as Request;
+        const Url = UPDATE_ACSP_DETAILS_BASE_URL;
+        request = {
+            session: getSessionRequestWithExtraData(true),
+            originalUrl: Url
+        } as unknown as Request;
+        authenticationMiddleware(request, res, next);
+        expect(mockAcspProfileCreateAuthMiddleware).toHaveBeenCalledWith(expectedAuthMiddlewareConfigWithUpdateAcspDetailsURL);
+    });
+
+    it("should call CH authentication library with Limited URL when session is available", () => {
         let request = {} as Request;
         const Url = BASE_URL + LIMITED_WHAT_IS_YOUR_ROLE;
         request = {


### PR DESCRIPTION
It is required that the user must be signed in before they can access the Update ACSP Details service.

It was noted upon testing, that when navigating to the base url of the update service and the user had not signed in, the user is presented with the sign in screens for one login. 
Upon logging in, the user was then re-directed to the 'What is the business type you are registering?' screen within the registration service, rather than the Update ACSP Details start page.

Updated authentication middleware to correctly route the user to the 'Update ACSP Details' service after signing in, when using the base URL of the new service.