### PR TITLE
View and update details v4 prototype changes

### DIFF
--- a/locales/cy/update-your-details.json
+++ b/locales/cy/update-your-details.json
@@ -1,6 +1,6 @@
 {
     "updateYourDetailsHeading": "View and update the authorised agent's details Welsh",
-    "updateYourDetailsNote": "Any updates you make to the authorised agent's details are pending until you've submitted this filing, and we've accepted it Welsh",
+    "updateYourDetailsNote": "Any updates you make to the authorised agent’s details are pending until you submit this filing, and we accept it. welsh",
     "updateDetailsHeading": "Your details Welsh",
     "continueToPayment": "Parhau i dalu",
     "updateDetailsCorrespondenceAddress": "Correspondence address Welsh",
@@ -14,6 +14,7 @@
     "updateYourDetailsRegisteredOfficeAddress": "What is your registered office address Welsh?",
     "updateYourDetailsNameOfBusiness": "What is the name of your business Welsh?",
     "updateYourDetailsAMLMembershipDetails": "AML Membership Details Welsh",
+    "updateYourDetailsYouMustBeRegisteredAML": "You must be registered with one or more AML supervisory body. welsh",
     "addNewAMLDetails": "Add new AML details Welsh",
     "goBackToAuthorisedAgentServices": "Go back to authorised agent services Welsh"
 

--- a/locales/en/update-your-details.json
+++ b/locales/en/update-your-details.json
@@ -1,6 +1,6 @@
 {
     "updateYourDetailsHeading": "View and update the authorised agent's details",
-    "updateYourDetailsNote": "Any updates you make to the authorised agent's details are pending until you've submitted this filing, and we've accepted it",
+    "updateYourDetailsNote": "Any updates you make to the authorised agent’s details are pending until you submit this filing, and we accept it.",
     "updateDetailsHeading": "Your details",
     "continueToPayment": "Continue to payment",
     "updateDetailsCorrespondenceAddress": "Correspondence address",
@@ -16,6 +16,7 @@
     "updateYourDetailsRegisteredOfficeAddress": "What is your registered office address?",
     "updateYourDetailsNameOfBusiness": "What is the name of your business?",
     "updateYourDetailsAMLMembershipDetails": "AML Membership Details",
+    "updateYourDetailsYouMustBeRegisteredAML": "You must be registered with one or more AML supervisory body.",
     "addNewAMLDetails": "Add new AML details",
     "goBackToAuthorisedAgentServices": "Go back to authorised agent services",
     "updatedWarningCaption": "Details updated",

--- a/src/views/features/update-acsp-details/update-your-details.njk
+++ b/src/views/features/update-acsp-details/update-your-details.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% extends "layouts/default.njk" %}
 {% set amlList = [] %}
 {% for body in acspFullProfile.amlDetails %}
@@ -89,16 +90,23 @@
     {% set amlList = amlList.concat(amlSummaryObject) %}
 {% endfor %}
 
+{% set html %}
+<h3 class="govuk-notification-banner__heading">
+  {{ i18n.updateYourDetailsNote }}
+</h3>
+{% endset %}
+
 {% set title = i18n.updateYourDetailsHeading %}
+{% block defaultLayout %}
+<div class="govuk-grid-column-three-quarters" id="main-page-content">
 {% block main_content %}
+{{ govukNotificationBanner({
+    html: html,
+    titleText: i18n.important
+}) }}
     <form action="" method="post">
         {% include "partials/csrf_token.njk" %}
         <h1 class="govuk-heading-xl">{{ i18n.updateYourDetailsHeading }}</h1>
-        <div class="govuk-inset-text">
-            <p class="govuk-body">
-                {{ i18n.updateYourDetailsNote }}
-            </p>
-        </div>
         {% if acspFullProfile.type === "sole-trader" %}
             {% include "partials/update-your-details/sole-trader-answers.njk" %}
         {% elif acspFullProfile.type === "limited-company" or acspFullProfile.type === "limited-liability-partnership"  or acspFullProfile.type === "corporate-body"%}
@@ -107,6 +115,7 @@
             {% include "partials/update-your-details/unincorporated-answers.njk" %}
         {% endif %}
         <h2 class="govuk-heading-m">{{ i18n.checkYourAnswersAMLHeading }}</h2>
+        <p class="govuk-body">{{ i18n.updateYourDetailsYouMustBeRegisteredAML }}</p>
         <div class="govuk-button-group"> 
             {{ govukButton({
                 text: i18n.addNewAMLDetails,
@@ -134,3 +143,5 @@
         {% endif %}
     </form>
 {% endblock main_content %}
+</div>
+{% endblock defaultLayout %}

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -33,7 +33,9 @@
       <main class="govuk-main-wrapper " id="main-content">
         <div class="govuk-grid-row">
           {% include "partials/error_summary.njk" %}
+          {% block defaultLayout %}
           <div class="govuk-grid-column-two-thirds" id="main-page-content">{% block main_content %}{% endblock %}</div>
+          {% endblock %}
         </div>
       </main>
     </div>


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1812

Following changes made as part of v4 prototype:

- /update-your-details screen size changed from 2/3 to 3/4. I added a block around this in default.njk so I could override the class just for this screen in update-your-details.njk. Other screens remain 2/3 and have tested this in Registration also.
- blue notification banner added to the top
- inset text removed
- new content added in AML section