### PR TITLE
Add lang to payment return uri, remove lang select on confirmation view

### DIFF
--- a/src/controllers/features/common/checkYourAnswers.ts
+++ b/src/controllers/features/common/checkYourAnswers.ts
@@ -57,7 +57,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         if (!paymentUrl) {
             return res.redirect(addLangToUrl(BASE_URL + CONFIRMATION, lang));
         } else {
-            const paymentResponse: ApiResponse<Payment> = await startPaymentsSession(session, paymentUrl,
+            const paymentResponse: ApiResponse<Payment> = await startPaymentsSession(req, session, paymentUrl,
                 transactionId);
 
             if (!paymentResponse.resource) {

--- a/src/controllers/features/common/paymentCallbackController.ts
+++ b/src/controllers/features/common/paymentCallbackController.ts
@@ -21,6 +21,8 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
 
     if (paymentStatus === "paid") {
         logger.debug("Transaction id: " + transactionId + " - Payment status: " + paymentStatus + " - redirecting to the confirmation page");
+        console.log(req.query.lang);
+        console.log(lang);
         return res.redirect(addLangToUrl(BASE_URL + CONFIRMATION, lang));
     } else {
         logger.debug("Transaction id: " + transactionId + " - Payment status: " + paymentStatus + " - redirecting to the check your answers page");

--- a/src/controllers/features/common/paymentCallbackController.ts
+++ b/src/controllers/features/common/paymentCallbackController.ts
@@ -21,8 +21,6 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
 
     if (paymentStatus === "paid") {
         logger.debug("Transaction id: " + transactionId + " - Payment status: " + paymentStatus + " - redirecting to the confirmation page");
-        console.log(req.query.lang);
-        console.log(lang);
         return res.redirect(addLangToUrl(BASE_URL + CONFIRMATION, lang));
     } else {
         logger.debug("Transaction id: " + transactionId + " - Payment status: " + paymentStatus + " - redirecting to the check your answers page");

--- a/src/controllers/features/common/resumeJourneyController.ts
+++ b/src/controllers/features/common/resumeJourneyController.ts
@@ -30,7 +30,7 @@ export const get = async (req: Request, res: Response) => {
 
         if (transaction.status === transactionStatuses.CLOSED_PENDING_PAYMENT) {
             const paymentUrl = PAYMENTS_API_URL + PAYMENTS;
-            const paymentResponse: ApiResponse<Payment> = await startPaymentsSession(session, paymentUrl,
+            const paymentResponse: ApiResponse<Payment> = await startPaymentsSession(req, session, paymentUrl,
                 transactionId);
 
             if (!paymentResponse.resource) {

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -3,18 +3,21 @@ import { CreatePaymentRequest, Payment } from "@companieshouse/api-sdk-node/dist
 import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 import { Session } from "@companieshouse/node-session-handler";
 import logger, { createAndLogError } from "../utils/logger";
+import { Request } from "express";
 import { createPaymentApiClient } from "./apiService";
 import { API_URL, CHS_URL } from "../utils/properties";
 import { v4 as uuidv4 } from "uuid";
 import { BASE_URL, PAYMENT_CALLBACK_URL } from "../types/pageURL";
 import { PAYEMNT_REFERENCE } from "../common/__utils/constants";
+import { addLangToUrl, selectLang } from "../utils/localise";
 
-export const startPaymentsSession = async (session: Session, paymentSessionUrl: string,
+export const startPaymentsSession = async (req: Request, session: Session, paymentSessionUrl: string,
     transactionId: string): Promise<ApiResponse<Payment>> => {
     logger.debug("Starting payment session for transaction: " + transactionId);
     const apiClient: ApiClient = createPaymentApiClient(session, paymentSessionUrl);
     const reference: string = PAYEMNT_REFERENCE + transactionId;
-    const redirectUri: string = CHS_URL + BASE_URL + PAYMENT_CALLBACK_URL;
+    const lang = selectLang(req.query.lang);
+    const redirectUri: string = addLangToUrl(CHS_URL + BASE_URL + PAYMENT_CALLBACK_URL, lang);
     const paymentResourceUri: string = `/transactions/${transactionId}/payment`;
     const resourceWithHost = API_URL + paymentResourceUri;
 

--- a/src/utils/localise.ts
+++ b/src/utils/localise.ts
@@ -3,8 +3,10 @@ import { LOCALES_ENABLED, LOCALES_PATH } from "./properties";
 
 export const selectLang = (lang: any): string => {
     switch (lang) {
-    case "cy": return "cy";
+    case "cy":
+    case "cy?lang=cy": return "cy";
     case "en":
+    case "en?lang=en": return "en";
     default: return "en";
     }
 };

--- a/src/views/common/application-confirmation/application-confirmation.njk
+++ b/src/views/common/application-confirmation/application-confirmation.njk
@@ -1,6 +1,9 @@
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% extends "layouts/default.njk" %}
+{% block localesBanner %}
+  {# Remove language select #}
+{% endblock %}
 {% block backLink %}
   {# Remove back button on this page by replacing it with nothing #}
 {% endblock %}

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -21,7 +21,9 @@
       {% if userEmail %}
         {% include "partials/nav/top.njk" %}
       {% endif %}
-        {% include "locales-banner.njk" %}
+        {% block localesBanner %}
+          {% include "locales-banner.njk" %}
+        {% endblock %}
         {% block backLink %}
           <a href="{{ previousPage }}" class="govuk-back-link">{{i18n.Back}}</a>
         {% endblock %}

--- a/test/mocks/request.mock.ts
+++ b/test/mocks/request.mock.ts
@@ -10,5 +10,8 @@ export const mockRequest = () => {
     req.params = {
         id: "1"
     };
+    req.query = {
+        lang: "en"
+    };
     return req;
 };

--- a/test/src/services/paymentService.test.ts
+++ b/test/src/services/paymentService.test.ts
@@ -9,6 +9,7 @@ import { API_URL } from "../../../src/utils/properties";
 import { dummyPayment } from "../../mocks/payment_mock";
 import { BASE_URL, PAYMENT_CALLBACK_URL } from "../../../src/types/pageURL";
 import { PAYEMNT_REFERENCE } from "../../../src/common/__utils/constants";
+import { mockRequest } from "../../mocks/request.mock";
 
 jest.mock("../../../src/utils/logger");
 jest.mock("../../../src/services/apiService");
@@ -63,6 +64,7 @@ const dummyPaymentResult = {
 };
 
 let session: any;
+const req = mockRequest();
 
 describe("Payment Service tests", () => {
 
@@ -76,9 +78,9 @@ describe("Payment Service tests", () => {
         it("Should return a successful response", async () => {
             dummyApiResponse.httpStatusCode = 200;
             mockCreatePaymentWithFullUrl.mockResolvedValueOnce(dummyPaymentResult);
-            const apiResponse: ApiResponse<Payment> = await startPaymentsSession(session,
+            const apiResponse: ApiResponse<Payment> = await startPaymentsSession(req, session,
                 PAYMENT_SESSION_URL, TRANSACTION_ID);
-
+            expect(apiResponse).toBeDefined();
             expect(apiResponse.httpStatusCode).toBe(200);
             expect(apiResponse.resource).toBe(dummyPayment);
             expect(apiResponse.headers).toBe(dummyHeaders);
@@ -86,7 +88,7 @@ describe("Payment Service tests", () => {
             expect(mockCreatePaymentApiClient).toHaveBeenCalledWith(session, PAYMENT_SESSION_URL);
 
             const paymentRequest: CreatePaymentRequest = mockCreatePaymentWithFullUrl.mock.calls[0][0];
-            expect(paymentRequest.redirectUri).toBe("http://chs.local" + BASE_URL + PAYMENT_CALLBACK_URL);
+            expect(paymentRequest.redirectUri).toBe("http://chs.local" + BASE_URL + PAYMENT_CALLBACK_URL + "?lang=en");
             expect(paymentRequest.reference).toBe(REFERENCE);
             expect(paymentRequest.resource).toBe(API_URL + PAYMENT_RESOURCE_URI);
             expect(paymentRequest.state).toBe(UUID);
@@ -97,7 +99,7 @@ describe("Payment Service tests", () => {
             mockIsFailure.mockReturnValueOnce(true);
             mockCreatePaymentWithFullUrl.mockResolvedValueOnce(dummyPaymentResult);
 
-            await expect(startPaymentsSession(session,
+            await expect(startPaymentsSession(req, session,
                 PAYMENT_SESSION_URL, TRANSACTION_ID))
                 .rejects
                 .toThrow(ERROR);
@@ -110,7 +112,7 @@ describe("Payment Service tests", () => {
             mockIsFailure.mockReturnValueOnce(true);
             mockCreatePaymentWithFullUrl.mockResolvedValueOnce(dummyPaymentResult);
 
-            await expect(startPaymentsSession(session,
+            await expect(startPaymentsSession(req, session,
                 PAYMENT_SESSION_URL, TRANSACTION_ID))
                 .rejects
                 .toThrow(ERROR);
@@ -123,7 +125,7 @@ describe("Payment Service tests", () => {
             mockIsFailure.mockReturnValueOnce(true);
             mockCreatePaymentWithFullUrl.mockResolvedValueOnce(dummyPaymentResult);
 
-            await expect(startPaymentsSession(session,
+            await expect(startPaymentsSession(req, session,
                 PAYMENT_SESSION_URL, TRANSACTION_ID))
                 .rejects
                 .toThrow(ERROR);

--- a/test/src/utils/localise.test.ts
+++ b/test/src/utils/localise.test.ts
@@ -1,0 +1,44 @@
+import { addLangToUrl, selectLang } from "../../../src/utils/localise";
+
+describe("selectLang", () => {
+    it("should return 'cy' for 'cy'", () => {
+        expect(selectLang("cy")).toBe("cy");
+    });
+
+    it("should return 'cy' for 'cy?lang=cy'", () => {
+        expect(selectLang("cy?lang=cy")).toBe("cy");
+    });
+
+    it("should return 'en' for 'en'", () => {
+        expect(selectLang("en")).toBe("en");
+    });
+
+    it("should return 'en' for 'en?lang=en'", () => {
+        expect(selectLang("en?lang=en")).toBe("en");
+    });
+
+    it("should return 'en' for any other value", () => {
+        expect(selectLang("fr")).toBe("en");
+        expect(selectLang("")).toBe("en");
+        expect(selectLang(null)).toBe("en");
+        expect(selectLang(undefined)).toBe("en");
+    });
+});
+
+describe("addLangToUrl", () => {
+    it("should add lang parameter to URL without query string", () => {
+        expect(addLangToUrl("http://example.com", "cy")).toBe("http://example.com?lang=cy");
+    });
+
+    it("should add lang parameter to URL with existing query string", () => {
+        expect(addLangToUrl("http://example.com?param=value", "cy")).toBe("http://example.com?param=value&lang=cy");
+    });
+
+    it("should return the same URL if lang is undefined", () => {
+        expect(addLangToUrl("http://example.com", undefined)).toBe("http://example.com");
+    });
+
+    it("should return the same URL if lang is an empty string", () => {
+        expect(addLangToUrl("http://example.com", "")).toBe("http://example.com");
+    });
+});


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1719

- Added lang to return uri to store en/cy and return users to the confirmation screen in that language
- Removed language switch from confirmation view to prevent users switching and throwing error caused by clearing the session data
- Updated tests