### PR TITLE
Feature/idva5 1825 update acsp develop correspondence email address screen

### DIFF
--- a/locales/cy/update-acsp-what-is-your-email.json
+++ b/locales/cy/update-acsp-what-is-your-email.json
@@ -1,0 +1,5 @@
+{
+    "wellUseThisToSendInformationHint": "We'll use this to send information about the authorised agent account once the business is registered. Welsh",
+    "whatCorrespondenceWellSend": "What correspondence we'll send to the email address Welsh",
+    "wellUseThisToSendEssentialEmails": "We'll use this to send essential emails about the agent account. For example, if we need to: Welsh"
+}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -8,5 +8,6 @@
     "AcceptAndContinue": "Accept and continue",
     "CommonTabTitle": "Apply to register as a Companies House authorised agent - GOV.UK",
     "Cancel": "Cancel",
+    "CancelUpdate": "Cancel update",
     "Edit": "Edit"
 }

--- a/locales/en/update-acsp-what-is-your-email.json
+++ b/locales/en/update-acsp-what-is-your-email.json
@@ -1,0 +1,5 @@
+{
+    "wellUseThisToSendInformationHint": "We'll use this to send information about the authorised agent account once the business is registered.",
+    "whatCorrespondenceWellSend": "What correspondence we'll send to the email address",
+    "wellUseThisToSendEssentialEmails": "We'll use this to send essential emails about the agent account. For example, if we need to:"
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -69,6 +69,7 @@ const BASE_UPDATE_ACSP_DETAILS_URL = `${BASE_VIEWS_URL}/update-acsp-details`;
 
 export const UPDATE_ACSP_DETAILS_HOME = `${BASE_UPDATE_ACSP_DETAILS_URL}/index/home`;
 export const UPDATE_YOUR_ANSWERS = `${BASE_UPDATE_ACSP_DETAILS_URL}/update-your-details`;
+export const UPDATE_WHAT_IS_YOUR_EMAIL = `${BASE_UPDATE_ACSP_DETAILS_URL}/what-is-your-email/what-is-your-email`;
 export const UPDATE_ACSP_DETAILS_APPLICATION_CONFIRMATION = `${BASE_UPDATE_ACSP_DETAILS_URL}/application-confirmation/application-confirmation`;
 export const UPDATE_ADD_AML_SUPERVISORY_BODY = `${BASE_UPDATE_ACSP_DETAILS_URL}/add-aml-supervisory-body/add-aml-supervisory-body`;
 export const UPDATE_CANCEL_ALL_UPDATES = `${BASE_UPDATE_ACSP_DETAILS_URL}/cancel-all-updates/cancel-all-updates`;

--- a/src/controllers/features/update-acsp/whatIsYourEmailAddressController.ts
+++ b/src/controllers/features/update-acsp/whatIsYourEmailAddressController.ts
@@ -8,9 +8,6 @@ import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/cons
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { saveDataInSession } from "../../../common/__utils/sessionHelper";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSPFullProfileDetails } from "../../../model/ACSPFullProfileDetails";
-import { getProfileDetails } from "../../../services/update-acsp/updateYourDetailsService";
-import { getBusinessName } from "../../../utils/web";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {

--- a/src/controllers/features/update-acsp/whatIsYourEmailAddressController.ts
+++ b/src/controllers/features/update-acsp/whatIsYourEmailAddressController.ts
@@ -1,0 +1,77 @@
+import { NextFunction, Request, Response } from "express";
+import * as config from "../../../config";
+import { BASE_URL, UPDATE_WHAT_IS_YOUR_EMAIL, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_ANSWERS } from "../../../types/pageURL";
+import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
+import { validationResult } from "express-validator";
+import { Session } from "@companieshouse/node-session-handler";
+import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { formatValidationError, getPageProperties } from "../../../validation/validation";
+import { saveDataInSession } from "../../../common/__utils/sessionHelper";
+import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
+import { ACSPFullProfileDetails } from "../../../model/ACSPFullProfileDetails";
+import { getProfileDetails } from "../../../services/update-acsp/updateYourDetailsService";
+import { getBusinessName } from "../../../utils/web";
+
+export const get = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lang = selectLang(req.query.lang);
+        const locales = getLocalesService();
+        const session: Session = req.session as any as Session;
+        const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
+        const previousPage = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang);
+        const currentUrl = BASE_URL + UPDATE_WHAT_IS_YOUR_EMAIL;
+
+        let payload = {};
+        if (acspUpdatedFullProfile.email === acspFullProfile.email) {
+            payload = {
+                whatIsYourEmailRadio: acspUpdatedFullProfile.email
+            };
+        } else {
+            payload = {
+                whatIsYourEmailRadio: "A Different Email",
+                whatIsYourEmailInput: acspUpdatedFullProfile.email
+            };
+        }
+        res.render(config.UPDATE_WHAT_IS_YOUR_EMAIL, {
+            ...getLocaleInfo(locales, lang),
+            previousPage,
+            currentUrl,
+            correspondenceEmail: acspFullProfile.email,
+            payload
+        });
+    } catch (err) {
+        next(err);
+    }
+};
+
+export const post = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lang = selectLang(req.query.lang);
+        const locales = getLocalesService();
+        const errorList = validationResult(req);
+        const session: Session = req.session as any as Session;
+        const previousPage = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang);
+        const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
+        if (!errorList.isEmpty()) {
+            const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
+            res.status(400).render(config.UPDATE_WHAT_IS_YOUR_EMAIL, {
+                previousPage,
+                correspondenceEmail: acspFullProfile.email,
+                payload: req.body,
+                ...getLocaleInfo(locales, lang),
+                currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_YOUR_EMAIL,
+                ...pageProperties
+            });
+        } else {
+            if (req.body.whatIsYourEmailRadio === "A Different Email") {
+                acspUpdatedFullProfile.email = req.body.whatIsYourEmailInput;
+                saveDataInSession(req, ACSP_DETAILS_UPDATED, acspUpdatedFullProfile);
+            }
+            res.redirect(previousPage);
+        }
+    } catch (err) {
+        next(err);
+    }
+};

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -84,6 +84,7 @@ export * as businessAddressManualController from "./features/update-acsp/busines
 export * as businessAddressAutoLookupController from "./features/update-acsp/businessAddressAutoLookupController";
 export * as businessAddressListController from "./features/update-acsp/businessAddressListController";
 export * as businessAddressConfirmController from "./features/update-acsp/businessAddressConfirmController";
