### PR TITLE
IDVA5-1461 Limited registered office address screens for Update ACSP

### DIFF
--- a/locales/cy/address-look-up.json
+++ b/locales/cy/address-look-up.json
@@ -1,6 +1,7 @@
 {
     "correspondenceLookUpAddressTitle" : "Beth yw'r cyfeiriad gohebiaeth?",
     "businessLookUpAddressTitle": "Beth yw'r cyfeiriad busnes?",
+    "registeredOfficeLookUpAddressTitle": "What is the registered office address? welsh",
     "correspondenceLookUpAddressPostCodeInput": "Cod post y DU",
     "correspondenceLookUpAddressInputHint1": "Enw neu rif eiddo",
     "correspondenceLookUpAddressInputHint2": "Bydd angen i chi cofnodi'r cyfeiriad â llaw os nad yw yn y Deyrnas Unedig.",

--- a/locales/cy/common-address-confirm.json
+++ b/locales/cy/common-address-confirm.json
@@ -1,4 +1,5 @@
 {
     "correspondenceAddressConfirmTitle" : "Cadarnhau'r cyfeiriad gohebiaeth",
-    "businessAddressConfirmTitle" : "Cadarnhau'r cyfeiriad busnes"
+    "businessAddressConfirmTitle" : "Cadarnhau'r cyfeiriad busnes",
+    "registeredOfficeAddressConfirmTitle" : "Confirm the registered office address welsh"
 }

--- a/locales/cy/common-address-manual.json
+++ b/locales/cy/common-address-manual.json
@@ -1,5 +1,6 @@
 {
     "correspondenceAddressManualTitle" : "Cofnodwch y cyfeiriad gohebiaeth",
+    "registeredOfficeAddressManualTitle" : "Enter the registered office address welsh",
     "businessAddressManualTitle" : "Cofnodwch y cyfeiriad busnes",
     "addressPropertyDetails": "Enw neu rif eiddo",
     "addressPropertyDetailsHint": "Er enghraifft, 'Y Felin', '116' neu 'Fflat 37a'",

--- a/locales/en/address-look-up.json
+++ b/locales/en/address-look-up.json
@@ -1,6 +1,7 @@
 {
     "correspondenceLookUpAddressTitle" : "What is the correspondence address?",
     "businessLookUpAddressTitle": "What is the business address?",
+    "registeredOfficeLookUpAddressTitle": "What is the registered office address?",
     "correspondenceLookUpAddressPostCodeInput": "UK postcode",
     "correspondenceLookUpAddressInputHint1": "Property name or number",
     "correspondenceLookUpAddressInputHint2": "You'll need to enter the address manually if it's not in the UK.",

--- a/locales/en/common-address-confirm.json
+++ b/locales/en/common-address-confirm.json
@@ -1,4 +1,5 @@
 {
     "correspondenceAddressConfirmTitle" : "Confirm the correspondence address",
-    "businessAddressConfirmTitle" : "Confirm the business address"
+    "businessAddressConfirmTitle" : "Confirm the business address",
+    "registeredOfficeAddressConfirmTitle" : "Confirm the registered office address"
 }

--- a/locales/en/common-address-manual.json
+++ b/locales/en/common-address-manual.json
@@ -1,6 +1,7 @@
 {
     "correspondenceAddressManualTitle" : "Enter the correspondence address",
     "businessAddressManualTitle" : "Enter the business address",
+    "registeredOfficeAddressManualTitle" : "Enter the registered office address",
     "addressPropertyDetails": "Property name or number",
     "addressPropertyDetailsHint": "For example, 'The Mill', '116' or 'Flat 37a'",
     "addressLine1": "Address line 1",

--- a/src/controllers/features/update-acsp/businessAddressAutoLookupController.ts
+++ b/src/controllers/features/update-acsp/businessAddressAutoLookupController.ts
@@ -12,7 +12,7 @@ import {
     UPDATE_ACSP_DETAILS_BASE_URL
 } from "../../../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
-import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 
@@ -20,7 +20,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const session: Session = req.session as any as Session;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
-        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
         const locales = getLocalesService();
         const lang = selectLang(req.query.lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP;
@@ -37,7 +36,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             currentUrl,
             payload,
             businessAddressManualLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL, lang),
-            typeOfBusiness: acspFullProfile.type
+            typeOfBusiness: acspUpdatedFullProfile.type
         });
     } catch (err) {
         next(err);
@@ -49,7 +48,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const session: Session = req.session as any as Session;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
-        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
         const previousPage: string = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP;
         const locales = getLocalesService();
@@ -63,7 +61,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 pageProperties: pageProperties,
                 payload: req.body,
                 businessAddressManualLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL, lang),
-                typeOfBusiness: acspFullProfile.type
+                typeOfBusiness: acspUpdatedFullProfile.type
             });
         } else {
             const postcode = req.body.postCode;
@@ -89,7 +87,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                     pageProperties: pageProperties,
                     payload: req.body,
                     businessAddressManualLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL, lang),
