### PR TITLE
Updating the manual business address to not show an update if the country does not change

### DIFF
--- a/src/controllers/features/update-acsp/businessAddressManualController.ts
+++ b/src/controllers/features/update-acsp/businessAddressManualController.ts
@@ -57,7 +57,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         } else {
         // update acspUpdatedFullProfile
             const businessAddressService = new BusinessAddressService();
-            businessAddressService.saveBusinessAddressUpdate(req, acspUpdatedFullProfile, acspFullProfile);
+            businessAddressService.saveBusinessAddressUpdate(req, acspFullProfile, acspUpdatedFullProfile);
             session.setExtraData(ACSP_DETAILS_UPDATED, acspUpdatedFullProfile);
 
             // Redirect to the address confirmation page

--- a/src/controllers/features/update-acsp/businessAddressManualController.ts
+++ b/src/controllers/features/update-acsp/businessAddressManualController.ts
@@ -6,7 +6,7 @@ import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../.
 import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_BUSINESS_ADDRESS_MANUAL, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 import { BusinessAddressService } from "../../../services/business-address/businessAddressService";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -41,6 +41,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const previousPage: string = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP, lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
         const locales = getLocalesService();
         const errorList = validationResult(req);
         if (!errorList.isEmpty()) {
@@ -56,7 +57,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         } else {
         // update acspUpdatedFullProfile
             const businessAddressService = new BusinessAddressService();
-            businessAddressService.saveBusinessAddress(req, acspUpdatedFullProfile);
+            businessAddressService.saveBusinessAddressUpdate(req, acspUpdatedFullProfile, acspFullProfile);
             session.setExtraData(ACSP_DETAILS_UPDATED, acspUpdatedFullProfile);
 
             // Redirect to the address confirmation page

--- a/src/services/business-address/businessAddressService.ts
+++ b/src/services/business-address/businessAddressService.ts
@@ -4,7 +4,7 @@ import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile
 
 export class BusinessAddressService {
 
-    public saveBusinessAddress (req: Request, acspData: AcspData | AcspFullProfile): void {
+    public saveBusinessAddress (req: Request, acspData: AcspData): void {
         // Extract business address details from request body
         const businessAddress: Address = {
             premises: req.body.addressPropertyDetails,
@@ -16,6 +16,21 @@ export class BusinessAddressService {
             postalCode: req.body.addressPostcode
         };
         acspData.registeredOfficeAddress = businessAddress;
+    }
+
+    public saveBusinessAddressUpdate (req: Request, acspFullProfile: AcspFullProfile, acspUpdatedFullProfile: AcspFullProfile): void {
+        const originalCountry = acspFullProfile.registeredOfficeAddress.country;
+        // Extract business address details from request body
+        const businessAddress: Address = {
+            premises: req.body.addressPropertyDetails,
+            addressLine1: req.body.addressLine1,
+            addressLine2: req.body.addressLine2,
+            locality: req.body.addressTown,
+            region: req.body.addressCounty,
+            country: req.body.addressCountry.toUpperCase() === originalCountry?.toUpperCase() ? originalCountry : req.body.addressCountry,
+            postalCode: req.body.addressPostcode
+        };
+        acspUpdatedFullProfile.registeredOfficeAddress = businessAddress;
     }
 
     public getBusinessManualAddress (acspData: AcspData | AcspFullProfile) {


### PR DESCRIPTION
Updating the manual business address to not show an update if the country does not change
Previously it was changing the address to be lower case and so showing as an update. This change checks to see if the countries are the same when case is ignored