### PR TITLE
Updating service address to show country for sole trader

### DIFF
--- a/src/controllers/features/update-acsp/correspondenceAddressManualController.ts
+++ b/src/controllers/features/update-acsp/correspondenceAddressManualController.ts
@@ -9,7 +9,6 @@ import { Session } from "@companieshouse/node-session-handler";
 import countryList from "../../../../lib/countryListWithUKCountries";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
-import { BusinessAddressService } from "../../../services/business-address/businessAddressService";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -22,12 +21,11 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
         // Get existing correspondence address details and display on the page
         let payload;
+        const addressManualservice = new CorrespondenceAddressManualService();
         if (acspUpdatedFullProfile.type === "sole-trader") {
-            const addressManualservice = new BusinessAddressService();
-            payload = addressManualservice.getBusinessManualAddress(acspUpdatedFullProfile);
+            payload = addressManualservice.getCorrespondenceManualAddressUpdate(acspUpdatedFullProfile.registeredOfficeAddress);
         } else {
-            const addressManualservice = new CorrespondenceAddressManualService();
-            payload = addressManualservice.getCorrespondenceManualAddressUpdate(acspUpdatedFullProfile);
+            payload = addressManualservice.getCorrespondenceManualAddressUpdate(acspUpdatedFullProfile.serviceAddress);
         }
 
         res.render(config.CORRESPONDENCE_ADDRESS_MANUAL, {
@@ -63,15 +61,13 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             });
         } else {
         // update acspUpdatedFullProfile
+            const addressManualservice = new CorrespondenceAddressManualService();
             if (acspUpdatedFullProfile.type === "sole-trader") {
-                const addressManualservice = new BusinessAddressService();
-                addressManualservice.saveBusinessAddress(req, acspUpdatedFullProfile);
+                addressManualservice.saveManualAddressUpdate(req, acspUpdatedFullProfile, true);
             } else {
-                const addressManualservice = new CorrespondenceAddressManualService();
-                addressManualservice.saveCorrespondenceManualAddressUpdate(req, acspUpdatedFullProfile);
+                addressManualservice.saveManualAddressUpdate(req, acspUpdatedFullProfile, false);
             }
             session.setExtraData(ACSP_DETAILS_UPDATED, acspUpdatedFullProfile);
-
             // Redirect to the address confirmation page
             res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM, lang));
         }

--- a/src/services/correspondence-address/correspondence-address-manual.ts
+++ b/src/services/correspondence-address/correspondence-address-manual.ts
@@ -33,7 +33,7 @@ export class CorrespondenceAddressManualService {
         };
     }
 
-    public saveCorrespondenceManualAddressUpdate (req: Request, acspDetails: AcspFullProfile): void {
+    public saveManualAddressUpdate (req: Request, acspDetails: AcspFullProfile, isSoleTrader: boolean): void {
         // Extract correspondence address details from request body
         const correspondenceAddress: Address = {
             premises: req.body.addressPropertyDetails,
@@ -44,18 +44,25 @@ export class CorrespondenceAddressManualService {
             country: req.body.countryInput,
             postalCode: req.body.addressPostcode
         };
-        acspDetails.serviceAddress = correspondenceAddress;
+        if (isSoleTrader) {
+            acspDetails.registeredOfficeAddress = correspondenceAddress;
+        } else {
+            acspDetails.serviceAddress = correspondenceAddress;
+        }
     }
 
-    public getCorrespondenceManualAddressUpdate (acspDetails: AcspFullProfile) {
+    public getCorrespondenceManualAddressUpdate (address: Address | undefined) {
+        if (!address) {
+            return {};
+        }
         return {
-            addressPropertyDetails: acspDetails.serviceAddress?.premises,
-            addressLine1: acspDetails.serviceAddress?.addressLine1,
-            addressLine2: acspDetails.serviceAddress?.addressLine2,
-            addressTown: acspDetails.serviceAddress?.locality,
-            addressCounty: acspDetails.serviceAddress?.region,
-            countryInput: acspDetails.serviceAddress?.country,
-            addressPostcode: acspDetails.serviceAddress?.postalCode
+            addressPropertyDetails: address.premises,
+            addressLine1: address.addressLine1,
+            addressLine2: address.addressLine2,
+            addressTown: address.locality,
+            addressCounty: address.region,
+            countryInput: address.country,
+            addressPostcode: address.postalCode
         };
     }
 }

--- a/test/src/services/correspondence-address/correspondence-address-manual.test.ts
+++ b/test/src/services/correspondence-address/correspondence-address-manual.test.ts
@@ -151,7 +151,7 @@ describe("CorrespondenceAddressManualService", () => {
             addressPostcode: "EX1 1EX"
         };
 
-        service.saveCorrespondenceManualAddressUpdate(req, acspDetails);
+        service.saveManualAddressUpdate(req, acspDetails, false);
 
         expect(acspDetails.serviceAddress).toEqual({
             premises: "Suite 200",
@@ -175,7 +175,7 @@ describe("CorrespondenceAddressManualService", () => {
             postalCode: "TE5 5TL"
         };
 
-        const retrievedAddressUpdate = service.getCorrespondenceManualAddressUpdate(acspDetails);
+        const retrievedAddressUpdate = service.getCorrespondenceManualAddressUpdate(acspDetails.serviceAddress);
 
         expect(retrievedAddressUpdate).toEqual({
             addressPropertyDetails: "Suite 100",
@@ -191,7 +191,7 @@ describe("CorrespondenceAddressManualService", () => {
     test("getCorrespondenceManualAddressUpdate retrieves the correct address from acspDetails", () => {
         acspDetails.serviceAddress = undefined;
 
-        const retrievedAddressUpdate = service.getCorrespondenceManualAddressUpdate(acspDetails);
+        const retrievedAddressUpdate = service.getCorrespondenceManualAddressUpdate(acspDetails.serviceAddress);
 
         expect(retrievedAddressUpdate).toEqual({
             addressPropertyDetails: undefined,


### PR DESCRIPTION
This bug was preventing the country field being pre-populated when a sole trader updated their correspondence address and went to the manual address page.

Updated the getCorrespondenceManualAddressUpdate to accept an address and then used this to populate the fields. Previously it was using getBusinessManualAddress function which has a different input name for country field.