-                    typeOfBusiness: acspFullProfile.type
+                    typeOfBusiness: acspUpdatedFullProfile.type
                 });
             });
         }

--- a/src/controllers/features/update-acsp/businessAddressAutoLookupController.ts
+++ b/src/controllers/features/update-acsp/businessAddressAutoLookupController.ts
@@ -12,7 +12,7 @@ import {
     UPDATE_ACSP_DETAILS_BASE_URL
 } from "../../../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
-import { ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 
@@ -20,6 +20,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const session: Session = req.session as any as Session;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
         const locales = getLocalesService();
         const lang = selectLang(req.query.lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP;
@@ -35,7 +36,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             ...getLocaleInfo(locales, lang),
             currentUrl,
             payload,
-            businessAddressManualLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL, lang)
+            businessAddressManualLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL, lang),
+            typeOfBusiness: acspFullProfile.type
         });
     } catch (err) {
         next(err);
@@ -47,6 +49,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const session: Session = req.session as any as Session;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
         const previousPage: string = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP;
         const locales = getLocalesService();
@@ -59,7 +62,8 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 currentUrl,
                 pageProperties: pageProperties,
                 payload: req.body,
-                businessAddressManualLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL, lang)
+                businessAddressManualLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL, lang),
+                typeOfBusiness: acspFullProfile.type
             });
         } else {
             const postcode = req.body.postCode;
@@ -84,7 +88,8 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                     currentUrl,
                     pageProperties: pageProperties,
                     payload: req.body,
-                    businessAddressManualLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL, lang)
+                    businessAddressManualLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL, lang),
+                    typeOfBusiness: acspFullProfile.type
                 });
             });
         }

--- a/src/controllers/features/update-acsp/businessAddressConfirmController.ts
+++ b/src/controllers/features/update-acsp/businessAddressConfirmController.ts
@@ -4,7 +4,7 @@ import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../.
 import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_MANUAL, UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_ANSWERS } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -14,7 +14,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
         const previousPage: string = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP, lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_CONFIRM;
-        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
 
         res.render(config.UNINCORPORATED_BUSINESS_ADDRESS_CONFIRM, {
             previousPage,
@@ -22,7 +21,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             ...getLocaleInfo(locales, lang),
             currentUrl,
             businessAddress: acspUpdatedFullProfile?.registeredOfficeAddress,
-            typeOfBusiness: acspFullProfile.type
+            typeOfBusiness: acspUpdatedFullProfile.type
         });
     } catch (err) {
         next(err);

--- a/src/controllers/features/update-acsp/businessAddressConfirmController.ts
+++ b/src/controllers/features/update-acsp/businessAddressConfirmController.ts
@@ -4,7 +4,7 @@ import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../.
 import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_MANUAL, UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_ANSWERS } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -14,13 +14,15 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
         const previousPage: string = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP, lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_CONFIRM;
