### PR TITLE
Updating routing for update acsp details start page

### DIFF
--- a/src/middleware/authentication_middleware.ts
+++ b/src/middleware/authentication_middleware.ts
@@ -1,8 +1,8 @@
 import { NextFunction, Request, Response } from "express";
 import { AuthOptions, authMiddleware, acspProfileCreateAuthMiddleware } from "@companieshouse/web-security-node";
 import { isActiveFeature } from "../utils/feature.flag";
-import { CHS_URL, FEATURE_FLAG_VERIFY_SOLE_TRADER_ONLY } from "../utils/properties";
-import { BASE_URL, CHECK_SAVED_APPLICATION } from "../types/pageURL";
+import { CHS_URL, FEATURE_FLAG_ENABLE_UPDATE_ACSP_DETAILS, FEATURE_FLAG_VERIFY_SOLE_TRADER_ONLY } from "../utils/properties";
+import { BASE_URL, CHECK_SAVED_APPLICATION, UPDATE_ACSP_DETAILS_BASE_URL } from "../types/pageURL";
 import { SessionKey } from "@companieshouse/node-session-handler/lib/session/keys/SessionKey";
 import { SignInInfoKeys } from "@companieshouse/node-session-handler/lib/session/keys/SignInInfoKeys";
 import { ISignInInfo } from "@companieshouse/node-session-handler/lib/session/model/SessionInterfaces";
