### PR TITLE
Refactor controller to include AML values in errors

### DIFF
--- a/src/controllers/features/common/amlBodyMembershipNumberController.ts
+++ b/src/controllers/features/common/amlBodyMembershipNumberController.ts
@@ -61,7 +61,8 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const errorList = validationResult(req);
         if (!errorList.isEmpty()) {
-            errorListDisplay(errorList.array(), acspData.amlSupervisoryBodies!, lang);
+            const amlSupervisoryBodyStrings = acspData.amlSupervisoryBodies!.map(body => body.amlSupervisoryBody).filter((body): body is string => body !== undefined);
+            errorListDisplay(errorList.array(), amlSupervisoryBodyStrings, lang);
             const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
             res.status(400).render(config.AML_MEMBERSHIP_NUMBER, {
                 previousPage: addLangToUrl(previousPage, lang),
@@ -93,14 +94,14 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     }
 };
 
-const errorListDisplay = (errors: any[], amlSupervisoryBodies: AmlSupervisoryBody[], lang: string) => {
-    return errors.forEach((element) => {
-        const index = element.param.substr("membershipNumber_".length) - 1;
-        const selection = amlSupervisoryBodies[index].amlSupervisoryBody;
+const errorListDisplay = (errors: any[], amlSupervisoryBodies: string[], lang: string) => {
+    return errors.map((element) => {
+        const index = parseInt(element.param.substr("membershipNumber_".length)) - 1;
+        const selectionKey = amlSupervisoryBodies[index];
+        const selectionValue = AMLSupervisoryBodies[selectionKey as keyof typeof AMLSupervisoryBodies];
         element.msg = resolveErrorMessage(element.msg, lang);
-        element.msg = element.msg + selection;
+        element.msg = element.msg + selectionValue;
         return element;
-
     });
 };
 

--- a/test/src/controllers/common/amlBodyMembershipNumberController.test.ts
+++ b/test/src/controllers/common/amlBodyMembershipNumberController.test.ts
@@ -18,7 +18,10 @@ const acspData: AcspData = {
     applicantDetails: {
         firstName: "John",
         lastName: "Doe"
-    }
+    },
+    amlSupervisoryBodies: [
+        { amlSupervisoryBody: "ACCA" }
+    ]
 };
 
 describe("GET " + AML_MEMBERSHIP_NUMBER, () => {
@@ -67,6 +70,14 @@ describe("POST" + AML_MEMBERSHIP_NUMBER, () => {
             lastName: "Doe"
         }
     };
+    beforeEach(() => {
+        mocks.mockSessionMiddleware.mockImplementation((req, res, next) => {
+            req.session = {
+                getExtraData: () => acspData
+            };
+            next();
+        });
+    });
     it("should return status 302 after redirect for valid input, ", async () => {
         const res = await router.post(BASE_URL + AML_MEMBERSHIP_NUMBER).send(formData);
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
@@ -75,11 +86,11 @@ describe("POST" + AML_MEMBERSHIP_NUMBER, () => {
         expect(res.header.location).toBe(BASE_URL + AML_BODY_DETAILS_CONFIRM + "?lang=en");
     });
 
-    it("should return status 400 for invalid input, empty value", async () => {
-        const res = await router.post(BASE_URL + AML_MEMBERSHIP_NUMBER + "?lang=en").send({ membershipNumber_1: " " });
+    it("should return status 400 and display error message for empty membership number", async () => {
+        const res = await router.post(BASE_URL + AML_MEMBERSHIP_NUMBER + "?lang=en").send({ membershipNumber_1: "" });
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
         expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
-        expect(400);
+        expect(res.status).toBe(400);
         expect(res.text).toContain("Enter the details for Association of Chartered Certified Accountants (ACCA)");
     });
 

--- a/test/src/controllers/common/amlBodyMembershipNumberController.test.ts
+++ b/test/src/controllers/common/amlBodyMembershipNumberController.test.ts
@@ -86,11 +86,11 @@ describe("POST" + AML_MEMBERSHIP_NUMBER, () => {
         expect(res.header.location).toBe(BASE_URL + AML_BODY_DETAILS_CONFIRM + "?lang=en");
     });
 
-    it("should return status 400 and display error message for empty membership number", async () => {
-        const res = await router.post(BASE_URL + AML_MEMBERSHIP_NUMBER + "?lang=en").send({ membershipNumber_1: "" });
+    it("should return status 400 for invalid input, empty value", async () => {
+        const res = await router.post(BASE_URL + AML_MEMBERSHIP_NUMBER + "?lang=en").send({ membershipNumber_1: " " });
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
         expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
-        expect(res.status).toBe(400);
+        expect(400);
         expect(res.text).toContain("Enter the details for Association of Chartered Certified Accountants (ACCA)");
     });
 


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1733

- Refactored the errorListDisplay function in amlBodyMembershipNumberController to get the value from AMLSupervisoryBodies Enums and include this in the error message rather than the abbreviation
- Added mock value of ACCA for unit test scenarios with errors displayed

<img width="1004" alt="Screenshot 2025-01-27 at 16 32 48" src="https://github.com/user-attachments/assets/c2bf2d45-db25-49f6-bb81-7212b85abc6f" />