+        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
 
         res.render(config.UNINCORPORATED_BUSINESS_ADDRESS_CONFIRM, {
             previousPage,
             editAddress: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL, lang),
             ...getLocaleInfo(locales, lang),
             currentUrl,
-            businessAddress: acspUpdatedFullProfile?.registeredOfficeAddress
+            businessAddress: acspUpdatedFullProfile?.registeredOfficeAddress,
+            typeOfBusiness: acspFullProfile.type
         });
     } catch (err) {
         next(err);

--- a/src/controllers/features/update-acsp/businessAddressManualController.ts
+++ b/src/controllers/features/update-acsp/businessAddressManualController.ts
@@ -6,7 +6,7 @@ import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../.
 import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_BUSINESS_ADDRESS_MANUAL, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 import { BusinessAddressService } from "../../../services/business-address/businessAddressService";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -17,7 +17,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const previousPage: string = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP, lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
-        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
 
         // Get existing business address details and display on the page
         const businessAddressService = new BusinessAddressService();
@@ -28,7 +27,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             previousPage,
             currentUrl,
             payload,
-            typeOfBusiness: acspFullProfile.type
+            typeOfBusiness: acspUpdatedFullProfile.type
         });
     } catch (err) {
         next(err);
@@ -42,7 +41,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const previousPage: string = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP, lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
-        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
         const locales = getLocalesService();
         const errorList = validationResult(req);
         if (!errorList.isEmpty()) {
@@ -53,7 +51,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 currentUrl,
                 pageProperties: pageProperties,
                 payload: req.body,
-                typeOfBusiness: acspFullProfile.type
+                typeOfBusiness: acspUpdatedFullProfile.type
             });
         } else {
         // update acspUpdatedFullProfile

--- a/src/controllers/features/update-acsp/businessAddressManualController.ts
+++ b/src/controllers/features/update-acsp/businessAddressManualController.ts
@@ -6,7 +6,7 @@ import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../.
 import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_BUSINESS_ADDRESS_MANUAL, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 import { BusinessAddressService } from "../../../services/business-address/businessAddressService";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -17,6 +17,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const previousPage: string = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP, lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
 
         // Get existing business address details and display on the page
         const businessAddressService = new BusinessAddressService();
@@ -26,7 +27,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             ...getLocaleInfo(locales, lang),
             previousPage,
             currentUrl,
-            payload
+            payload,
+            typeOfBusiness: acspFullProfile.type
         });
     } catch (err) {
         next(err);
@@ -40,6 +42,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const previousPage: string = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP, lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
         const locales = getLocalesService();
         const errorList = validationResult(req);
         if (!errorList.isEmpty()) {
@@ -49,7 +52,8 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 ...getLocaleInfo(locales, lang),
                 currentUrl,
                 pageProperties: pageProperties,
-                payload: req.body
+                payload: req.body,
+                typeOfBusiness: acspFullProfile.type
             });
         } else {
         // update acspUpdatedFullProfile

--- a/src/views/features/unincorporated/business-address-auto-lookup/auto-lookup-address.njk
+++ b/src/views/features/unincorporated/business-address-auto-lookup/auto-lookup-address.njk
@@ -3,7 +3,11 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% set errors = pageProperties.errors %}
 
-{% set title = i18n.businessLookUpAddressTitle %}
+{% if typeOfBusiness === "limited-company" or typeOfBusiness === "limited-liability-partnership"  or typeOfBusiness === "corporate-body" %}
+  {% set title = i18n.registeredOfficeLookUpAddressTitle %}
+{% else %}
+  {% set title = i18n.businessLookUpAddressTitle %} 
+{% endif %}
 {% block main_content %}
   <div class="govuk-width-container">
     <form action="" method="POST">
@@ -11,7 +15,11 @@
       {% if businessName %}
         {% include "partials/business_name.njk" %}
       {% endif %}
