### PR TITLE
Fixing Correspondence address country input not showing on back

### DIFF
--- a/src/controllers/features/sole-trader/whereDoYouLiveController.ts
+++ b/src/controllers/features/sole-trader/whereDoYouLiveController.ts
@@ -26,7 +26,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const acspData = await getAcspRegistration(session, session.getExtraData(SUBMISSION_ID)!, res.locals.applicationId);
         saveDataInSession(req, USER_DATA, acspData);
 
-        const { payload, countryInput } = new WhereDoYouLivBodyService().getCountryPayload(acspData);
+        const payload = new WhereDoYouLivBodyService().getCountryPayload(acspData);
         res.render(config.SOLE_TRADER_WHERE_DO_YOU_LIVE, {
             ...getLocaleInfo(locales, lang),
             previousPage,
@@ -34,7 +34,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             countryList: countryList,
             firstName: acspData?.applicantDetails?.firstName,
             lastName: acspData?.applicantDetails?.lastName,
-            countryInput,
             payload
         });
     } catch (err) {

--- a/src/controllers/features/update-acsp/whereDoYouLiveController.ts
+++ b/src/controllers/features/update-acsp/whereDoYouLiveController.ts
@@ -21,7 +21,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     // This ensures functionality until the page is ready, at which point we can handle null separately.
     const acspData: AcspData = session.getExtraData(USER_DATA) ? session.getExtraData(USER_DATA)! : {};
 
-    const { payload, countryInput } = new WhereDoYouLivBodyService().getCountryPayload(acspData);
+    const payload = new WhereDoYouLivBodyService().getCountryPayload(acspData);
     const reqType = REQ_TYPE_UPDATE_ACSP;
     res.render(config.SOLE_TRADER_WHERE_DO_YOU_LIVE, {
         ...getLocaleInfo(locales, lang),
@@ -30,7 +30,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         countryList: countryList,
         firstName: acspData?.applicantDetails?.firstName,
         lastName: acspData?.applicantDetails?.lastName,
-        countryInput,
         payload,
         reqType
     });

--- a/src/services/where-do-you-live/whereDoYouLive.ts
+++ b/src/services/where-do-you-live/whereDoYouLive.ts
@@ -1,9 +1,12 @@
 import { AcspData } from "@companieshouse/api-sdk-node/dist/services/acsp";
 
 export class WhereDoYouLivBodyService {
-    public getCountryPayload (ascpData: AcspData): { payload: any, countryInput?: string } {
+    public getCountryPayload (ascpData: AcspData) {
         let payload = {};
-        let countryInput: string | undefined;
+
+        if (!ascpData.applicantDetails?.countryOfResidence) {
+            return payload;
+        }
 
         switch (ascpData.applicantDetails?.countryOfResidence) {
         case "England":
@@ -13,13 +16,11 @@ export class WhereDoYouLivBodyService {
             payload = { whereDoYouLiveRadio: ascpData?.applicantDetails?.countryOfResidence };
             break;
         default:
-            if (ascpData.applicantDetails?.countryOfResidence) {
-                payload = { whereDoYouLiveRadio: "countryOutsideUK" };
-                countryInput = ascpData.applicantDetails?.countryOfResidence;
-            }
-            break;
-
-        }
-        return { payload, countryInput };
+            payload = {
+                whereDoYouLiveRadio: "countryOutsideUK",
+                countryInput: ascpData.applicantDetails?.countryOfResidence
+            };
+        };
+        return payload;
     }
 }

--- a/src/services/where-do-you-live/whereDoYouLive.ts
+++ b/src/services/where-do-you-live/whereDoYouLive.ts
@@ -8,19 +8,19 @@ export class WhereDoYouLivBodyService {
             return payload;
         }
 
-        switch (ascpData.applicantDetails?.countryOfResidence) {
+        switch (ascpData.applicantDetails.countryOfResidence) {
         case "England":
         case "Scotland":
         case "Wales":
         case "Northern Ireland":
-            payload = { whereDoYouLiveRadio: ascpData?.applicantDetails?.countryOfResidence };
+            payload = { whereDoYouLiveRadio: ascpData.applicantDetails?.countryOfResidence };
             break;
         default:
             payload = {
                 whereDoYouLiveRadio: "countryOutsideUK",
-                countryInput: ascpData.applicantDetails?.countryOfResidence
+                countryInput: ascpData.applicantDetails.countryOfResidence
             };
-        };
+        }
         return payload;
     }
 }

--- a/src/views/common/correspondence-address-manual/capture-correspondence-address-manual.njk
+++ b/src/views/common/correspondence-address-manual/capture-correspondence-address-manual.njk
@@ -88,7 +88,6 @@
         {% set dropdownDefaultText = i18n.whereDoYouLiveDefaultDropdownText %}
         {% if payload.countryInput | length %}
             {% set dropdownValue = payload.countryInput %}
-            {% set countryInput = payload.countryInput %}
         {% endif %}
         <p class="govuk-hint" id="typeahead-hint">{{ i18n.whereDoYouLiveHint }}</p>
         <div id="my-autocomplete-container" class="autocomplete-wrapper govuk-!-width-two-thirds"></div>

--- a/src/views/partials/country-typeahead-input.njk
+++ b/src/views/partials/country-typeahead-input.njk
@@ -2,7 +2,7 @@
 <script type="text/javascript" nonce={{ nonce | dump | safe }}>
   const countryList = "{{countryList}}"
   const error = "{{errors.countryInput.text}}"
