### PR TITLE
Adding span to show the aml body name on change link

### DIFF
--- a/src/views/common/check-aml-details/check-aml-details.njk
+++ b/src/views/common/check-aml-details/check-aml-details.njk
@@ -29,7 +29,7 @@
       {% set row = [
         {text: i18n[body.amlSupervisoryBody]},
         {text: body.membershipId},
-        {html: "<a href=" + changeUrl + "#" + "membershipNumber_" + loop.index + ">" + i18n.checkAmlDetailsChange + "</a>"}
+        {html: "<a href=" + changeUrl + "#" + "membershipNumber_" + loop.index + ">" + i18n.checkAmlDetailsChange + "<span class='govuk-visually-hidden'>" + i18n[body.amlSupervisoryBody] + "</span></a>"}
       ] %}
       {% set ROWS = ROWS.concat([row]) %}
     {% endfor %}


### PR DESCRIPTION
Ticket: [IDVA5-1994](https://companieshouse.atlassian.net/browse/IDVA5-1994)
Adding span to show the AML body name on change link for screen readers on the Check AML details page

[IDVA5-1994]: https://companieshouse.atlassian.net/browse/IDVA5-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