### PR TITLE
wording change on accessibility stament

### DIFF
--- a/src/views/common/accessibility-statement/accessibility-statement.njk
+++ b/src/views/common/accessibility-statement/accessibility-statement.njk
@@ -213,7 +213,7 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>work with real users who have accessibility issues to make sure that our services meet their needs</li>
         <li>carry out internal tests for compliance with Web Content Accessibility Guidelines V2.2 level A and level AA</li>
-        <li>recruit customers through
+        <li>recruit users through
           <a class="govuk-link" href="https://www.gov.uk/government/news/help-improve-companies-house">our user panel</a>
           and agencies to take part in usability sessions</li>
         <li>build and test our services to meet

--- a/src/views/common/accessibility-statement/accessibility-statement.njk
+++ b/src/views/common/accessibility-statement/accessibility-statement.njk
@@ -62,7 +62,6 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>the language setting of some pages cannot be determined by screen readers or other assistive technologies</li>
         <li>some pages have titles that do not uniquely describe their topic or purpose</li>
-        <li>some pages require the user to re-enter data they have previously entered</li>
         <li>some pages lack a correct heading hierarchy</li>
         <li>some pages lack correctly labelled form fields</li>
         <li>some forms do not feature the necessary fieldset component</li>
@@ -124,12 +123,6 @@
           We plan to fix this issue by April 2025.
         </li>
         <li>
-          On some pages, previously entered data has not been used to pre-populate 
-          form fields to avoid redundant re-entry. This fails WCAG 2.2 success 
-          criteria 3.3.7 Redundant Entry (Level 
-          A) and 4.1.2 Name, Role, Value (Level A). We plan to fix this issue by April 2025.
-        </li>
-        <li>
           On some pages, information, structure, and relationships conveyed 
           through presentation cannot be programmatically determined or is not 
           available in text. This fails WCAG 2.2 success criterion 1.3.1 Info and 
@@ -145,11 +138,6 @@
           On some pages, related form controls are not grouped within a fieldset. 
           This fails WCAG 2.2 success criterion 1.3.1 Info and Relationships (Level A). 
           We plan to fix this issue by April 2025.
-        </li>
-        <li>
-          An email confirmation prevents users from pasting data into the input. This 
-          fails WCAG 2.2 success criterion 3.3.7 Redundant Entry (Level A). We plan 
-          to fix this issue by April 2025.
         </li>
         <li>
           On some pages, text which visually labels a component does not 


### PR DESCRIPTION
Wording update 'customers' to 'users' to match prototype
Removing text content from accessibility statement that are redundant for the Registration service (following confirmation from PM for removal)