-  const countryDefaultValue = "{{countryInput}}"
+  const countryDefaultValue = "{{payload.countryInput}}"
 
   var autocompleteConfig = {
     element: document.querySelector('#my-autocomplete-container'),

--- a/test/src/services/where-do-you-live/whereDoYouLive.test.ts
+++ b/test/src/services/where-do-you-live/whereDoYouLive.test.ts
@@ -2,8 +2,14 @@ import { AcspData } from "@companieshouse/api-sdk-node/dist/services/acsp/types"
 import { WhereDoYouLivBodyService } from "../../../../src/services/where-do-you-live/whereDoYouLive";
 
 describe("WhereDoYouLiveBodyService", () => {
+
+    let whereDoYouLiveBodyService: WhereDoYouLivBodyService;
+
+    beforeEach(() => {
+        whereDoYouLiveBodyService = new WhereDoYouLivBodyService();
+    });
+
     it("should return payload for England", () => {
-        const whereDoYouLiveBodyService = new WhereDoYouLivBodyService();
         const acspData: AcspData = {
             id: "abc",
             typeOfBusiness: "LIMITED",
@@ -12,13 +18,11 @@ describe("WhereDoYouLiveBodyService", () => {
             }
         };
 
-        const { payload, countryInput } = whereDoYouLiveBodyService.getCountryPayload(acspData);
+        const payload = whereDoYouLiveBodyService.getCountryPayload(acspData);
         expect(payload).toEqual({ whereDoYouLiveRadio: "England" });
-        expect(countryInput).toBeUndefined();
     });
 
     it("should return payload for Scotland", () => {
-        const whereDoYouLiveBodyService = new WhereDoYouLivBodyService();
         const acspData: AcspData = {
             id: "abc",
             typeOfBusiness: "LIMITED",
@@ -27,26 +31,23 @@ describe("WhereDoYouLiveBodyService", () => {
             }
         };
 
-        const { payload, countryInput } = whereDoYouLiveBodyService.getCountryPayload(acspData);
+        const payload = whereDoYouLiveBodyService.getCountryPayload(acspData);
         expect(payload).toEqual({ whereDoYouLiveRadio: "Scotland" });
-        expect(countryInput).toBeUndefined();
+
     });
 
     it("should return payload with countryOfResidence when applicantDetails is defined", () => {
-        const whereDoYouLiveBodyService = new WhereDoYouLivBodyService();
         const acspData: AcspData = {
             id: "abc",
             typeOfBusiness: "LIMITED"
         };
 
-        const { payload, countryInput } = whereDoYouLiveBodyService.getCountryPayload(acspData);
+        const payload = whereDoYouLiveBodyService.getCountryPayload(acspData);
 
         expect(payload).toEqual({});
-        expect(countryInput).toBeUndefined();
     });
 
     it("should return payload for Wales", () => {
-        const whereDoYouLiveBodyService = new WhereDoYouLivBodyService();
         const acspData: AcspData = {
             id: "abc",
             typeOfBusiness: "LIMITED",
@@ -55,13 +56,11 @@ describe("WhereDoYouLiveBodyService", () => {
             }
         };
 
-        const { payload, countryInput } = whereDoYouLiveBodyService.getCountryPayload(acspData);
+        const payload = whereDoYouLiveBodyService.getCountryPayload(acspData);
         expect(payload).toEqual({ whereDoYouLiveRadio: "Wales" });
-        expect(countryInput).toBeUndefined();
     });
 
     it("should return payload for Northern Ireland", () => {
-        const whereDoYouLiveBodyService = new WhereDoYouLivBodyService();
         const acspData: AcspData = {
             id: "abc",
             typeOfBusiness: "LIMITED",
@@ -70,13 +69,11 @@ describe("WhereDoYouLiveBodyService", () => {
             }
         };
 
-        const { payload, countryInput } = whereDoYouLiveBodyService.getCountryPayload(acspData);
+        const payload = whereDoYouLiveBodyService.getCountryPayload(acspData);
         expect(payload).toEqual({ whereDoYouLiveRadio: "Northern Ireland" });
-        expect(countryInput).toBeUndefined();
     });
 
     it("should return payload and countryInput for country outside UK", () => {
-        const whereDoYouLiveBodyService = new WhereDoYouLivBodyService();
         const acspData: AcspData = {
             id: "abc",
             typeOfBusiness: "LIMITED",
@@ -85,10 +82,11 @@ describe("WhereDoYouLiveBodyService", () => {
             }
         };
 
-        const { payload, countryInput } =
-      whereDoYouLiveBodyService.getCountryPayload(acspData);
-        expect(payload).toEqual({ whereDoYouLiveRadio: "countryOutsideUK" });
-        expect(countryInput).toEqual("France");
+        const payload = whereDoYouLiveBodyService.getCountryPayload(acspData);
+        expect(payload).toEqual({
+            whereDoYouLiveRadio: "countryOutsideUK",
+            countryInput: "France"
+        });
     });
 
     it("should return empty payload if countryOfResidence is not valid", () => {
@@ -100,9 +98,7 @@ describe("WhereDoYouLiveBodyService", () => {
                 countryOfResidence: undefined
             }
         };
-
-        const { payload, countryInput } = whereDoYouLiveBodyService.getCountryPayload(acspData);
+        const payload = whereDoYouLiveBodyService.getCountryPayload(acspData);
         expect(payload).toEqual({});
-        expect(countryInput).toBeUndefined();
     });
 });


### PR DESCRIPTION
Updating where do you live service to return a single payload object.
Updating the country-typeahead-input to get default value from payload like other inputs