### PR TITLE
IDVA5-1706 Add a new AML body

### DIFF
--- a/src/controllers/features/update-acsp/addAmlSupervisorController.ts
+++ b/src/controllers/features/update-acsp/addAmlSupervisorController.ts
@@ -12,13 +12,18 @@ import { AMLSupervioryBodiesFormatted } from "../../../model/AMLSupervisoryBodie
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
-        const session: Session = req.session as any as Session;
+        const session = req.session as Session;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
         const update: number | undefined = req.query.update as number | undefined;
         let amlBody = "";
         if (update) {
             amlBody = acspUpdatedFullProfile.amlDetails[update].supervisoryBody!;
             session.setExtraData(ADD_AML_BODY_UPDATE, update);
+        }
+
+        const newAmlBodyData = session.getExtraData(NEW_AML_BODY);
+        if (newAmlBodyData) {
+            amlBody = (newAmlBodyData as { amlSupervisoryBody: string }).amlSupervisoryBody;
         }
 
         const lang = selectLang(req.query.lang);

--- a/src/controllers/features/update-acsp/updateYourDetailsController.ts
+++ b/src/controllers/features/update-acsp/updateYourDetailsController.ts
@@ -3,7 +3,7 @@ import { selectLang, getLocalesService, getLocaleInfo, addLangToUrl } from "../.
 import * as config from "../../../config";
 import { AML_MEMBERSHIP_NUMBER, UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_APPLICATION_CONFIRMATION, CANCEL_AN_UPDATE, UPDATE_ADD_AML_SUPERVISOR, REMOVE_AML_SUPERVISOR, UPDATE_CANCEL_ALL_UPDATES } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { ACSP_DETAILS, ACSP_DETAILS_UPDATED, ADD_AML_BODY_UPDATE } from "../../../common/__utils/constants";
+import { ACSP_DETAILS, ACSP_DETAILS_UPDATED, ADD_AML_BODY_UPDATE, NEW_AML_BODY } from "../../../common/__utils/constants";
 import { getProfileDetails } from "../../../services/update-acsp/updateYourDetailsService";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { ACSPFullProfileDetails } from "../../../model/ACSPFullProfileDetails";
@@ -23,6 +23,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const profileDetailsUpdated: ACSPFullProfileDetails = getProfileDetails(acspUpdatedFullProfile);
         var updateFlag = JSON.stringify(acspFullProfile) !== JSON.stringify(acspUpdatedFullProfile);
         session.deleteExtraData(ADD_AML_BODY_UPDATE);
+        session.deleteExtraData(NEW_AML_BODY);
 
         const cancelChangeUrl = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + CANCEL_AN_UPDATE, lang);
         const removeAMLUrl = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + REMOVE_AML_SUPERVISOR, lang);

--- a/src/model/AMLSupervisoryBodiesFormatted.ts
+++ b/src/model/AMLSupervisoryBodiesFormatted.ts
@@ -14,6 +14,7 @@ export enum AMLSupervioryBodiesFormatted {
     "gambling-commission" = "Gambling Commission",
     "bar-standards-board" = "Bar Standards Board (BSB)",
     "general-council-of-the-bar-of-northern-ireland" = "General Council of the Bar of Northern Ireland",
+    "hm-revenue-customs-hmrc" = "HMRC",
     "institute-of-accountants-bookkeepers-iab" = "Institute of Accountants and Bookkeepers (IAB)",
     "insolvency-practitioners-association-ipa" = "Insolvency Practitioners Association (IPA)",
     "institute-of-certified-bookkeepers-icb" = "Institute of Certified Bookkeepers",
@@ -23,6 +24,5 @@ export enum AMLSupervioryBodiesFormatted {
     "institute-of-financial-accountants-ifa" = "Institute of Financial Accountants (IFA)",
     "law-society-of-northern-ireland" = "Law Society of Northern Ireland",
     "law-society-of-scotland" = "Law Society of Scotland",
-    "law-society-ew-solicitors-regulation-authority-sra" = "Solicitors Regulation Authority (SRA) Solicitors in England and Wales",
-    "hm-revenue-customs-hmrc" = "HMRC"
+    "law-society-ew-solicitors-regulation-authority-sra" = "Solicitors Regulation Authority (SRA) Solicitors in England and Wales"
 }


### PR DESCRIPTION
Fixing the below:
1. On New AML Body screen HMRC should appear in order of alphabetic.
2. In the AML ref number page on clicking of the back button the radio button should be pre selected with the AML body chosen earlier.