-      <h1 class="govuk-heading-l">{{ i18n.businessLookUpAddressTitle }}</h1>
+      {% if typeOfBusiness === "limited-company" or typeOfBusiness === "limited-liability-partnership" or typeOfBusiness === "corporate-body" %}
+        <h1 class="govuk-heading-l">{{ i18n.registeredOfficeLookUpAddressTitle }}</h1>
+      {% else %}
+        <h1 class="govuk-heading-l">{{ i18n.businessLookUpAddressTitle }}</h1>
+      {% endif %}
       <div class="govuk-form-group">
         {{ govukInput({
                 label: {

--- a/src/views/features/unincorporated/business-address-manual-entry/business-address-manual-entry.njk
+++ b/src/views/features/unincorporated/business-address-manual-entry/business-address-manual-entry.njk
@@ -5,7 +5,13 @@
 {% extends "layouts/default.njk" %}
 {% set errors = pageProperties.errors %}
 
-{% set title = i18n.businessAddressManualTitle %}
+{% if typeOfBusiness === "limited-company" or typeOfBusiness === "limited-liability-partnership"  or typeOfBusiness === "corporate-body" %}
+  {% set title = i18n.registeredOfficeAddressManualTitle %}
+  {% set legendHeader = i18n.registeredOfficeAddressManualTitle %}
+{% else %}
+  {% set title = i18n.businessAddressManualTitle %} 
+  {% set legendHeader = i18n.businessAddressManualTitle %}
+{% endif %}
 {% block main_content %}
 <form action="" method="POST">
     {% include "partials/csrf_token.njk" %}
@@ -13,7 +19,7 @@
     <div class="govuk-form-group">
         {{ govukFieldset({
             legend: {
-                text: i18n.businessAddressManualTitle,
+                text: legendHeader,
                 classes: "govuk-fieldset__legend--l",
                 isPageHeading: true
             }  

--- a/src/views/features/unincorporated/confirm-your-business-address/confirm-your-business-address.njk
+++ b/src/views/features/unincorporated/confirm-your-business-address/confirm-your-business-address.njk
@@ -1,13 +1,21 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% extends "layouts/default.njk" %}
 
-{% set title = i18n.businessAddressConfirmTitle %}
+{% if typeOfBusiness === "limited-company" or typeOfBusiness === "limited-liability-partnership"  or typeOfBusiness === "corporate-body" %}
+  {% set title = i18n.registeredOfficeAddressConfirmTitle %}
+{% else %}
+  {% set title = i18n.businessAddressConfirmTitle %} 
+{% endif %}
 {% block main_content %}
  {% set businessAddressField = businessAddress.premises + " " + businessAddress.addressLine1 + ", " %}
   <form action="" method="post">
     {% include "partials/csrf_token.njk" %}
     {% include "partials/business_name.njk" %}
-    <h1 class="govuk-heading-l">{{ i18n.businessAddressConfirmTitle }}</h1>
+    {% if typeOfBusiness === "limited-company" or typeOfBusiness === "limited-liability-partnership"  or typeOfBusiness === "corporate-body" %}
+      <h1 class="govuk-heading-l">{{ i18n.registeredOfficeAddressConfirmTitle }}</h1>
+    {% else %}
+      <h1 class="govuk-heading-l">{{ i18n.businessAddressConfirmTitle }}</h1>
+    {% endif %}
     <ul class="govuk-list">
       <li>{{ businessAddressField }}</li>
       <li>{{ businessAddress.addressLine2 }}</li>

--- a/src/views/partials/update-your-details/limited-answers.njk
+++ b/src/views/partials/update-your-details/limited-answers.njk
@@ -92,7 +92,7 @@
         actions: {
             items: [
               {
-                href: "#",
+                href: "/view-and-update-the-authorised-agents-details/business-address-lookup?lang=" + lang,
                 text: i18n.updateYourDetailsUpdate,
                 visuallyHiddenText: i18n.updateYourDetailsRegisteredOfficeAddress
               },
@@ -100,7 +100,7 @@
                 href: cancelChangeUrl + "&cancel=registeredOfficeAddress",
                 text: i18n.updateYourDetailsCancel,
                 visuallyHiddenText: i18n.updateYourDetailsRegisteredOfficeAddress
-              }if profileDetailsUpdated.correspondenceAddress !== profileDetails.correspondenceAddress
+              }if profileDetailsUpdated.businessAddress !== profileDetails.businessAddress
             ],
             classes: "govuk-!-width-one-third"
           }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1461

- Limited journey doesn't have office address screens in Registration so I am reusing the 'Business address' screens for Unincorporated journey.
- I set the title and h1 according to the business type from AcspFullProfile so if it matches "limited-company", "limited-liability-partnership" or "corporate-body" then it will be 'Registered address' otherwise keep it as 'Business address' as in current Unincorporated flow.
- I did some sanity checks on Registration service and also Update ACSP as unincorporated and it was displaying correctly