### PR TITLE
Fixing bugs on manual address screens

### DIFF
--- a/src/services/business-address/businessAddressService.ts
+++ b/src/services/business-address/businessAddressService.ts
@@ -31,11 +31,11 @@ export class BusinessAddressService {
     }
 
     // convert string to lowercase and capitalizing the first letter of each word
-    private formatCountry = (country: string|undefined) => {
-        if (country !== undefined) {
+    private formatCountry = (country: string | undefined) => {
+        if (country) {
             return country
                 .split(" ")
-                .map((word, index) => {
+                .map((word) => {
                     return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(); // Capitalize every word
                 })
                 .join(" ");

--- a/src/validation/correspondenceAddressManual.ts
+++ b/src/validation/correspondenceAddressManual.ts
@@ -7,7 +7,12 @@ const addressPostcodevaild:RegExp = /^[A-Za-z0-9\s]*$/;
 
 const manualCorrespondenceAddressValidator = [
 
-    body("countryInput", "countryIsMissing").notEmpty().bail().isIn(countryList.split(";")),
+    body("countryInput", "countryIsMissing").notEmpty().bail().custom((value: string) => {
+        if (!countryList.split(";").map((country) => country.toLowerCase()).includes(value.toLowerCase())) {
+            throw new Error("countryIsMissing");
+        }
+        return true;
+    }),
 
     body("addressPostcode").trim().toUpperCase().notEmpty().withMessage("noPostCode").bail()
         .custom((value: string, { req }) => {

--- a/test/src/controllers/updateAcspDetails/correspondenceAddressManualController.test.ts
+++ b/test/src/controllers/updateAcspDetails/correspondenceAddressManualController.test.ts
@@ -35,6 +35,13 @@ describe("POST" + UPDATE_CORRESPONDENCE_ADDRESS_MANUAL, () => {
         expect(res.status).toBe(302);
         expect(res.header.location).toBe(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM + "?lang=en");
     });
+    // Test for uppercase country name, will return 302.
+    it("should return status 302 after redirect", async () => {
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CORRESPONDENCE_ADDRESS_MANUAL)
+            .send({ addressPropertyDetails: "abc", addressLine1: "pqr", addressLine2: "pqr", addressTown: "lmn", addressCounty: "lmnop", countryInput: "ENGLAND", addressPostcode: "MK9 3GB" });
+        expect(res.status).toBe(302);
+        expect(res.header.location).toBe(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM + "?lang=en");
+    });
     // Test for no addressPropertyDetails, will return 400.
     it("should return status 400", async () => {
         const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CORRESPONDENCE_ADDRESS_MANUAL)


### PR DESCRIPTION
Allowing country on manual correspondence address screen to be entered in a case insensitive way as data from data sync comes back in call capitals.

Updating the country check in formatCountry function to check for null and undefined.