### PR TITLE
Updating jquery script to the latest version

### DIFF
--- a/src/views/partials/__footer.njk
+++ b/src/views/partials/__footer.njk
@@ -34,6 +34,6 @@
 <script src="{{ cdnHost }}/javascripts/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.js"></script>
 <script src="{{ cdnHost }}/javascripts/app/cookie-consent/cookie-consent-1.0.0.js"></script>
 <script src="{{ cdnHost }}/javascripts/app/cookie-consent/matomo-only-cookie-consent.js"></script>
-<script src="{{ cdnHost }}/javascripts/vendor/jquery-3.3.1.min.js"></script>
+<script src="{{ cdnHost }}/javascripts/vendor/jquery-3.5.1.min.js"></script>
 <script src="{{ cdnHost }}/javascripts/lib/navbar.js"></script>
 <script nonce={{ nonce | dump | safe }}>window.GOVUKFrontend.initAll()</script>


### PR DESCRIPTION
Updating jquery script to the latest version to remove 'Vulnerable JS Library' in ZAP test