### PR TITLE
Fixing accessibility issues on links opening in a new tab

### DIFF
--- a/locales/cy/common.json
+++ b/locales/cy/common.json
@@ -7,5 +7,6 @@
     "SignOut": "Allgofnodi",
     "AcceptAndContinue": "Derbyn a pharhau",
     "CommonTabTitle": "Gwneud cais i gofrestru fel asiant awdurdodedig Tŷ'r Cwmnïau - GOV.UK",
-    "Cancel": "Canslo"
+    "Cancel": "Canslo",
+    "openInNewTab": "opens in a new tab Welsh"
 }

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -9,5 +9,6 @@
     "CommonTabTitle": "Apply to register as a Companies House authorised agent - GOV.UK",
     "Cancel": "Cancel",
     "CancelUpdate": "Cancel update",
-    "Edit": "Edit"
+    "Edit": "Edit",
+    "openInNewTab": "opens in a new tab"
 }

--- a/src/views/common/application-confirmation/application-confirmation.njk
+++ b/src/views/common/application-confirmation/application-confirmation.njk
@@ -19,7 +19,7 @@
   <div class="govuk-tag--grey govuk-!-padding-4">
     <h2 class="govuk-heading-m">{{ i18n.applicationSubmittedHeading1 }}</h2>
     <p class="govuk-body">
-      {{ i18n.applicationSubmittedText2 }} <a href={{ feedbackLink }} class="govuk-link govuk-link--no-visited-state" target="_blank">{{i18n.applicationSubmittedLink1}}</a> {{ i18n.applicationSubmittedText3 }}
+      {{ i18n.applicationSubmittedText2 }} <a href={{ feedbackLink }} class="govuk-link govuk-link--no-visited-state" target="_blank">{{i18n.applicationSubmittedLink1}} {{ i18n.openInNewTab }}</a> {{ i18n.applicationSubmittedText3 }}
     </p>
   </div>
 
@@ -30,7 +30,7 @@
   <p class="govuk-body">{{ i18n.applicationSubmittedText7 }}</p>
   <p class="govuk-body">
     {{ i18n.applicationSubmittedText8 }} 
-    <a target="_blank" href="https://www.gov.uk/guidance/applying-to-register-as-a-companies-house-authorised-agent" id="Read the guidance-id">{{ i18n.applicationSubmittedGuidanceLink }}</a>
+    <a target="_blank" href="https://www.gov.uk/guidance/applying-to-register-as-a-companies-house-authorised-agent" id="Read the guidance-id">{{ i18n.applicationSubmittedGuidanceLink }} {{ i18n.openInNewTab }}</a>
     {{ i18n.applicationSubmittedText9 }}
   </p>
 

--- a/src/views/common/index/home.njk
+++ b/src/views/common/index/home.njk
@@ -73,7 +73,7 @@
       <li>{{ i18n.registrationFeeBullet | replace('XX', ACSP01_COST) }}</li>
     </ul>
     <p class="govuk-body">
-      {{ i18n.readThe }}<a target="_blank" href="https://www.gov.uk/guidance/applying-to-register-as-a-companies-house-authorised-agent" id="Read the guidance-id">{{ i18n.guidanceOnApplyingLink }}</a>{{ i18n.toCheckYouHave }}
+      {{ i18n.readThe }}<a href="https://www.gov.uk/guidance/applying-to-register-as-a-companies-house-authorised-agent" id="Read the guidance-id">{{ i18n.guidanceOnApplyingLink }}</a>{{ i18n.toCheckYouHave }}
     </p>
     <p class="govuk-body">{{ i18n.saveYourAnswers }}</p>
     <div class="ch-info-panel ch-info-panel-custom">
@@ -100,18 +100,18 @@
     </button>
     <h2 class="govuk-heading-m">{{ i18n.helpToApplyOnlineHeading }}</h2>
     <p class="govuk-body">
-      <a href="https://www.gov.uk/contact-companies-house" target="_blank" id="contact-us-start-page-id">{{ i18n.contactUsStartPageLink }}</a>
+      <a href="https://www.gov.uk/contact-companies-house" id="contact-us-start-page-id">{{ i18n.contactUsStartPageLink }}</a>
       {{ i18n.ifYouNeedHelpToUseThisService }}
     </p>
     <h2 class="govuk-heading-m">{{ i18n.adaptYourDeviceHeading }}</h2>
     <p class="govuk-body">
-      <a href={{ abilityNetAccessibilityLink }} target="_blank" id="read-the-advice-from-abilitynet-id">{{ i18n.readAdviceFromAbilityNetLink }}</a>{{ i18n.forExampleLearnHowTo }}
+      <a href={{ abilityNetAccessibilityLink }} id="read-the-advice-from-abilitynet-id">{{ i18n.readAdviceFromAbilityNetLink }}</a>{{ i18n.forExampleLearnHowTo }}
     </p>
     <h2 class="govuk-heading-m">{{ i18n.afterYouRegisterHeading }}</h2>
     <p class="govuk-body">{{ i18n.wellCreateAnAuthorisedAgentAccount }}</p>
     <p class="govuk-body">
       {{ i18n.readThe }}
