### PR TITLE
Added cancel all updates screen and tests

### DIFF
--- a/locales/cy/cancel-all-updates.json
+++ b/locales/cy/cancel-all-updates.json
@@ -1,0 +1,5 @@
+{
+    "cancelAllUpdatesTitle" : "Are you sure you want to cancel all updates? welsh",
+    "ifYouContinueBodyText": "If you continue, we’ll return you to the authorised agent account. Any updates you’ve made to the authorised agent’s details will not be saved. Go back if you need to update the authorised agent’s details. welsh",
+    "cancelAllUpdatesGoBackLink": "Go back to update details welsh"
+}

--- a/locales/en/cancel-all-updates.json
+++ b/locales/en/cancel-all-updates.json
@@ -1,0 +1,5 @@
+{
+    "cancelAllUpdatesTitle" : "Are you sure you want to cancel all updates?",
+    "ifYouContinueBodyText": "If you continue, we’ll return you to the authorised agent account. Any updates you’ve made to the authorised agent’s details will not be saved. Go back if you need to update the authorised agent’s details.",
+    "cancelAllUpdatesGoBackLink": "Go back to update details"
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -71,3 +71,4 @@ export const UPDATE_ACSP_DETAILS_HOME = `${BASE_UPDATE_ACSP_DETAILS_URL}/index/h
 export const UPDATE_YOUR_ANSWERS = `${BASE_UPDATE_ACSP_DETAILS_URL}/update-your-details`;
 export const UPDATE_ACSP_DETAILS_APPLICATION_CONFIRMATION = `${BASE_UPDATE_ACSP_DETAILS_URL}/application-confirmation/application-confirmation`;
 export const UPDATE_ADD_AML_SUPERVISORY_BODY = `${BASE_UPDATE_ACSP_DETAILS_URL}/add-aml-supervisory-body/add-aml-supervisory-body`;
+export const UPDATE_CANCEL_ALL_UPDATES = `${BASE_UPDATE_ACSP_DETAILS_URL}/cancel-all-updates/cancel-all-updates`;

--- a/src/controllers/features/update-acsp/cancelAllUpdatesController.ts
+++ b/src/controllers/features/update-acsp/cancelAllUpdatesController.ts
@@ -1,0 +1,35 @@
+import { NextFunction, Request, Response } from "express";
+import * as config from "../../../config";
+import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
+import { Session } from "@companieshouse/node-session-handler";
+import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
+import { ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_CANCEL_ALL_UPDATES, MANAGE_USERS_DASHBOARD } from "../../../types/pageURL";
+
+export const get = async (req: Request, res: Response, next: NextFunction) => {
+    const lang = selectLang(req.query.lang);
+    const locales = getLocalesService();
+    const updateDetailsGoBackLink = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang);
+
+    res.render(config.UPDATE_CANCEL_ALL_UPDATES, {
+        previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
+        ...getLocaleInfo(locales, lang),
+        currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CANCEL_ALL_UPDATES,
+        updateDetailsGoBackLink
+    });
+};
+
+export const post = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const session: Session = req.session as any as Session;
+        const manageUsersDashboard = MANAGE_USERS_DASHBOARD;
+        const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+
+        if (acspUpdatedFullProfile) {
+            session.deleteExtraData(ACSP_DETAILS_UPDATED);
+        }
+        res.redirect(manageUsersDashboard);
+    } catch (err) {
+        next(err);
+    }
+};

--- a/src/controllers/features/update-acsp/updateYourDetailsController.ts
+++ b/src/controllers/features/update-acsp/updateYourDetailsController.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { selectLang, getLocalesService, getLocaleInfo, addLangToUrl } from "../../../utils/localise";
 import * as config from "../../../config";
-import { AML_MEMBERSHIP_NUMBER, UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_APPLICATION_CONFIRMATION, CANCEL_AN_UPDATE, UPDATE_ADD_AML_SUPERVISOR, REMOVE_AML_SUPERVISOR } from "../../../types/pageURL";
+import { AML_MEMBERSHIP_NUMBER, UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_APPLICATION_CONFIRMATION, CANCEL_AN_UPDATE, UPDATE_ADD_AML_SUPERVISOR, REMOVE_AML_SUPERVISOR, UPDATE_CANCEL_ALL_UPDATES } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import { ACSP_DETAILS, ACSP_DETAILS_UPDATED, ADD_AML_BODY_UPDATE, NEW_AML_BODIES } from "../../../common/__utils/constants";
 import { getProfileDetails } from "../../../services/update-acsp/updateYourDetailsService";
@@ -27,6 +27,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
         const cancelChangeUrl = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + CANCEL_AN_UPDATE, lang);
         const removeAMLUrl = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + REMOVE_AML_SUPERVISOR, lang);
+        const cancelAllUpdatesUrl = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CANCEL_ALL_UPDATES, lang);
 
         res.render(config.UPDATE_YOUR_ANSWERS, {
             ...getLocaleInfo(locales, lang),
@@ -43,7 +44,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             cancelChangeUrl,
             removeAMLUrl,
             AMLSupervioryBodiesFormatted,
-            addedAmlBodies
+            addedAmlBodies,
+            cancelAllUpdatesUrl
         });
     } catch (err) {
         next(err);

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -89,3 +89,4 @@ export * as updateApplicationConfirmationController from "./features/update-acsp
 export * as addAmlSupervisorController from "./features/update-acsp/addAmlSupervisorController";
 export * as removeAmlSupervisorController from "./features/update-acsp/removeAmlSupervisorController";
 export * as updateAmlMembershipNumberController from "./features/update-acsp/amlMembershipNumberController";
+export * as cancelAllUpdatesController from "./features/update-acsp/cancelAllUpdatesController";

--- a/src/routes/updateAcsp.ts
+++ b/src/routes/updateAcsp.ts
@@ -18,7 +18,8 @@ import {
     updateApplicationConfirmationController,
     addAmlSupervisorController,
     removeAmlSupervisorController,
-    updateAmlMembershipNumberController
+    updateAmlMembershipNumberController,
+    cancelAllUpdatesController
 } from "../controllers";
 import { nameValidator } from "../validation/whatIsYourName";
 import { whereDoYouLiveValidator } from "../validation/whereDoYouLive";
@@ -83,5 +84,8 @@ updateRoutes.get(urls.CANCEL_AN_UPDATE, cancelAnUpdateController.get);
 
 updateRoutes.get(urls.AML_MEMBERSHIP_NUMBER, updateAmlMembershipNumberController.get);
 updateRoutes.post(urls.AML_MEMBERSHIP_NUMBER, amlBodyMembershipNumberControllerValidator.call(this), updateAmlMembershipNumberController.post);
+
+updateRoutes.get(urls.UPDATE_CANCEL_ALL_UPDATES, cancelAllUpdatesController.get);
+updateRoutes.post(urls.UPDATE_CANCEL_ALL_UPDATES, cancelAllUpdatesController.post);
 
 export default updateRoutes;

--- a/src/types/pageURL.ts
+++ b/src/types/pageURL.ts
@@ -60,6 +60,8 @@ export const CANNOT_REGISTER_AGAIN = "/cannot-register-again";
 
 export const AUTHORISED_AGENT = `${CHS_URL}/authorised-agent`;
 
+export const MANAGE_USERS_DASHBOARD = `${CHS_URL}/authorised-agent/manage-users`;
+
 export const VERIFY_IDENTITY = `${ACCOUNT_URL}/identity-verification/verify-your-identity-for-companies-house`;
 
 // sole trader journey urls
@@ -203,4 +205,7 @@ export const CANCEL_AN_UPDATE = "/cancel-an-update";
 export const UPDATE_ADD_AML_SUPERVISOR = "/select-aml-supervisor";
 
 export const REMOVE_AML_SUPERVISOR = "/remove-an-aml";
+
 export const UPDATE_SELECT_AML_SUPERVISOR = "/select-aml-supervisor";
+
+export const UPDATE_CANCEL_ALL_UPDATES = "/cancel-all-updates";

--- a/src/views/features/update-acsp-details/cancel-all-updates/cancel-all-updates.njk
+++ b/src/views/features/update-acsp-details/cancel-all-updates/cancel-all-updates.njk
@@ -1,0 +1,23 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "layouts/default.njk" %}
+{% set title = i18n.cancelAllUpdatesTitle %}
+{% block main_content %}
+    <form action="" method="POST">
+        {% include "partials/csrf_token.njk" %} 
+        <h1 class="govuk-heading-l"> {{ i18n.cancelAllUpdatesTitle }} </h1>
+        <p class="govuk-body">{{ i18n.ifYouContinueBodyText }}</p>
+        <div class="govuk-button-group"> 
+            {{ govukButton({
+                text: i18n.Continue,
+                id:"continue-button-id"
+              }) }}
+            <a 
+            href={{ updateDetailsGoBackLink }} 
+            class="govuk-link" 
+            id="back-link-id">
+                {{ i18n.cancelAllUpdatesGoBackLink }}
+            </a>
+        </div>
+    </form>
+{% endblock main_content %}

--- a/src/views/features/update-acsp-details/update-your-details.njk
+++ b/src/views/features/update-acsp-details/update-your-details.njk
@@ -115,7 +115,7 @@
                     text: i18n.updateYourDetailsContinue,
                     id:"update-acsp-details"
                     }) }}
-                <a class="govuk-link" href="#" id="cancel-id">{{i18n.Cancel}}</a>
+                <a class="govuk-link" href="{{ cancelAllUpdatesUrl }}" id="cancel-id">{{i18n.Cancel}}</a>
             </div>
         {% endif %}
     </form>

--- a/test/src/controllers/updateAcspDetails/cancelAllUpdatesController.test.ts
+++ b/test/src/controllers/updateAcspDetails/cancelAllUpdatesController.test.ts
@@ -1,0 +1,82 @@
+import mocks from "../../../mocks/all_middleware_mock";
+import supertest from "supertest";
+import app from "../../../../src/app";
+import { getSessionRequestWithPermission } from "../../../mocks/session.mock";
+import { MANAGE_USERS_DASHBOARD, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_CANCEL_ALL_UPDATES } from "../../../../src/types/pageURL";
+import { Session } from "@companieshouse/node-session-handler";
+import { Request, Response, NextFunction } from "express";
+import { sessionMiddleware } from "../../../../src/middleware/session_middleware";
+import { dummyFullProfile } from "../../../mocks/acsp_profile.mock";
+import { ACSP_DETAILS_UPDATED } from "../../../../src/common/__utils/constants";
+import { createRequest, MockRequest } from "node-mocks-http";
+
+const router = supertest(app);
+
+let customMockSessionMiddleware : any;
+
+describe("GET " + UPDATE_CANCEL_ALL_UPDATES, () => {
+    it("should respond with status 200", async () => {
+        const res = await router.get(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CANCEL_ALL_UPDATES);
+        expect(res.text).toContain("Are you sure you want to cancel all updates?");
+        expect(res.text).toContain("If you continue, we’ll return you to the authorised agent account.");
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
+        expect(res.status).toBe(200);
+    });
+});
+
+describe("POST " + UPDATE_ACSP_DETAILS_BASE_URL, () => {
+
+    let req: MockRequest<Request>;
+    beforeEach(() => {
+        jest.clearAllMocks();
+        req = createRequest({
+            method: "POST",
+            url: "/"
+        });
+        const session = getSessionRequestWithPermission();
+        req.session = session;
+    });
+
+    it("should return status 500 if deleteExtraData throws an error", async () => {
+        mocks.mockSessionMiddleware.mockImplementation((req, res, next) => {
+            req.session = {
+                deleteExtraData: jest.fn().mockImplementation(() => {
+                    throw new Error();
+                })
+            } as unknown as Session;
+            next();
+        });
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CANCEL_ALL_UPDATES);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
+        expect(res.status).toBe(500);
+        expect(res.text).toContain("Sorry we are experiencing technical difficulties");
+    });
+
+    it("should delete ACSP_DETAILS_UPDATED from session if acspUpdatedFullProfile exists", async () => {
+        const session: Session = req.session as any as Session;
+        createMockSessionMiddlewareAcspFullProfile();
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CANCEL_ALL_UPDATES);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
+        expect(res.status).toBe(302);
+        expect(session.getExtraData(ACSP_DETAILS_UPDATED)).toBe(undefined);
+    });
+
+    it("should redirect to manage users dashboard", async () => {
+        const manageUsersDashboard = MANAGE_USERS_DASHBOARD;
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CANCEL_ALL_UPDATES);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
+        expect(res.status).toBe(302);
+        expect(res.header.location).toBe(manageUsersDashboard);
+    });
+
+});
+
+function createMockSessionMiddlewareAcspFullProfile () {
+    customMockSessionMiddleware = sessionMiddleware as jest.Mock;
+    const session = getSessionRequestWithPermission();
+    session.setExtraData(ACSP_DETAILS_UPDATED, { dummyFullProfile });
+    customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        req.session = session;
+        next();
+    });
+}

--- a/test/src/controllers/updateAcspDetails/cancelAllUpdatesController.test.ts
+++ b/test/src/controllers/updateAcspDetails/cancelAllUpdatesController.test.ts
@@ -40,6 +40,7 @@ describe("POST " + UPDATE_ACSP_DETAILS_BASE_URL, () => {
     it("should return status 500 if deleteExtraData throws an error", async () => {
         mocks.mockSessionMiddleware.mockImplementation((req, res, next) => {
             req.session = {
+                getExtraData: jest.fn().mockReturnValue({}),
                 deleteExtraData: jest.fn().mockImplementation(() => {
                     throw new Error();
                 })


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1713

- Added cancel all updates screen upon clicking 'cancel' link on update details screen based on new prototype below
- New controller to clear the acspUpdatedFullProfile from session in post method when clicking continue
- Added manage users url for redirect

![image](https://github.com/user-attachments/assets/c2e13297-f8cb-46a8-a869-b499e9ab137b)
