### PR TITLE
fixing redirection issue when using welsh toggle on 404 page

### DIFF
--- a/src/services/errorService.ts
+++ b/src/services/errorService.ts
@@ -18,7 +18,7 @@ export class ErrorService {
         res.status(404).render(config.ERROR_404, {
             title: "Page not found",
             ...getLocaleInfo(locales, lang),
-            currentUrl: req.url
+            currentUrl: req.originalUrl
         });
     }
 


### PR DESCRIPTION
Bug fix for ticket: [IDVA5-1946](https://companieshouse.atlassian.net/browse/IDVA5-1946?atlOrigin=eyJpIjoiNzEwNjVhYzc4N2E2NDBlN2IzNDFiZWU0NzMzOWMzMjkiLCJwIjoiaiJ9)

It was discovered that during test of the Welsh language, upon navigating to the 'Page not found screen' and selecting the Welsh language toggle, the user would be redirected to the URL chs.local/?lang=cy, rather than refreshing the page with Welsh language visible.

Updated the currentUrl value of the render404Page function to redirect to the original URL of the 404 page when using the Welsh language toggle

[IDVA5-1946]: https://companieshouse.atlassian.net/browse/IDVA5-1946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