### PR TITLE
Remove button and add new text link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3417,9 +3417,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/src/controllers/features/update-acsp/updateYourDetailsController.ts
+++ b/src/controllers/features/update-acsp/updateYourDetailsController.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { selectLang, getLocalesService, getLocaleInfo, addLangToUrl } from "../../../utils/localise";
 import * as config from "../../../config";
-import { AML_MEMBERSHIP_NUMBER, UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, CANCEL_AN_UPDATE, UPDATE_ADD_AML_SUPERVISOR, REMOVE_AML_SUPERVISOR, UPDATE_CANCEL_ALL_UPDATES, UPDATE_CHECK_YOUR_UPDATES } from "../../../types/pageURL";
+import { AML_MEMBERSHIP_NUMBER, UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, CANCEL_AN_UPDATE, UPDATE_ADD_AML_SUPERVISOR, REMOVE_AML_SUPERVISOR, UPDATE_CANCEL_ALL_UPDATES, UPDATE_CHECK_YOUR_UPDATES, AUTHORISED_AGENT } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import { ACSP_DETAILS, ACSP_DETAILS_UPDATED, ADD_AML_BODY_UPDATE, NEW_AML_BODY } from "../../../common/__utils/constants";
 import { getProfileDetails } from "../../../services/update-acsp/updateYourDetailsService";
@@ -44,7 +44,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             removeAMLUrl,
             AMLSupervisoryBodies,
             AMLSupervioryBodiesFormatted,
-            cancelAllUpdatesUrl
+            cancelAllUpdatesUrl,
+            authorisedAgentUrl: AUTHORISED_AGENT
         });
     } catch (err) {
         next(err);

--- a/src/views/features/update-acsp-details/update-your-details.njk
+++ b/src/views/features/update-acsp-details/update-your-details.njk
@@ -123,11 +123,6 @@
                 id:"add-new-aml-details",
                 href: addAML
                 }) }}
-            {{ govukButton({
-                text: i18n.goBackToAuthorisedAgentServices,
-                classes: "govuk-button--secondary",
-                id:"go-back-to-authorised-agent-services"
-                }) }}
         </div>
         {{ govukSummaryList({
             rows: amlList
@@ -140,6 +135,8 @@
                     }) }}
                 <a class="govuk-link" href="{{ cancelAllUpdatesUrl }}" id="cancel-id">{{i18n.Cancel}}</a>
             </div>
+        {% else %}
+            <a class="govuk-link" href="{{ authorisedAgentUrl }}">{{i18n.goBackToAuthorisedAgentServices}}</a>
         {% endif %}
     </form>
 {% endblock main_content %}


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1812

Removed 'Go back to authorised agent services' button in AML details section and added it as text link at bottom of page to match the v4 prototype.

This text link will not be shown once an update has been made.