@@ -13,11 +13,18 @@ export const authenticationMiddleware = (req: Request, res: Response, next: Next
     const signedIn: boolean = signInInfo[SignInInfoKeys.SignedIn] === 1;
 
     let authMiddlewareConfig: AuthOptions;
+    const updateAcspDetailsBaseURL = new RegExp(`^${UPDATE_ACSP_DETAILS_BASE_URL}(/.*)?$`);
 
     if (!signedIn) {
+        let returnUrl = "";
+        if (FEATURE_FLAG_ENABLE_UPDATE_ACSP_DETAILS && updateAcspDetailsBaseURL.test((req.originalUrl))) {
+            returnUrl = req.originalUrl;
+        } else {
+            returnUrl = BASE_URL + CHECK_SAVED_APPLICATION;
+        }
         authMiddlewareConfig = {
             chsWebUrl: CHS_URL,
-            returnUrl: BASE_URL + CHECK_SAVED_APPLICATION
+            returnUrl: returnUrl
         };
     } else {
         authMiddlewareConfig = {

--- a/test/src/middleware/authentication_middleware.test.ts
+++ b/test/src/middleware/authentication_middleware.test.ts
@@ -23,6 +23,7 @@ mockAcspProfileCreateAuthMiddleware.mockReturnValue(mockAuthReturnedFunctionAcsp
 const req: Request = {} as Request;
 const res: Response = {} as Response;
 const next = jest.fn();
+const originalEnv = process.env;
 
 const expectedAuthMiddlewareConfig: AuthOptions = {
     chsWebUrl: "http://chs.local",
@@ -40,15 +41,25 @@ const expectedAuthMiddlewareConfigWithWhatisRoleURL: AuthOptions = {
 };
 
 describe("authentication middleware tests", () => {
+    beforeEach(() => {
+        jest.resetModules(); // Clears the module cache
+        process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
     it("should call CH authentication library", async () => {
         authenticationMiddleware(req, res, next);
         expect(mockAcspProfileCreateAuthMiddleware).toHaveBeenCalledWith(expectedAuthMiddlewareConfig);
         expect(mockAuthReturnedFunctionAcspProfileCreateAuthMiddleware).toHaveBeenCalledWith(req, res, next);
     });
 
-    it("should call CH authentication library with Update ACSP Details URL when session is available", () => {
+    it("should call CH authentication library with Update ACSP Details URL when session is available and feature flag is enabled", () => {
         let request = {} as Request;
         const Url = UPDATE_ACSP_DETAILS_BASE_URL;
+        process.env.FEATURE_FLAG_ENABLE_UPDATE_ACSP_DETAILS = "true";
         request = {
             session: getSessionRequestWithExtraData(true),
             originalUrl: Url

--- a/test/src/middleware/authentication_middleware.test.ts
+++ b/test/src/middleware/authentication_middleware.test.ts
@@ -41,31 +41,25 @@ const expectedAuthMiddlewareConfigWithWhatisRoleURL: AuthOptions = {
 };
 
 describe("authentication middleware tests", () => {
+    let request = {} as Request;
+
     beforeEach(() => {
-        jest.resetModules(); // Clears the module cache
-        process.env = { ...originalEnv };
+        jest.clearAllMocks();
     });
 
-    afterEach(() => {
-        process.env = originalEnv;
+    it("should call CH authentication library with Update ACSP Details URL when session is available and feature flag is enabled", () => {
+        const Url = UPDATE_ACSP_DETAILS_BASE_URL;
+        request = {
+            originalUrl: Url
+        } as unknown as Request;
+        authenticationMiddleware(request, res, next);
+        expect(mockAcspProfileCreateAuthMiddleware).toHaveBeenCalledWith(expectedAuthMiddlewareConfigWithUpdateAcspDetailsURL);
     });
 
     it("should call CH authentication library", async () => {
         authenticationMiddleware(req, res, next);
         expect(mockAcspProfileCreateAuthMiddleware).toHaveBeenCalledWith(expectedAuthMiddlewareConfig);
         expect(mockAuthReturnedFunctionAcspProfileCreateAuthMiddleware).toHaveBeenCalledWith(req, res, next);
-    });
-
-    it("should call CH authentication library with Update ACSP Details URL when session is available and feature flag is enabled", () => {
-        let request = {} as Request;
-        const Url = UPDATE_ACSP_DETAILS_BASE_URL;
-        process.env.FEATURE_FLAG_ENABLE_UPDATE_ACSP_DETAILS = "true";
-        request = {
-            session: getSessionRequestWithExtraData(true),
-            originalUrl: Url
-        } as unknown as Request;
-        authenticationMiddleware(request, res, next);
-        expect(mockAcspProfileCreateAuthMiddleware).toHaveBeenCalledWith(expectedAuthMiddlewareConfigWithUpdateAcspDetailsURL);
     });
 
     it("should call CH authentication library with Limited URL when session is available ", () => {

--- a/test/src/middleware/authentication_middleware.test.ts
+++ b/test/src/middleware/authentication_middleware.test.ts
@@ -4,7 +4,7 @@ process.env.FEATURE_FLAG_VERIFY_SOLE_TRADER_ONLY = "false";
 import { acspProfileCreateAuthMiddleware, authMiddleware, AuthOptions } from "@companieshouse/web-security-node";
 import { Request, Response } from "express";
 import { authenticationMiddleware } from "../../../src/middleware/authentication_middleware";
-import { BASE_URL, CHECK_SAVED_APPLICATION, LIMITED_WHAT_IS_YOUR_ROLE } from "../../../src/types/pageURL";
+import { BASE_URL, CHECK_SAVED_APPLICATION, LIMITED_WHAT_IS_YOUR_ROLE, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../src/types/pageURL";
 import { getSessionRequestWithPermission } from "../../mocks/session.mock";
 import { USER_DATA, COMPANY_NUMBER } from "../../../src/common/__utils/constants";
 import { Session } from "@companieshouse/node-session-handler";
@@ -29,6 +29,11 @@ const expectedAuthMiddlewareConfig: AuthOptions = {
     returnUrl: BASE_URL + CHECK_SAVED_APPLICATION
 };
 
+const expectedAuthMiddlewareConfigWithUpdateAcspDetailsURL: AuthOptions = {
+    chsWebUrl: "http://chs.local",
+    returnUrl: UPDATE_ACSP_DETAILS_BASE_URL
+};
+
 const expectedAuthMiddlewareConfigWithWhatisRoleURL: AuthOptions = {
     chsWebUrl: "http://chs.local",
     returnUrl: BASE_URL + LIMITED_WHAT_IS_YOUR_ROLE
@@ -39,6 +44,17 @@ describe("authentication middleware tests", () => {
         authenticationMiddleware(req, res, next);
         expect(mockAcspProfileCreateAuthMiddleware).toHaveBeenCalledWith(expectedAuthMiddlewareConfig);
         expect(mockAuthReturnedFunctionAcspProfileCreateAuthMiddleware).toHaveBeenCalledWith(req, res, next);
+    });
+
+    it("should call CH authentication library with Update ACSP Details URL when session is available", () => {
+        let request = {} as Request;
+        const Url = UPDATE_ACSP_DETAILS_BASE_URL;
+        request = {
+            session: getSessionRequestWithExtraData(true),
+            originalUrl: Url
+        } as unknown as Request;
+        authenticationMiddleware(request, res, next);
+        expect(mockAcspProfileCreateAuthMiddleware).toHaveBeenCalledWith(expectedAuthMiddlewareConfigWithUpdateAcspDetailsURL);
     });
 
     it("should call CH authentication library with Limited URL when session is available ", () => {


### PR DESCRIPTION
Updating routing for the Update ACSP Details start page through using a regular expression to check the endpoint matches the update acsp endpoint, whilst also checking if the feature flag has been enabled for the service.
If both checks result to true, then the user will be routed directly to the Update ACSP Details start page when directly navigating to the endpoint (after log in).

Previously when a user navigated directly to the endpoint of the Update ACSP Service, they would be asked to login, upon logging in, they would then be routed to the 'Do you want to start a new application' page on the registration service rather than the Update ACSP start page. This change should fix this behaviour.