-      <a target="_blank" href="https://www.gov.uk/guidance/being-an-authorised-corporate-service-provider" id="guidance-for-authorised-agents-id">{{ i18n.guidanceForAuthorisedAgentsLink }}</a>
+      <a href="https://www.gov.uk/guidance/being-an-authorised-corporate-service-provider" id="guidance-for-authorised-agents-id">{{ i18n.guidanceForAuthorisedAgentsLink }}</a>
       {{ i18n.toFindOutHowToUse }}
     </p>
   </form>

--- a/src/views/common/stop-not-relevant-officer/stop-not-relevant-officer.njk
+++ b/src/views/common/stop-not-relevant-officer/stop-not-relevant-officer.njk
@@ -18,7 +18,7 @@
     <li>{{ i18n.kickoutSoleTrader }}</li>
   </ul>
   <p class="govuk-body">
-    <a target="_blank" href="https://www.gov.uk/guidance/applying-to-register-as-a-companies-house-authorised-agent" class="govuk-link govuk-link--no-visited-state" id= "guidance-link">{{ i18n.guidancePageText }} </a>
+    <a href="https://www.gov.uk/guidance/applying-to-register-as-a-companies-house-authorised-agent" class="govuk-link govuk-link--no-visited-state" id= "guidance-link">{{ i18n.guidancePageText }} </a>
     {{ i18n.moreInformation }}
   </p>
 {% endblock %}

--- a/src/views/features/limited/company-number/company-number.njk
+++ b/src/views/features/limited/company-number/company-number.njk
@@ -39,7 +39,7 @@
               rel="noreferrer noopener"
               target="_blank"
               id="find-company-number-link">
-              {{ i18n.linkWhereToHowGetCompanyNumer }}
+              {{ i18n.linkWhereToHowGetCompanyNumer }} {{ i18n.openInNewTab }}
             </a>
           </div>
         </details>

--- a/src/views/partials/__header.njk
+++ b/src/views/partials/__header.njk
@@ -14,9 +14,7 @@
       </strong>
       <span class="govuk-phase-banner__text">
         This is a new service – your 
-        <a class="govuk-link" href="{{ feedbackLink | default('https://www.smartsurvey.co.uk/s/reg-as-acsp-fdbk/') }}" target="_blank" rel="noopener noreferrer">
-          feedback
-        </a> 
+        <a class="govuk-link" href="{{ feedbackLink | default('https://www.smartsurvey.co.uk/s/reg-as-acsp-fdbk/') }}" {% if currentUrl !== "/register-as-companies-house-authorised-agent" and currentUrl !== "/register-as-companies-house-authorised-agent/cannot-use-service" %} target="_blank" {% endif %} rel="noopener noreferrer">feedback{% if currentUrl !== "/register-as-companies-house-authorised-agent" and currentUrl !== "/register-as-companies-house-authorised-agent/cannot-use-service" %}(opens in a new tab){% endif %}</a>
         will help us to improve it.
       </span>
     </p>

--- a/src/views/partials/cookie_consent_banner.njk
+++ b/src/views/partials/cookie_consent_banner.njk
@@ -7,12 +7,12 @@
 
 {% set acceptHtml %}
  <p>{{ i18n.acceptedAnalyticsCookies }} {{ i18n.changeCookie1 }} <a class="govuk-link" target="_blank" rel="noopener noreferrer"
- href="{{ CHS_URL }}/help/cookies">{{ i18n.changeCookie2 }}</a> {{ i18n.changeCookie3 }}</p>
+ href="{{ CHS_URL }}/help/cookies">{{ i18n.changeCookie2 }} {{ i18n.openInNewTab }}</a> {{ i18n.changeCookie3 }}</p>
 {% endset %}
 
 {% set rejectHtml %}
  <p>{{ i18n.rejectedAnalyticsCookies }} {{ i18n.changeCookie1 }} <a class="govuk-link" target="_blank" rel="noopener noreferrer" 
- href="{{ CHS_URL }}/help/cookies">{{ i18n.changeCookie2 }}</a> {{ i18n.changeCookie3 }}</p>
+ href="{{ CHS_URL }}/help/cookies">{{ i18n.changeCookie2 }} {{ i18n.openInNewTab }}</a> {{ i18n.changeCookie3 }}</p>
 {% endset %}
 
 {{ govukCookieBanner({
@@ -49,7 +49,7 @@
       }
       },
       {
-        text: i18n.viewCookies,
+        text: i18n.viewCookies + " " + i18n.openInNewTab,
         href: chsUrl + "/help/cookies",
         attributes: {
           target: "_blank",


### PR DESCRIPTION
Adding opens in new tab to feedback and guidance links except on the start page where they open in the same tab