### PR TITLE
Removing the need for companyAuthCodeProvided flag.

### DIFF
--- a/src/middleware/company_authentication_middleware.ts
+++ b/src/middleware/company_authentication_middleware.ts
@@ -2,23 +2,16 @@ import { NextFunction, Request, Response } from "express";
 import { authMiddleware, AuthOptions } from "@companieshouse/web-security-node";
 import { CHS_URL } from "../utils/properties";
 import { Session } from "@companieshouse/node-session-handler";
-import { COMPANY_NUMBER, USER_DATA } from "../common/__utils/constants";
-import { AcspData } from "@companieshouse/api-sdk-node/dist/services/acsp";
+import { COMPANY_NUMBER } from "../common/__utils/constants";
 
 export const companyAuthenticationMiddleware = async (req: Request, res: Response, next: NextFunction) => {
     const session: Session = req.session as any as Session;
     const companyNumber: string | undefined = session?.getExtraData(COMPANY_NUMBER);
-    const acspData: AcspData = session?.getExtraData(USER_DATA)!;
-    const companyAuthCodeProvided = acspData.companyAuthCodeProvided;
+    const authMiddlewareConfig: AuthOptions = {
+        chsWebUrl: CHS_URL,
+        returnUrl: req.originalUrl,
+        companyNumber: companyNumber
+    };
+    return authMiddleware(authMiddlewareConfig)(req, res, next);
 
-    if (companyAuthCodeProvided !== true) {
-        const authMiddlewareConfig: AuthOptions = {
-            chsWebUrl: CHS_URL,
-            returnUrl: req.originalUrl,
-            companyNumber: companyNumber
-        };
-        return authMiddleware(authMiddlewareConfig)(req, res, next);
-    } else {
-        next();
-    }
 };

--- a/test/src/middleware/company_authentication_middleware.test.ts
+++ b/test/src/middleware/company_authentication_middleware.test.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { companyAuthenticationMiddleware } from "../../../src/middleware/company_authentication_middleware";
 import { getSessionRequestWithPermission } from "../../mocks/session.mock";
-import { USER_DATA, COMPANY_NUMBER } from "../../../src/common/__utils/constants";
+import { COMPANY_NUMBER } from "../../../src/common/__utils/constants";
 import { Session } from "@companieshouse/node-session-handler";
 import { BASE_URL, LIMITED_WHAT_IS_YOUR_ROLE } from "../../../src/types/pageURL";
 
@@ -25,31 +25,18 @@ describe("company authentication middleware tests", () => {
         jest.clearAllMocks();
     });
 
-    it("should ask for auth code when companyAuthCodeProvided is false ", () => {
+    it("should ask for auth code ", () => {
         req = {
-            session: getSessionRequestWithExtraData(false),
+            session: getSessionRequestWithExtraData(),
             originalUrl: Url
         } as unknown as Request;
         companyAuthenticationMiddleware(req, mockResponse, mockNext);
         expect(mockAuthMiddleware).toHaveBeenCalled();
     });
-
-    it("should not ask for auth code when companyAuthCodeProvided is true ", () => {
-        req = {
-            session: getSessionRequestWithExtraData(true),
-            originalUrl: Url
-        } as unknown as Request;
-        companyAuthenticationMiddleware(req, mockResponse, mockNext);
-        expect(mockAuthMiddleware).not.toHaveBeenCalled();
-    });
 });
 
-function getSessionRequestWithExtraData (value: Boolean): Session {
+function getSessionRequestWithExtraData (): Session {
     const session = getSessionRequestWithPermission();
-
-    session.setExtraData(USER_DATA, {
-        companyAuthCodeProvided: value
-    });
     session.setExtraData(COMPANY_NUMBER, "NI038379");
     return session;
 }


### PR DESCRIPTION
Removing the need for companyAuthCodeProvided flag. We dont need this flag checking as this work is automatically done by Auth Middleware