### PR TITLE
Removing inset text correspondence address

### DIFF
--- a/locales/cy/common-address-manual.json
+++ b/locales/cy/common-address-manual.json
@@ -10,8 +10,6 @@
     "addressCountry": "Gwlad",
     "addressPostcode": "Cod post",
     "correspondenceAddressPostcode": "Cod post neu ZIP",
-    "infoShowOnPublic": "Pa wybodaeth byddwn yn dangos ar y rhestr gyhoeddus o asiantau awdurdodedig",
-    "correspondenceLocationInfo": "Byddwn yn dangos tref neu ddinas y cyfeiriad gohebiaeth.",
     "england": "Lloegr",
     "scotland": "Yr Alban",
     "northernIreland": "Gogledd Iwerddon",

--- a/locales/en/common-address-manual.json
+++ b/locales/en/common-address-manual.json
@@ -10,8 +10,6 @@
     "addressCountry": "Country",
     "addressPostcode": "Postcode",
     "correspondenceAddressPostcode": "Postcode or ZIP",
-    "infoShowOnPublic": "What information we'll show on the public list of authorised agents",
-    "correspondenceLocationInfo": "We'll show the town or city of the correspondence address.",
     "england": "England",
     "scotland": "Scotland",
     "northernIreland": "Northern Ireland",

--- a/src/views/common/correspondence-address-manual/capture-correspondence-address-manual.njk
+++ b/src/views/common/correspondence-address-manual/capture-correspondence-address-manual.njk
@@ -106,16 +106,9 @@
         } if errors.addressPostcode
     }) }}
     </div>
-    
-    {% if typeOfBusiness === "LC" or typeOfBusiness === "LP" or typeOfBusiness === "LLP" %}
-        <div class="govuk-inset-text">
-            <h2 class="govuk-heading-m">{{ i18n.infoShowOnPublic }}</h2>
-            <p>{{ i18n.correspondenceLocationInfo }}</p>
-        </div>
-    {% endif %}
 
     <button class="govuk-button" id="save-continue-button">{{ i18n.SaveAndContinue }}</button>
-  </form>
+</form> 
   <script>
     trackEventBasedOnPageTitle("save-continue-button", "{{title}}", "click-button", "SAVE AND CONTINUE");
   </script>


### PR DESCRIPTION
Removing inset text on Correspondence Address page.

Ticket:
[IDVA5-1595](https://companieshouse.atlassian.net/browse/IDVA5-1595)

[IDVA5-1595]: https://companieshouse.atlassian.net/browse/IDVA5-1595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