### PR TITLE
Updating catch clause on company lookup

### DIFF
--- a/src/controllers/features/limited/companyLookupController.ts
+++ b/src/controllers/features/limited/companyLookupController.ts
@@ -78,23 +78,27 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                         await acspDataService.saveAcspData(session, acspData);
                         res.redirect(nextPageUrl);
                     }
-                }).catch(() => {
-                const validationError : ValidationError[] = [{
-                    value: companyNumber,
-                    msg: "companyNumberDontExsits",
-                    param: "companyNumber",
-                    location: "body"
-                }];
-                const pageProperties = getPageProperties(formatValidationError(validationError, lang));
+                }).catch((error) => {
+                if (error.message?.includes("Company Not Found")) {
+                    const validationError : ValidationError[] = [{
+                        value: companyNumber,
+                        msg: "companyNumberDontExsits",
+                        param: "companyNumber",
+                        location: "body"
+                    }];
+                    const pageProperties = getPageProperties(formatValidationError(validationError, lang));
 
-                res.status(400).render(config.LIMITED_COMPANY_NUMBER, {
-                    previousPage,
-                    payload: req.body,
-                    title: "What is the company number?",
-                    ...getLocaleInfo(locales, lang),
-                    currentUrl,
-                    pageProperties: pageProperties
-                });
+                    res.status(400).render(config.LIMITED_COMPANY_NUMBER, {
+                        previousPage,
+                        payload: req.body,
+                        title: "What is the company number?",
+                        ...getLocaleInfo(locales, lang),
+                        currentUrl,
+                        pageProperties: pageProperties
+                    });
+                } else {
+                    next(error);
+                }
             });
         }
     } catch (err) {

--- a/test/src/controllers/limited/companyLookupController.test.ts
+++ b/test/src/controllers/limited/companyLookupController.test.ts
@@ -70,7 +70,7 @@ describe("POST" + LIMITED_WHAT_IS_THE_COMPANY_NUMBER, () => {
     });
 
     it("should return status 400 for company number not found", async () => {
-        mockGetCompanyDetails.mockRejectedValueOnce(new Error("Company number does not exist"));
+        mockGetCompanyDetails.mockRejectedValueOnce(new Error("Company Not Found"));
         const res = await router.post(BASE_URL + LIMITED_WHAT_IS_THE_COMPANY_NUMBER).send({ companyNumber: "08694860" });
         expect(res.status).toBe(400);
         expect(res.text).toContain("Enter a valid company number");

--- a/test/src/controllers/limited/companyLookupController.test.ts
+++ b/test/src/controllers/limited/companyLookupController.test.ts
@@ -76,6 +76,15 @@ describe("POST" + LIMITED_WHAT_IS_THE_COMPANY_NUMBER, () => {
         expect(res.text).toContain("Enter a valid company number");
     });
 
+    it("should return status 400 and render the page with validation error when company not found", async () => {
+        mockGetCompanyDetails.mockRejectedValueOnce(new Error("Company Not Found"));
+        const res = await router.post(BASE_URL + LIMITED_WHAT_IS_THE_COMPANY_NUMBER).send({ companyNumber: "08694860" });
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("What is the company number?");
+        expect(res.text).toContain("Enter a valid company number");
+        expect(res.text).toContain("08694860");
+    });
+
     it("should handle unexpected errors in the catch block and pass them to the next middleware", async () => {
         mockGetCompanyDetails.mockRejectedValueOnce(new Error("Unexpected Error"));
         const res = await router.post(BASE_URL + LIMITED_WHAT_IS_THE_COMPANY_NUMBER).send({ companyNumber: "08694860" });

--- a/test/src/controllers/limited/companyLookupController.test.ts
+++ b/test/src/controllers/limited/companyLookupController.test.ts
@@ -76,6 +76,13 @@ describe("POST" + LIMITED_WHAT_IS_THE_COMPANY_NUMBER, () => {
         expect(res.text).toContain("Enter a valid company number");
     });
 
+    it("should handle unexpected errors in the catch block and pass them to the next middleware", async () => {
+        mockGetCompanyDetails.mockRejectedValueOnce(new Error("Unexpected Error"));
+        const res = await router.post(BASE_URL + LIMITED_WHAT_IS_THE_COMPANY_NUMBER).send({ companyNumber: "08694860" });
+        expect(res.status).toBe(500);
+        expect(res.text).toContain("Sorry we are experiencing technical difficulties");
+    });
+
     it("should return status 400 for invalid company number", async () => {
         const res = await router.post(BASE_URL + LIMITED_WHAT_IS_THE_COMPANY_NUMBER).send({ companyNumber: "@&£29864" });
         expect(res.status).toBe(400);


### PR DESCRIPTION
It was discovered during the testing of [IDVA5-915](https://companieshouse.atlassian.net/browse/IDVA5-915?atlOrigin=eyJpIjoiMTcyN2EzZDRjYTkyNGU4YmI5MTAxNWMzM2NmZjg3MzMiLCJwIjoiaiJ9) that when the on the company number input screen and the authorisation token had expired after idle time, upon entering a valid company number, the application was throwing the validation message "Enter a valid company number".

This was due to the controller encountering the first catch block on the POST request and halting the service, rather than filtering through to the second catch block and redirecting the user to sign in > checked saved application page.

Updated the first catch block to only catch the validation error when the company number is not valid. 
If the authorisation token has expired after idle time and the user attempts to enter a valid company number, then the application will correctly route the user to sign in > checked saved application page and refresh the authorisation token.



[IDVA5-915]: https://companieshouse.atlassian.net/browse/IDVA5-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