### PR TITLE
Fixing technical error screen being shown when resuming from filings

### DIFF
--- a/test/mocks/transaction_mock.ts
+++ b/test/mocks/transaction_mock.ts
@@ -23,7 +23,15 @@ export const mockOpenTransaction: Transaction = {
     id: "119709-207817-181835",
     status: "open",
     reference: REFERENCE,
-    description: "Mandatory transaction description"
+    description: "Mandatory transaction description",
+    resources: {
+        "/transactions/119709-207817-181835/authorised-corporate-service-provider-applications/Y2VkZWVlMzhlZWFjY2M4MzQ3MT": {
+            kind: "acsp",
+            links: {
+                resource: ""
+            }
+        }
+    }
 };
 
 export const mockClosedPendingPaymentTransaction: Transaction = {

--- a/test/src/controllers/common/resumeJourneyController.test.ts
+++ b/test/src/controllers/common/resumeJourneyController.test.ts
@@ -26,6 +26,15 @@ describe("GET resume journey", () => {
         expect(res.header.location).toBe(BASE_URL + TYPE_OF_BUSINESS + "?lang=en");
     });
 
+    it("should return status 302 and redirect to type of business screen if transaction is open even if no acspId returned", async () => {
+        mockGetTransaction.mockResolvedValueOnce(mockOpenTransaction);
+        const res = await router.get(BASE_URL + "/resume?transactionId=119709-207817-181835");
+        expect(res.status).toBe(302);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+        expect(res.header.location).toBe(BASE_URL + TYPE_OF_BUSINESS + "?lang=en");
+    });
+
     it("should return status 302 and redirect to payment if transaction is closed pending payment", async () => {
         mockGetTransaction.mockResolvedValueOnce(mockClosedPendingPaymentTransaction);
         mockStartPaymentsSession.mockResolvedValueOnce(dummyPaymentResponse);


### PR DESCRIPTION
The technical error screen was showing when resuming from filings because when the user is redirected to login the acspId query parameter is lost. This resulted in the user being shown a technical error page due to the get request failing with no application Id

Fix: Getting applicationId from the transaction if it does not get returned by the resume journey link

Also removing code smells from this file