### PR TITLE
Adding lang query paramter to form actions to retain language selection

### DIFF
--- a/src/views/common/address-correspondance-selector/address-correspondance-selector.njk
+++ b/src/views/common/address-correspondance-selector/address-correspondance-selector.njk
@@ -22,7 +22,7 @@
         {% set optionalFields = optionalFields + businessAddress.country + ", " %}
     {% endif %}
 
-    <form action="{{ currentUrl }}" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         {% if businessName %}
             {% include "partials/business_name.njk" %}

--- a/src/views/common/aml-body-number/aml-body-number.njk
+++ b/src/views/common/aml-body-number/aml-body-number.njk
@@ -5,7 +5,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.amlMembershipTitle %}
 {% block main_content %}
-    <form action="{{ currentUrl }}" method="post">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="post">
         {% include "partials/csrf_token.njk" %}
         <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/src/views/common/check-aml-details/check-aml-details.njk
+++ b/src/views/common/check-aml-details/check-aml-details.njk
@@ -5,7 +5,7 @@
 {% set title = i18n.checkAmlDetailsTitle %}
 {% block main_content %}
 
-  <form action="{{ currentUrl }}" method="post" class="form">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="post" class="form">
     {% include "partials/csrf_token.njk" %}
     {% if typeOfBusiness === "SOLE_TRADER" %}
         {% include "partials/user_name.njk" %}

--- a/src/views/common/check-your-answers/check-your-answers.njk
+++ b/src/views/common/check-your-answers/check-your-answers.njk
@@ -27,7 +27,7 @@
 
 {% set title = i18n.checkYourAnswersHeading %}
 {% block main_content %}
-    <form action="{{ currentUrl }}" method="post">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="post">
         {% include "partials/csrf_token.njk" %}
         <h1 class="govuk-heading-xl">{{ i18n.checkYourAnswersHeading }}</h1>
         {% if typeOfBusiness === "SOLE_TRADER" %}

--- a/src/views/common/correspondence-address-confirm/correspondence-address-confirm.njk
+++ b/src/views/common/correspondence-address-confirm/correspondence-address-confirm.njk
@@ -3,7 +3,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.correspondenceAddressConfirmTitle %}
 {% block main_content %}
-  <form class="form" action="{{ currentUrl }}" method="post">
+  <form class="form" action="{{ currentUrl }}?lang={{ lang }}" method="post">
     {% include "partials/csrf_token.njk" %}
     {% if businessName %}
       {% include "partials/business_name.njk" %}

--- a/src/views/common/correspondence-address-manual/capture-correspondence-address-manual.njk
+++ b/src/views/common/correspondence-address-manual/capture-correspondence-address-manual.njk
@@ -7,7 +7,7 @@
 {% set errors = pageProperties.errors %}
 {% set title = i18n.correspondenceAddressManualTitle %}
 {% block main_content %}
-<form action="{{ currentUrl }}" method="POST">
+<form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {% if businessName %}
         {% include "partials/business_name.njk" %}

--- a/src/views/common/correspondence-auto-lookup-address/auto-lookup-address.njk
+++ b/src/views/common/correspondence-auto-lookup-address/auto-lookup-address.njk
@@ -5,7 +5,7 @@
 {% set errors = pageProperties.errors %}
 {% set title = i18n.correspondenceLookUpAddressTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {% if businessName %}
       {% include "partials/business_name.njk" %}

--- a/src/views/common/correspondence-auto-lookup-address/correspondence-address-list.njk
+++ b/src/views/common/correspondence-auto-lookup-address/correspondence-address-list.njk
@@ -17,7 +17,7 @@
         {% set ITEMS = ITEMS.concat(addressObject) %}
     {% endfor %}
     {# Form section #}
-    <form action="{{ currentUrl }}" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         {% if businessName %}
             {% include "partials/business_name.njk" %}

--- a/src/views/common/index/home.njk
+++ b/src/views/common/index/home.njk
@@ -16,7 +16,7 @@
 {% set title = "" %}
 {% set matomoPageTitle = i18n.startPageTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {{ govukNotificationBanner({
       html: html,

--- a/src/views/common/name-registered-with-aml/name-registered-with-aml.njk
+++ b/src/views/common/name-registered-with-aml/name-registered-with-aml.njk
@@ -4,7 +4,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.nameRegisteredWithAmlTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {{ govukRadios({
       errorMessage: errors.nameRegisteredWithAml if errors,

--- a/src/views/common/name/capture-name.njk
+++ b/src/views/common/name/capture-name.njk
@@ -4,7 +4,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.whatIsYourNameTitle %}
 {% block main_content %}
-    <form action="{{ currentUrl }}" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         <div class="govuk-form-group">
             <h1 class="govuk-heading-l">{{ i18n.whatIsYourNameTitle }}</h1>

--- a/src/views/common/other-type-of-business/other-type-of-business.njk
+++ b/src/views/common/other-type-of-business/other-type-of-business.njk
@@ -3,7 +3,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.otherTypeOfBusinessTitle %}
 {% block main_content %}
-    <form action="{{ currentUrl }}" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
        {% include "partials/csrf_token.njk" %}
        {% include "partials/user_name.njk" %}
         <div class="govuk-form-group">

--- a/src/views/common/saved-application/saved-application.njk
+++ b/src/views/common/saved-application/saved-application.njk
@@ -3,7 +3,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.savedTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {{ govukRadios({
       errorMessage: errors.savedApplication if errors,

--- a/src/views/common/sector-you-work-in/sector-you-work-in.njk
+++ b/src/views/common/sector-you-work-in/sector-you-work-in.njk
@@ -4,7 +4,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.sectorYouWorkInTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {% if acspType == "SOLE_TRADER" %}
       {% include "partials/user_name.njk" %}

--- a/src/views/common/select-aml-supervisory-bodies/select-aml-supervisory-bodies.njk
+++ b/src/views/common/select-aml-supervisory-bodies/select-aml-supervisory-bodies.njk
@@ -15,7 +15,7 @@
 {% endfor %}
 {% set title = i18n.selectAmlSupervisorTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {% if acspType == "SOLE_TRADER" %}
       {% include "partials/user_name.njk" %}

--- a/src/views/common/sign-out-page/sign-out.njk
+++ b/src/views/common/sign-out-page/sign-out.njk
@@ -10,7 +10,7 @@
 
 {% set title = i18n.signoutTitle %}
 {% block main_content %}
-	<form action="{{ currentUrl }}" method="POST">
+	<form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
 	    {% include "partials/csrf_token.njk" %}
 		{{ govukRadios({
 			errorMessage: errors.signout if errors,

--- a/src/views/common/type-of-business/type-of-business.njk
+++ b/src/views/common/type-of-business/type-of-business.njk
@@ -3,7 +3,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.typeOfBusinessTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {% include "partials/user_name.njk" %}
     {{ govukRadios({

--- a/src/views/common/what-is-the-business-name/what-is-the-business-name.njk
+++ b/src/views/common/what-is-the-business-name/what-is-the-business-name.njk
@@ -5,7 +5,7 @@
 
 {% set title = i18n.whatIsTheBusinessNameTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="POST">  
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">  
     {% include "partials/csrf_token.njk" %}  
     {{ govukInput({
       label: {

--- a/src/views/common/what-is-your-email/what-is-your-email.njk
+++ b/src/views/common/what-is-your-email/what-is-your-email.njk
@@ -6,7 +6,7 @@
 
 {% set title = i18n.whatIsYourEmailAddressTitle %}
 {% block main_content %}
-    <form action="{{ currentUrl }}" method="POST">   
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">   
     {% include "partials/csrf_token.njk" %}   
     {% set textHtml %}
         {{ govukInput({

--- a/src/views/common/what-is-your-role/what-is-your-role.njk
+++ b/src/views/common/what-is-your-role/what-is-your-role.njk
@@ -4,7 +4,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.whatIsYourRoleTitle %}
 {% block main_content %}
-    <form action="{{ currentUrl }}" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         <div class="govuk-form-group">
             {{ govukRadios({

--- a/src/views/common/which-sector-other/which-sector-other.njk
+++ b/src/views/common/which-sector-other/which-sector-other.njk
@@ -4,7 +4,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.whichSectorOtherTitle %}
 {% block main_content %}
-    <form action="{{ currentUrl }}" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %} 
         {% if acspType == "SOLE_TRADER" %}
            {% include "partials/user_name.njk" %}

--- a/src/views/common/your-responsibilities/your-responsibilities.njk
+++ b/src/views/common/your-responsibilities/your-responsibilities.njk
@@ -4,7 +4,7 @@
 {% set title = i18n.yourResponsibilitiesTitle %}
 
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="post">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="post">
     {% include "partials/csrf_token.njk" %}
     {% if typeOfBusiness === "SOLE_TRADER" %}
       {% include "partials/user_name.njk" %}

--- a/src/views/features/close-acsp/index/home.njk
+++ b/src/views/features/close-acsp/index/home.njk
@@ -8,7 +8,7 @@
 
 {% block main_content %}
 
-  <form action="{{ currentUrl }}" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
       <h1 class="govuk-heading-l">
         {{ i18n.startPageTitleCloseAcsp }}

--- a/src/views/features/limited/business-mustbe-aml-registered/business-mustbe-aml-registered.njk
+++ b/src/views/features/limited/business-mustbe-aml-registered/business-mustbe-aml-registered.njk
@@ -9,7 +9,7 @@
   {% endblock %}
 {% set title = i18n.amlInterruptTitle %}
 {% block main_content %}
-    <form action="{{ currentUrl }}" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         <h1 class="govuk-heading-l">{{ i18n.amlInterruptTitle }}</h1>
         <p class="govuk-body">{{ i18n.text1 }}</p>

--- a/src/views/features/limited/company-number/company-number.njk
+++ b/src/views/features/limited/company-number/company-number.njk
@@ -4,7 +4,7 @@
 {% set errors = pageProperties.errors %}
 {% set title = i18n.companyNumberTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     <div class="govuk-form-group">
       {{ govukInput({

--- a/src/views/features/limited/is-this-your-company/is-this-your-company.njk
+++ b/src/views/features/limited/is-this-your-company/is-this-your-company.njk
@@ -4,7 +4,7 @@
 {% set title = i18n.isThisYourCompany %}
 {% block main_content %}
   <!-- The action will need to change depending on the location of the confirm-company page -->
-  <form action="{{ currentUrl }}" method="post">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="post">
     {% include "partials/csrf_token.njk" %}
     <h1 class="govuk-heading-l">{{i18n.isThisYourCompany}}</h1>
     <dl class="govuk-summary-list">

--- a/src/views/features/limited/name-registered-with-aml/name-registered-with-aml.njk
+++ b/src/views/features/limited/name-registered-with-aml/name-registered-with-aml.njk
@@ -4,7 +4,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.nameRegisteredWithAmlTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {{ govukRadios({
       errorMessage: errors.nameRegisteredWithAml if errors,

--- a/src/views/features/sole-trader/nationality/nationality.njk
+++ b/src/views/features/sole-trader/nationality/nationality.njk
@@ -8,7 +8,7 @@
         {% set dropdownTwoError =  errors.nationality_input_1 %}
         {% set dropdownThreeError =  errors.nationality_input_2 %}
     {% endif %}
-    <form action="{{ currentUrl }}" method="post">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="post">
         {% include "partials/csrf_token.njk" %}
         <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/src/views/features/sole-trader/what-is-the-business-name/what-is-the-business-name.njk
+++ b/src/views/features/sole-trader/what-is-the-business-name/what-is-the-business-name.njk
@@ -5,7 +5,7 @@
 
 {% set title = i18n.whatIsTheBusinessNameTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="POST">     
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">     
     {% include "partials/csrf_token.njk" %} 
     {% set textHtml %}
       {{ govukInput({

--- a/src/views/features/sole-trader/what-is-your-date-of-birth/what-is-your-date-of-birth.njk
+++ b/src/views/features/sole-trader/what-is-your-date-of-birth/what-is-your-date-of-birth.njk
@@ -17,7 +17,7 @@
   {% endif %}
 
   <div>
-    <form action="{{ currentUrl }}" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
       {% include "partials/csrf_token.njk" %}
       {% include "partials/user_name.njk" %}
       

--- a/src/views/features/sole-trader/where-do-you-live/where-do-you-live.njk
+++ b/src/views/features/sole-trader/where-do-you-live/where-do-you-live.njk
@@ -3,7 +3,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.whereDoYouLiveTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="post">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="post">
     {% include "partials/csrf_token.njk" %}
     {% include "partials/user_name.njk" %}
     {% set countryInput %}

--- a/src/views/features/unincorporated/business-address-auto-lookup/auto-lookup-address.njk
+++ b/src/views/features/unincorporated/business-address-auto-lookup/auto-lookup-address.njk
@@ -10,7 +10,7 @@
 {% endif %}
 {% block main_content %}
   <div class="govuk-width-container">
-    <form action="{{ currentUrl }}" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
       {% include "partials/csrf_token.njk" %}
       {% if businessName %}
         {% include "partials/business_name.njk" %}

--- a/src/views/features/unincorporated/business-address-auto-lookup/business-address-list.njk
+++ b/src/views/features/unincorporated/business-address-auto-lookup/business-address-list.njk
@@ -17,7 +17,7 @@
     {% set ITEMS = ITEMS.concat(addressObject) %}
 {% endfor %}
     {# Form section #}
-    <form action="{{ currentUrl }}" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %}
         {% if businessName %}
             {% include "partials/business_name.njk" %}

--- a/src/views/features/unincorporated/business-address-manual-entry/business-address-manual-entry.njk
+++ b/src/views/features/unincorporated/business-address-manual-entry/business-address-manual-entry.njk
@@ -13,7 +13,7 @@
   {% set legendHeader = i18n.businessAddressManualTitle %}
 {% endif %}
 {% block main_content %}
-<form action="{{ currentUrl }}" method="POST">
+<form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {% include "partials/business_name.njk" %}
     <div class="govuk-form-group">

--- a/src/views/features/unincorporated/confirm-your-business-address/confirm-your-business-address.njk
+++ b/src/views/features/unincorporated/confirm-your-business-address/confirm-your-business-address.njk
@@ -8,7 +8,7 @@
 {% endif %}
 {% block main_content %}
  {% set businessAddressField = businessAddress.premises + " " + businessAddress.addressLine1 + ", " %}
-  <form action="{{ currentUrl }}" method="post">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="post">
     {% include "partials/csrf_token.njk" %}
     {% include "partials/business_name.njk" %}
     {% if typeOfBusiness === "limited-company" or typeOfBusiness === "limited-liability-partnership"  or typeOfBusiness === "corporate-body" %}

--- a/src/views/features/update-acsp-details/add-aml-supervisory-body/add-aml-supervisory-body.njk
+++ b/src/views/features/update-acsp-details/add-aml-supervisory-body/add-aml-supervisory-body.njk
@@ -14,7 +14,7 @@
 {% endfor %}
 {% set title = i18n.addAmlSupervisorTitle %}
 {% block main_content %}
-  <form action="{{ currentUrl }}" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     {{ govukRadios ({
       name: "AML-supervisory-bodies",

--- a/src/views/features/update-acsp-details/cancel-all-updates/cancel-all-updates.njk
+++ b/src/views/features/update-acsp-details/cancel-all-updates/cancel-all-updates.njk
@@ -3,7 +3,7 @@
 {% extends "layouts/default.njk" %}
 {% set title = i18n.cancelAllUpdatesTitle %}
 {% block main_content %}
-    <form action="{{ currentUrl }}" method="POST">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
         {% include "partials/csrf_token.njk" %} 
         <h1 class="govuk-heading-l"> {{ i18n.cancelAllUpdatesTitle }} </h1>
         <p class="govuk-body">{{ i18n.ifYouContinueBodyText }}</p>

--- a/src/views/features/update-acsp-details/index/home.njk
+++ b/src/views/features/update-acsp-details/index/home.njk
@@ -8,7 +8,7 @@
 
 {% block main_content %}
 
-  <form action="{{ currentUrl }}" method="POST">
+  <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
     {% include "partials/csrf_token.njk" %}
     <h1 class="govuk-heading-l">
       {{ i18n.startPageTitleUpdateAcsp }}

--- a/src/views/features/update-acsp-details/update-your-details.njk
+++ b/src/views/features/update-acsp-details/update-your-details.njk
@@ -104,7 +104,7 @@
     html: html,
     titleText: i18n.important
 }) }}
-    <form action="{{ currentUrl }}" method="post">
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="post">
         {% include "partials/csrf_token.njk" %}
         <h1 class="govuk-heading-xl">{{ i18n.updateYourDetailsHeading }}</h1>
         {% if acspFullProfile.type === "sole-trader" %}

--- a/src/views/features/update-acsp-details/what-is-your-email/what-is-your-email.njk
+++ b/src/views/features/update-acsp-details/what-is-your-email/what-is-your-email.njk
@@ -6,7 +6,7 @@
 
 {% set title = i18n.whatEmailForCorrespondence %}
 {% block main_content %}
-    <form action="{{ currentUrl }}" method="POST">   
+    <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">   
     {% include "partials/csrf_token.njk" %}   
     {% set textHtml %}
         {{ govukInput({

--- a/src/views/features/update-acsp-details/your-updates/your-updates.njk
+++ b/src/views/features/update-acsp-details/your-updates/your-updates.njk
@@ -208,7 +208,7 @@
   {% include "partials/your-updates-remove-aml.njk" %}
 {% endif %}
 
-<form action="{{ currentUrl }}" method="POST">
+<form action="{{ currentUrl }}?lang={{ lang }}" method="POST">
   {% include "partials/csrf_token.njk" %}
   {{ govukRadios({
     name: "moreUpdates",


### PR DESCRIPTION
Fix for ticket:
[IDVA5-1967](https://companieshouse.atlassian.net/browse/IDVA5-1967?atlOrigin=eyJpIjoiMGMzOWY4YTk2ZjEyNDk4Y2JkNTg3Njk2ZjY3YjZhMDMiLCJwIjoiaiJ9)

- Adding lang query parameter to currentUrl within form actions for applicable views.
- This fixes an issue where the language is not retained between pages

[IDVA5-1967]: https://companieshouse.atlassian.net/browse/IDVA5-1967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