+export * as updateWhatIsYourEmailAddressController from "./features/update-acsp/whatIsYourEmailAddressController";
 export * as cancelAnUpdateController from "./features/update-acsp/cancelAnUpdateController";
 export * as updateApplicationConfirmationController from "./features/update-acsp/applicationConfirmationController";
 export * as addAmlSupervisorController from "./features/update-acsp/addAmlSupervisorController";

--- a/src/routes/updateAcsp.ts
+++ b/src/routes/updateAcsp.ts
@@ -14,6 +14,7 @@ import {
     updateWhereDoYouLiveController,
     updateYourDetailsController,
     updateWhatIsTheBusinessNameController,
+    updateWhatIsYourEmailAddressController,
     cancelAnUpdateController,
     updateApplicationConfirmationController,
     addAmlSupervisorController,
@@ -34,6 +35,7 @@ import { businessAddressListValidator } from "../validation/businessAddressList"
 import { addAmlSupervisorValidator } from "../validation/addAmlSupervisor";
 import amlBodyMembershipNumberControllerValidator from "../validation/amlBodyMembershipNumber";
 import { yourUpdatesValidator } from "../validation/yourUpdates";
+import { whatIsYourEmailValidator } from "../validation/whatIsYourEmail";
 
 const updateRoutes = Router();
 
@@ -75,6 +77,9 @@ updateRoutes.post(urls.UPDATE_BUSINESS_ADDRESS_CONFIRM, businessAddressConfirmCo
 
 updateRoutes.get(urls.UPDATE_WHAT_IS_THE_BUSINESS_NAME, updateWhatIsTheBusinessNameController.get);
 updateRoutes.post(urls.UPDATE_WHAT_IS_THE_BUSINESS_NAME, unicorporatedWhatIsTheBusinessNameValidator, updateWhatIsTheBusinessNameController.post);
+
+updateRoutes.get(urls.UPDATE_WHAT_IS_YOUR_EMAIL, updateWhatIsYourEmailAddressController.get);
+updateRoutes.post(urls.UPDATE_WHAT_IS_YOUR_EMAIL, whatIsYourEmailValidator, updateWhatIsYourEmailAddressController.post);
 
 updateRoutes.get(urls.UPDATE_ADD_AML_SUPERVISOR, addAmlSupervisorController.get);
 updateRoutes.post(urls.UPDATE_ADD_AML_SUPERVISOR, addAmlSupervisorValidator, addAmlSupervisorController.post);

--- a/src/types/pageURL.ts
+++ b/src/types/pageURL.ts
@@ -188,6 +188,8 @@ export const UPDATE_CORRESPONDENCE_ADDRESS_LIST = "/select-your-correspondence-a
 
 export const UPDATE_WHAT_IS_THE_BUSINESS_NAME = "/what-is-the-business-name";
 
+export const UPDATE_WHAT_IS_YOUR_EMAIL = "/what-email-should-we-use";
+
 export const UPDATE_BUSINESS_ADDRESS_MANUAL = "/business-address-manual-entry";
 
 export const UPDATE_BUSINESS_ADDRESS_LOOKUP = "/business-address-lookup";

--- a/src/views/features/update-acsp-details/what-is-your-email/what-is-your-email.njk
+++ b/src/views/features/update-acsp-details/what-is-your-email/what-is-your-email.njk
@@ -1,0 +1,83 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% extends "layouts/default.njk" %}
+
+{% set title = i18n.whatEmailForCorrespondence %}
+{% block main_content %}
+    <form action="" method="POST">   
+    {% include "partials/csrf_token.njk" %}   
+    {% set textHtml %}
+        {{ govukInput({
+            label: {
+            text: i18n.emailAddressTextInput
+            },
+            errorMessage: {
+            text: errors.whatIsYourEmailInput.text
+            } if errors.whatIsYourEmailInput | length,
+            classes: "govuk-input",
+            id: "whatIsYourEmailInput",
+            name: "whatIsYourEmailInput",
+            value: payload.whatIsYourEmailInput
+        }) }}
+    {% endset -%}
+
+    {{ govukRadios({
+        errorMessage: errors.whatIsYourEmailRadio if errors,
+        name: "whatIsYourEmailRadio",
+        value: payload.whatIsYourEmailRadio,
+        classes: "govuk-radios",
+        fieldset: {
+            legend: {
+                text: i18n.whatEmailForCorrespondence,
+                classes: "govuk-fieldset__legend--l",
+                isPageHeading: true
+            }
+        },
+        hint: {
+            text: i18n.wellUseThisToSendInformationHint
+        },
+        items: [
+        {
+            value: correspondenceEmail,
+            text: correspondenceEmail
+        },
+        {
+            value: "A Different Email",
+            text: i18n.aDifferentEmailAddress,
+            id: "a-different-email-radio", 
+            conditional: {
+                html: textHtml
+            }
+        }
+      ]
+    }) }}
+
+    <details class="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            {{ i18n.whatCorrespondenceWellSend }}
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+            <p>{{ i18n.wellUseThisToSendEssentialEmails }}</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>{{ i18n.askForMoreInformation }}</li>
+                <li>{{ i18n.checkTheAgentIsComplying }}</li>
+                <li>{{ i18n.suspendTheAgentAccount }}</li>
+            </ul>
+            <p>{{ i18n.updateEmailAddressAfter }}</p>
+        </div>
+    </details>
+
+    <div class="govuk-button-group">
+        {{ govukButton({
+          text: i18n.Continue,
+          id: "continue-button-id"
+        })}}
+        <a class="govuk-link" id="cancel-id" href={{previousPage}}>{{i18n.CancelUpdate}}</a>
+    </div>
+
+    </form>
+{% endblock main_content %}

--- a/src/views/features/update-acsp-details/your-updates/your-updates.njk
+++ b/src/views/features/update-acsp-details/your-updates/your-updates.njk
@@ -134,7 +134,7 @@
     actions: {
         items: [
           {
-            href: "/view-and-update-the-authorised-agents-details/#?lang=" + lang,
+            href: "/view-and-update-the-authorised-agents-details/what-email-should-we-use?lang=" + lang,
             text: i18n.Edit,
             visuallyHiddenText: i18n.yourUpdatesCorrespondenceEmailAddress
           },

--- a/src/views/partials/update-your-details/limited-answers.njk
+++ b/src/views/partials/update-your-details/limited-answers.njk
@@ -76,7 +76,7 @@
         actions: {
             items: [
               {
-                href: "#",
+                href: "/view-and-update-the-authorised-agents-details/what-email-should-we-use" + "?lang=" + lang,
                 text: i18n.updateYourDetailsUpdate,
                 visuallyHiddenText: i18n.updateDetailsCorrespondenceEmail
               },

--- a/src/views/partials/update-your-details/sole-trader-answers.njk
+++ b/src/views/partials/update-your-details/sole-trader-answers.njk
@@ -135,7 +135,7 @@
         actions: {
             items: [
               {
-                href: "#",
+                href: "/view-and-update-the-authorised-agents-details/what-email-should-we-use" + "?lang=" + lang,
                 text: i18n.updateYourDetailsUpdate,
                 visuallyHiddenText: i18n.updateDetailsCorrespondenceEmail
               },

--- a/src/views/partials/update-your-details/unincorporated-answers.njk
+++ b/src/views/partials/update-your-details/unincorporated-answers.njk
@@ -111,7 +111,7 @@
         actions: {
             items: [
               {
-                href: "#",
+                href: "/view-and-update-the-authorised-agents-details/what-email-should-we-use" + "?lang=" + lang,
                 text: i18n.updateYourDetailsUpdate,
                 visuallyHiddenText: i18n.updateDetailsCorrespondenceEmail
               },

--- a/test/src/controllers/updateAcspDetails/whatIsYourEmailAddressController.test.ts
+++ b/test/src/controllers/updateAcspDetails/whatIsYourEmailAddressController.test.ts
@@ -1,0 +1,83 @@
+import mocks from "../../../mocks/all_middleware_mock";
+import supertest from "supertest";
+import app from "../../../../src/app";
+import * as localise from "../../../../src/utils/localise";
+import { UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_ANSWERS, UPDATE_WHAT_IS_YOUR_EMAIL } from "../../../../src/types/pageURL";
+
+jest.mock("@companieshouse/api-sdk-node");
+const router = supertest(app);
+
+describe("GET " + UPDATE_WHAT_IS_YOUR_EMAIL, () => {
+    it("should render the what email address should we use for correspondence page with status 200", async () => {
+        const res = await router.get(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_YOUR_EMAIL);
+        expect(res.status).toBe(200);
+        expect(res.text).toContain("What email address should we use for correspondence?");
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockUpdateAcspAuthenticationMiddleware).toHaveBeenCalled();
+    });
+    it("should return status 500 when an error occurs", async () => {
+        const errorMessage = "Test error";
+        jest.spyOn(localise, "selectLang").mockImplementationOnce(() => {
+            throw new Error(errorMessage);
+        });
+        const res = await router.get(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_YOUR_EMAIL);
+        expect(res.status).toBe(500);
+        expect(res.text).toContain("Sorry we are experiencing technical difficulties");
+    });
+});
+
+describe("POST " + UPDATE_WHAT_IS_YOUR_EMAIL, () => {
+    it("should redirect to UPDATE_YOUR_ANSWERS with status 302 for valid email input", async () => {
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_YOUR_EMAIL)
+            .send({
+                whatIsYourEmailRadio: "A Different Email",
+                whatIsYourEmailInput: "test@email.com"
+            });
+        expect(res.status).toBe(302);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockUpdateAcspAuthenticationMiddleware).toHaveBeenCalled();
+        expect(res.header.location).toBe(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS + "?lang=en");
+    });
+    it("should return status 400 after no email address entered", async () => {
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_YOUR_EMAIL)
+            .send({
+                whatIsYourEmailRadio: "A Different Email",
+                whatIsYourEmailInput: ""
+            });
+        expect(res.status).toBe(400);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockUpdateAcspAuthenticationMiddleware).toHaveBeenCalled();
+        expect(res.text).toContain("Enter an email address");
+    });
+    it("should return status 400 after no radio selected", async () => {
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_YOUR_EMAIL)
+            .send({
+                whatIsYourEmailRadio: "",
+                whatIsYourEmailInput: ""
+            });
+        expect(res.status).toBe(400);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockUpdateAcspAuthenticationMiddleware).toHaveBeenCalled();
+        expect(res.text).toContain("Enter an email address");
+    });
+    it("should return status 400 after incorrect data entered", async () => {
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_YOUR_EMAIL)
+            .send({
+                whatIsYourEmailRadio: "A Different Email",
+                whatIsYourEmailInput: "test"
+            });
+        expect(res.status).toBe(400);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockUpdateAcspAuthenticationMiddleware).toHaveBeenCalled();
+        expect(res.text).toContain("Enter an email address in the correct format, like name@example.com");
+    });
+    it("should show the error page if an error occurs", async () => {
+        const errorMessage = "Test error";
+        jest.spyOn(localise, "selectLang").mockImplementationOnce(() => {
+            throw new Error(errorMessage);
+        });
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_YOUR_EMAIL);
+        expect(res.status).toBe(500);
+        expect(res.text).toContain("Sorry we are experiencing technical difficulties");
+    });
+});


### PR DESCRIPTION
Changes made for ticket:
[IDVA5-1825](https://companieshouse.atlassian.net/browse/IDVA5-1825?atlOrigin=eyJpIjoiZGZhZDhkNDAxMDAwNDkyOGIxYzAyMjQ5MTIzNGJkYTciLCJwIjoiaiJ9)

- Added new controller for correspondence email within update acsp service
- Added routing to new screen
- Added new view file (as content of the screen differs from the email screen used in Registration service)
- Added locales files for update email screen (existing text is taken from what-is-your-email.json files - Registration service)
- Updated njk files to correctly route to new email screen
- Added unit tests

[IDVA5-1825]: https://companieshouse.atlassian.net/browse/IDVA5-1825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