### PR TITLE
Updating AML bodies to use Welsh names

### DIFF
--- a/src/controllers/features/common/amlBodyMembershipNumberController.ts
+++ b/src/controllers/features/common/amlBodyMembershipNumberController.ts
@@ -14,7 +14,6 @@ import { saveDataInSession } from "../../../common/__utils/sessionHelper";
 import { AcspDataService } from "../../../services/acspDataService";
 import { AMLSupervisoryBodies } from "../../../model/AMLSupervisoryBodies";
 
-const selectedAMLSupervisoryBodies: string[] = [];
 const amlSupervisoryBody = new AmlSupervisoryBodyService();
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -62,7 +61,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const errorList = validationResult(req);
         if (!errorList.isEmpty()) {
             const amlSupervisoryBodyStrings = acspData.amlSupervisoryBodies!.map(body => body.amlSupervisoryBody).filter((body): body is string => body !== undefined);
-            errorListDisplay(errorList.array(), amlSupervisoryBodyStrings, lang);
+            errorListDisplay(errorList.array(), amlSupervisoryBodyStrings, lang, locales.i18nCh.resolveNamespacesKeys(lang));
             const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
             res.status(400).render(config.AML_MEMBERSHIP_NUMBER, {
                 previousPage: addLangToUrl(previousPage, lang),
@@ -94,11 +93,11 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     }
 };
 
-const errorListDisplay = (errors: any[], amlSupervisoryBodies: string[], lang: string) => {
+const errorListDisplay = (errors: any[], amlSupervisoryBodies: string[], lang: string, i18n: any) => {
     return errors.map((element) => {
         const index = parseInt(element.param.substr("membershipNumber_".length)) - 1;
         const selectionKey = amlSupervisoryBodies[index];
-        const selectionValue = AMLSupervisoryBodies[selectionKey as keyof typeof AMLSupervisoryBodies];
+        const selectionValue = i18n[selectionKey];
         element.msg = resolveErrorMessage(element.msg, lang);
         element.msg = element.msg + selectionValue;
         return element;

--- a/src/controllers/features/common/checkAmlDetailsController.ts
+++ b/src/controllers/features/common/checkAmlDetailsController.ts
@@ -6,7 +6,6 @@ import { Session } from "@companieshouse/node-session-handler";
 import { SUBMISSION_ID, GET_ACSP_REGISTRATION_DETAILS_ERROR } from "../../../common/__utils/constants";
 import { getAcspRegistration } from "../../../services/acspRegistrationService";
 import logger from "../../../utils/logger";
-import { AMLSupervisoryBodies } from "../../../model/AMLSupervisoryBodies";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
@@ -17,7 +16,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
         // get data from mongo and save to session
         const acspData = await getAcspRegistration(session, session.getExtraData(SUBMISSION_ID)!, res.locals.applicationId);
-        const url = "/register-as-companies-house-authorised-agent/aml-membership-number";
+        const changeUrl = addLangToUrl(BASE_URL + AML_MEMBERSHIP_NUMBER, lang);
         res.render(config.CHECK_AML_DETAILS, {
             ...getLocaleInfo(locales, lang),
             previousPage: addLangToUrl(BASE_URL + AML_MEMBERSHIP_NUMBER, lang),
@@ -27,8 +26,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             firstName: acspData?.applicantDetails?.firstName,
             lastName: acspData?.applicantDetails?.lastName,
             businessName: acspData?.businessName,
-            AMLSupervisoryBodies,
-            url
+            changeUrl
         });
     } catch (err) {
         logger.error(GET_ACSP_REGISTRATION_DETAILS_ERROR);

--- a/src/views/common/check-aml-details/check-aml-details.njk
+++ b/src/views/common/check-aml-details/check-aml-details.njk
@@ -29,7 +29,7 @@
       {% set row = [
         {text: i18n[body.amlSupervisoryBody]},
         {text: body.membershipId},
-        {html: "<a href=" + url + "#" + "membershipNumber_" + loop.index + ">" + i18n.checkAmlDetailsChange + "</a>"}
+        {html: "<a href=" + changeUrl + "#" + "membershipNumber_" + loop.index + ">" + i18n.checkAmlDetailsChange + "</a>"}
       ] %}
       {% set ROWS = ROWS.concat([row]) %}
     {% endfor %}


### PR DESCRIPTION
- Updated the error messages on AML membership number page to include the translated AML body names
- Updated the link on the check AML details page to add the language so when the user edits an AML body in Welsh they are taken back to the AML membership number page in Welsh