### PR TITLE
Adding cancel update link to all applicable update acsp details screens

### DIFF
--- a/src/controllers/features/update-acsp/amlMembershipNumberController.ts
+++ b/src/controllers/features/update-acsp/amlMembershipNumberController.ts
@@ -20,7 +20,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const newAMLBody: AmlSupervisoryBody = session.getExtraData(NEW_AML_BODY)!;
         const updateBodyIndex: number | undefined = session.getExtraData(ADD_AML_BODY_UPDATE);
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
-        const reqType = REQ_TYPE_UPDATE_ACSP;
 
         let payload;
         if (updateBodyIndex) {
@@ -34,7 +33,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             payload,
             amlSupervisoryBodies: [newAMLBody],
             AMLSupervisoryBodies,
-            reqType,
             cancelLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang)
         });
     } catch (err) {

--- a/src/controllers/features/update-acsp/businessAddressConfirmController.ts
+++ b/src/controllers/features/update-acsp/businessAddressConfirmController.ts
@@ -20,6 +20,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             editAddress: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL, lang),
             ...getLocaleInfo(locales, lang),
             currentUrl,
+            cancelUpdateLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
             businessAddress: acspUpdatedFullProfile?.registeredOfficeAddress,
             typeOfBusiness: acspUpdatedFullProfile.type
         });

--- a/src/controllers/features/update-acsp/businessAddressListController.ts
+++ b/src/controllers/features/update-acsp/businessAddressListController.ts
@@ -5,7 +5,8 @@ import { ACSP_DETAILS_UPDATED, ADDRESS_LIST } from "../../../common/__utils/cons
 import * as config from "../../../config";
 import {
     UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_LIST,
-    UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_BUSINESS_ADDRESS_MANUAL
+    UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_BUSINESS_ADDRESS_MANUAL,
+    UPDATE_YOUR_ANSWERS
 } from "../../../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
@@ -25,6 +26,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             ...getLocaleInfo(locales, lang),
             currentUrl,
             previousPage,
+            cancelUpdateLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
             addresses: addressList,
             businessAddressManualLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_MANUAL, lang)
         });

--- a/src/controllers/features/update-acsp/businessAddressManualController.ts
+++ b/src/controllers/features/update-acsp/businessAddressManualController.ts
@@ -3,7 +3,7 @@ import { validationResult } from "express-validator";
 import * as config from "../../../config";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
-import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_BUSINESS_ADDRESS_MANUAL, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../types/pageURL";
+import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_BUSINESS_ADDRESS_MANUAL, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_ANSWERS } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
@@ -26,6 +26,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             ...getLocaleInfo(locales, lang),
             previousPage,
             currentUrl,
+            cancelUpdateLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
             payload,
             typeOfBusiness: acspUpdatedFullProfile.type
         });

--- a/src/controllers/features/update-acsp/correspondenceAddressConfirmController.ts
+++ b/src/controllers/features/update-acsp/correspondenceAddressConfirmController.ts
@@ -25,6 +25,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         res.render(config.CORRESPONDENCE_ADDRESS_CONFIRM, {
             previousPage,
             editPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CORRESPONDENCE_ADDRESS_MANUAL, lang),
+            cancelUpdateLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
             ...getLocaleInfo(locales, lang),
             currentUrl,
             correspondenceAddress

--- a/src/controllers/features/update-acsp/correspondenceAddressListController.ts
+++ b/src/controllers/features/update-acsp/correspondenceAddressListController.ts
@@ -5,7 +5,7 @@ import { ACSP_DETAILS_UPDATED, ADDRESS_LIST } from "../../../common/__utils/cons
 import * as config from "../../../config";
 import {
     UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM, UPDATE_CORRESPONDENCE_ADDRESS_LIST,
-    UPDATE_CORRESPONDENCE_ADDRESS_LOOKUP, UPDATE_CORRESPONDENCE_ADDRESS_MANUAL
+    UPDATE_CORRESPONDENCE_ADDRESS_LOOKUP, UPDATE_CORRESPONDENCE_ADDRESS_MANUAL, UPDATE_YOUR_ANSWERS
 } from "../../../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
@@ -25,6 +25,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             ...getLocaleInfo(locales, lang),
             currentUrl,
             previousPage,
+            cancelUpdateLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
             addresses: addressList,
             correspondenceAddressManualLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CORRESPONDENCE_ADDRESS_MANUAL, lang)
         });

--- a/src/controllers/features/update-acsp/correspondenceAddressManualController.ts
+++ b/src/controllers/features/update-acsp/correspondenceAddressManualController.ts
@@ -4,7 +4,7 @@ import * as config from "../../../config";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { CorrespondenceAddressManualService } from "../../../services/correspondence-address/correspondence-address-manual";
-import { UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM, UPDATE_CORRESPONDENCE_ADDRESS_LOOKUP, UPDATE_CORRESPONDENCE_ADDRESS_MANUAL, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../types/pageURL";
+import { UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM, UPDATE_CORRESPONDENCE_ADDRESS_LOOKUP, UPDATE_CORRESPONDENCE_ADDRESS_MANUAL, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_ANSWERS } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import countryList from "../../../../lib/countryListWithUKCountries";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
@@ -32,6 +32,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             ...getLocaleInfo(locales, lang),
             previousPage,
             currentUrl,
+            cancelUpdateLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
             countryList: countryList,
             payload
         });

--- a/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
+++ b/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
@@ -19,15 +19,11 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const payload = {
             whatIsTheBusinessName: getBusinessName(acspUpdatedFullProfile.name)
         };
-
-        const reqType = REQ_TYPE_UPDATE_ACSP;
-
         res.render(config.WHAT_IS_THE_BUSINESS_NAME, {
             previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
             ...getLocaleInfo(locales, lang),
             payload,
-            currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_BUSINESS_NAME,
-            reqType
+            currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_BUSINESS_NAME
         });
     } catch (err) {
         next(err);
@@ -42,7 +38,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const session: Session = req.session as any as Session;
         const previousPage = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang);
         var acspDataUpdated: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
-        const reqType = REQ_TYPE_UPDATE_ACSP;
         if (!errorList.isEmpty()) {
             const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
             res.status(400).render(config.WHAT_IS_THE_BUSINESS_NAME, {
@@ -50,7 +45,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 payload: req.body,
                 ...getLocaleInfo(locales, lang),
                 currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_BUSINESS_NAME,
-                reqType,
                 ...pageProperties
             });
         } else {

--- a/src/controllers/features/update-acsp/whatIsYourNameController.ts
+++ b/src/controllers/features/update-acsp/whatIsYourNameController.ts
@@ -25,13 +25,11 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             "middle-names": acspUpdatedFullProfile.soleTraderDetails?.otherForenames,
             "last-name": acspUpdatedFullProfile.soleTraderDetails?.surname
         };
-        const reqType = REQ_TYPE_UPDATE_ACSP;
         res.render(config.WHAT_IS_YOUR_NAME, {
             ...getLocaleInfo(locales, lang),
             currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_ACSP_WHAT_IS_YOUR_NAME,
             payload,
-            previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
-            reqType
+            previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang)
         });
     } catch (err) {
         next(err);
@@ -43,7 +41,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
         const errorList = validationResult(req);
-        const reqType = REQ_TYPE_UPDATE_ACSP;
         const previousPage = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang);
         if (!errorList.isEmpty()) {
             const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
@@ -52,8 +49,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 previousPage,
                 currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_ACSP_WHAT_IS_YOUR_NAME,
                 payload: req.body,
-                ...pageProperties,
-                reqType
+                ...pageProperties
             });
         } else {
             const session: Session = req.session as any as Session;

--- a/src/controllers/features/update-acsp/whereDoYouLiveController.ts
+++ b/src/controllers/features/update-acsp/whereDoYouLiveController.ts
@@ -20,14 +20,12 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const whereDoYouLiveBodyService = new WhereDoYouLiveBodyService();
 
         const payload = whereDoYouLiveBodyService.getCountryPayload(acspUpdatedFullProfile);
-        const reqType = REQ_TYPE_UPDATE_ACSP;
         res.render(config.SOLE_TRADER_WHERE_DO_YOU_LIVE, {
             ...getLocaleInfo(locales, lang),
             previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
             currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHERE_DO_YOU_LIVE,
             countryList: countryList,
-            payload,
-            reqType
+            payload
         });
     } catch (error) {
         next(error);
@@ -39,7 +37,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
         const errorList = validationResult(req);
-        const reqType = REQ_TYPE_UPDATE_ACSP;
 
         const session: Session = req.session as any as Session;
         var acspDataUpdated: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
@@ -52,8 +49,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHERE_DO_YOU_LIVE,
                 countryList: countryList,
                 ...pageProperties,
-                payload: req.body,
-                reqType
+                payload: req.body
             });
         } else {
             let countryOfResidence;

--- a/src/middleware/update-acsp/update_variables_middleware.ts
+++ b/src/middleware/update-acsp/update_variables_middleware.ts
@@ -1,3 +1,4 @@
+import { REQ_TYPE_UPDATE_ACSP } from "../../common/__utils/constants";
 import { Handler } from "express";
 
 /**
@@ -13,6 +14,7 @@ export const updateVariablesMiddleware: Handler = (req, res, next) => {
 
     res.locals.serviceName = "View and update the authorised agent's details";
     res.locals.serviceUrl = "/view-and-update-the-authorised-agents-details";
+    res.locals.reqType = REQ_TYPE_UPDATE_ACSP;
 
     next();
 };

--- a/src/views/common/correspondence-address-confirm/correspondence-address-confirm.njk
+++ b/src/views/common/correspondence-address-confirm/correspondence-address-confirm.njk
@@ -24,9 +24,19 @@
     <p class="govuk-body">
       <a href={{editPage}} class="govuk-link govuk-link--no-visited-state" id="edit-address-link">{{ i18n.EditAddress }}</a>
     </p>
-    {{ govukButton({
-      text: i18n.ConfirmAndContinue,
-      id:"save-continue-button"
-    }) }}
+    {% if reqType === "updateAcsp" %}
+      <div class="govuk-button-group">
+          {{ govukButton({
+            text: i18n.Continue,
+            id:"continue-button-id"
+          })}}
+          <a class="govuk-link" href={{cancelUpdateLink}} id="cancel-id">{{i18n.CancelUpdate}}</a>
+      </div>
+    {% else %}
+      {{ govukButton({
+        text: i18n.ConfirmAndContinue,
+        id:"save-continue-button"
+      }) }}
+    {% endif %}
   </form>
   {% endblock main_content %}

--- a/src/views/common/correspondence-address-manual/capture-correspondence-address-manual.njk
+++ b/src/views/common/correspondence-address-manual/capture-correspondence-address-manual.njk
@@ -108,6 +108,20 @@
     }) }}
     </div>
 
-    <button class="govuk-button" id="save-continue-button">{{ i18n.SaveAndContinue }}</button>
+    {% if reqType === "updateAcsp" %}
+        <div class="govuk-button-group">
+        {{ govukButton({
+            text: i18n.Continue,
+            id:"continue-button-id"
+        })}}
+        <a class="govuk-link" id="cancel-update-id" href={{cancelUpdateLink}}>{{i18n.CancelUpdate}}</a>
+        </div>
+    {% else %}
+        {{ govukButton({
+        text: i18n.SaveAndContinue,
+        id:"save-continue-button"
+        }) }}
+    {% endif %}
+
 </form>
 {% endblock main_content %}

--- a/src/views/common/correspondence-auto-lookup-address/auto-lookup-address.njk
+++ b/src/views/common/correspondence-auto-lookup-address/auto-lookup-address.njk
@@ -45,10 +45,20 @@
       autocomplete: "street-address",
       value: payload.premise
     }) }}
-    {{ govukButton({
-      text: i18n.correspondenceLookUpAddressFindAddressBtn,
-      id:"find-address-id"
-    }) }}
+    {% if reqType === "updateAcsp" %}
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: i18n.correspondenceLookUpAddressFindAddressBtn,
+          id: "find-address-id"
+        })}}
+        <a class="govuk-link" id="cancel-id" href={{previousPage}}>{{i18n.CancelUpdate}}</a>
+      </div>
+    {% else %}
+      {{ govukButton({
+        text: i18n.correspondenceLookUpAddressFindAddressBtn,
+        id:"find-address-id"
+      }) }}
+    {% endif %}
     <p>
       <a href={{correspondenceAddressManualLink}} class="govuk-link" id="manual-address-id">{{ i18n.correspondenceLookUpAddressManuallyBtn }}</a>
     </p>

--- a/src/views/common/correspondence-auto-lookup-address/correspondence-address-list.njk
+++ b/src/views/common/correspondence-auto-lookup-address/correspondence-address-list.njk
@@ -42,10 +42,20 @@
                 items: ITEMS
             }) }}
         </div>
-        {{ govukButton({
-            text: i18n.SaveAndContinue,
-            id: "save-continue-button"
-          }) }}
+        {% if reqType === "updateAcsp" %}
+            <div class="govuk-button-group">
+                {{ govukButton({
+                text: i18n.Continue,
+                id: "continue-button-id"
+                })}}
+                <a class="govuk-link" id="cancel-update-id" href={{cancelUpdateLink}}>{{i18n.CancelUpdate}}</a>
+            </div>
+        {% else %}
+            {{ govukButton({
+                text: i18n.SaveAndContinue,
+                id: "save-continue-button"
+            }) }}
+        {% endif %}
     </form>
     
     {# Manual address entry link #}

--- a/src/views/common/name/capture-name.njk
+++ b/src/views/common/name/capture-name.njk
@@ -53,10 +53,9 @@
              {{ govukButton({
                 text: i18n.Continue,
                 id:"continue-button-id"
-             })}}
-             <a class="govuk-link" href={{previousPage}} id="cancel-id">{{i18n.Cancel}}</a>
+             }) }}
+             <a class="govuk-link" href={{previousPage}} id="cancel-id">{{i18n.CancelUpdate}}</a>
           </div>
-           
         {% else %}
            {{ govukButton({
             text: i18n.SaveAndContinue,

--- a/src/views/common/what-is-the-business-name/what-is-the-business-name.njk
+++ b/src/views/common/what-is-the-business-name/what-is-the-business-name.njk
@@ -24,17 +24,18 @@
     
     {% if reqType === "updateAcsp" %}
       <div class="govuk-button-group">
-          {{ govukButton({
-            text: i18n.Continue,
-            id:"continue-button-id"
-          })}}
-          <a class="govuk-link" id="cancel-id" href={{previousPage}}>{{i18n.Cancel}}</a>
+        {{ govukButton({
+          text: i18n.Continue,
+          id:"continue-button-id"
+        })}}
+        <a class="govuk-link" id="cancel-id" href={{previousPage}}>{{i18n.CancelUpdate}}</a>
       </div>
     {% else %}
-        {{ govukButton({
+      {{ govukButton({
         text: i18n.SaveAndContinue,
         id:"save-continue-button"
-        }) }}
+      }) }}
     {% endif %}
+
   </form>
-  {% endblock main_content %}
+{% endblock main_content %}

--- a/src/views/features/sole-trader/where-do-you-live/where-do-you-live.njk
+++ b/src/views/features/sole-trader/where-do-you-live/where-do-you-live.njk
@@ -16,58 +16,57 @@
     </div>
     {% endset -%}
     {{ govukRadios({
-    errorMessage: errors.whereDoYouLiveRadio if errors,
-  name: "whereDoYouLiveRadio",
-  value: payload["whereDoYouLiveRadio"],
-  fieldset: {
-    legend: {
-      text: i18n.whereDoYouLiveTitle,
-      isPageHeading: true,
-      classes: "govuk-fieldset__legend--l"
-    }
-  },
-  items: [
-    {
-      value: "England",
-      text: i18n.whereDoYouLiveText1
-    },
-    {
-      value: "Scotland",
-      text: i18n.whereDoYouLiveText2
-    },
-    {
-      value: "Wales",
-      text: i18n.whereDoYouLiveText3
-    },
-    {
-      value: "Northern Ireland",
-      text: i18n.whereDoYouLiveText4
-    },
-    {
-      divider: i18n.whereDoYouLiveText5
-    },
-    {
-      value: "countryOutsideUK",
-      text: i18n.whereDoYouLiveText6, 
-      conditional:{ html : countryInput }
-    }
-  ]
-}) }}
+      errorMessage: errors.whereDoYouLiveRadio if errors,
+      name: "whereDoYouLiveRadio",
+      value: payload["whereDoYouLiveRadio"],
+      fieldset: {
+        legend: {
+          text: i18n.whereDoYouLiveTitle,
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--l"
+        }
+      },
+      items: [
+        {
+          value: "England",
+          text: i18n.whereDoYouLiveText1
+        },
+        {
+          value: "Scotland",
+          text: i18n.whereDoYouLiveText2
+        },
+        {
+          value: "Wales",
+          text: i18n.whereDoYouLiveText3
+        },
+        {
+          value: "Northern Ireland",
+          text: i18n.whereDoYouLiveText4
+        },
+        {
+          divider: i18n.whereDoYouLiveText5
+        },
+        {
+          value: "countryOutsideUK",
+          text: i18n.whereDoYouLiveText6, 
+          conditional:{ html : countryInput }
+        }
+      ]
+    }) }}
 
-{% if reqType === "updateAcsp" %}
-          <div class="govuk-button-group">
-             {{ govukButton({
-                text: i18n.Continue,
-                id:"continue-button-id"
-             })}}
-             <a class="govuk-link" id="cancel-id" href={{previousPage}}>{{i18n.Cancel}}</a>
-          </div>
-
-        {% else %}
-           {{ govukButton({
-            text: i18n.SaveAndContinue,
-            id:"save-continue-button"
-           }) }}
-        {% endif %}
+    {% if reqType === "updateAcsp" %}
+      <div class="govuk-button-group">
+          {{ govukButton({
+            text: i18n.Continue,
+            id:"continue-button-id"
+          })}}
+          <a class="govuk-link" id="cancel-id" href={{previousPage}}>{{i18n.CancelUpdate}}</a>
+      </div>
+    {% else %}
+        {{ govukButton({
+        text: i18n.SaveAndContinue,
+        id: "save-continue-button"
+        }) }}
+    {% endif %}
   </form>
 {% endblock main_content %}

--- a/src/views/features/unincorporated/business-address-auto-lookup/auto-lookup-address.njk
+++ b/src/views/features/unincorporated/business-address-auto-lookup/auto-lookup-address.njk
@@ -52,10 +52,20 @@
                 }
             }) }}
       </div>
-      {{ govukButton({
-           text: i18n.correspondenceLookUpAddressFindAddressBtn,
-           id:"find-address-id"
-         }) }}
+      {% if reqType === "updateAcsp" %}
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: i18n.correspondenceLookUpAddressFindAddressBtn,
+            id: "find-address-id"
+          })}}
+          <a class="govuk-link" id="cancel-id" href={{previousPage}}>{{i18n.CancelUpdate}}</a>
+        </div>
+      {% else %}
+        {{ govukButton({
+          text: i18n.correspondenceLookUpAddressFindAddressBtn,
+          id:"find-address-id"
+        }) }}
+      {% endif %}
       <p>
         <a href={{ businessAddressManualLink }} class="govuk-link" id="manual-address-id">{{ i18n.correspondenceLookUpAddressManuallyBtn }}</a>
       </p>

--- a/src/views/features/unincorporated/business-address-auto-lookup/business-address-list.njk
+++ b/src/views/features/unincorporated/business-address-auto-lookup/business-address-list.njk
@@ -39,10 +39,20 @@
             items: ITEMS
         }) }}
         </div>
-         {{ govukButton({
-             text: i18n.SaveAndContinue,
-             id:"save-continue-button"
-           }) }}
+        {% if reqType === "updateAcsp" %}
+        <div class="govuk-button-group">
+            {{ govukButton({
+                text: i18n.Continue,
+                id:"continue-button-id"
+            }) }}
+            <a class="govuk-link" href={{cancelUpdateLink}} id="cancel-id">{{i18n.CancelUpdate}}</a>
+        </div>
+        {% else %}
+        {{ govukButton({
+            text: i18n.SaveAndContinue,
+            id:"save-continue-button"
+        }) }}
+        {% endif %}
     </form>
     {# Manual address entry link #}
     <p>

--- a/src/views/features/unincorporated/business-address-manual-entry/business-address-manual-entry.njk
+++ b/src/views/features/unincorporated/business-address-manual-entry/business-address-manual-entry.njk
@@ -131,6 +131,19 @@
             } if errors.addressPostcode
         }) }}
     </div>
-    <button class="govuk-button" id="save-continue-button">{{ i18n.SaveAndContinue }}</button>
+    {% if reqType === "updateAcsp" %}
+        <div class="govuk-button-group">
+            {{ govukButton({
+                text: i18n.Continue,
+                id:"continue-button-id"
+            })}}
+            <a class="govuk-link" id="cancel-update-id" href={{cancelUpdateLink}}>{{i18n.CancelUpdate}}</a>
+        </div>
+    {% else %}
+        {{ govukButton({
+        text: i18n.SaveAndContinue,
+        id:"save-continue-button"
+        }) }}
+    {% endif %}
 </form>
 {% endblock main_content %}

--- a/src/views/features/unincorporated/confirm-your-business-address/confirm-your-business-address.njk
+++ b/src/views/features/unincorporated/confirm-your-business-address/confirm-your-business-address.njk
@@ -27,9 +27,19 @@
     <p class="govuk-body">
       <a href={{editAddress}} class="govuk-link govuk-link--no-visited-state" id="edit-address-link">{{ i18n.EditAddress }}</a>
     </p>
-    {{ govukButton({
-      text: i18n.ConfirmAndContinue,
-      id:"save-continue-button"
-    }) }}
+    {% if reqType === "updateAcsp" %}
+      <div class="govuk-button-group">
+        {{ govukButton({
+            text: i18n.Continue,
+            id:"continue-button-id"
+        }) }}
+        <a class="govuk-link" href={{cancelUpdateLink}} id="cancel-id">{{i18n.CancelUpdate}}</a>
+      </div>
+    {% else %}
+      {{ govukButton({
+        text: i18n.ConfirmAndContinue,
+        id:"confirm-continue-button"
+      }) }}
+    {% endif %}
   </form>
 {% endblock main_content %}

--- a/src/views/features/update-acsp-details/add-aml-supervisory-body/add-aml-supervisory-body.njk
+++ b/src/views/features/update-acsp-details/add-aml-supervisory-body/add-aml-supervisory-body.njk
@@ -32,9 +32,12 @@
       items: ITEMS
     }) }}
 
-    {{ govukButton ({
-      text: i18n.SaveAndContinue,
-      id: "continue-button"
-    }) }}
+    <div class="govuk-button-group">
+      {{ govukButton({
+         text: i18n.Continue,
+         id:"continue-button-id"
+      }) }}
+      <a class="govuk-link" href={{previousPage}} id="cancel-id">{{i18n.Cancel}}</a>
+    </div>
   </form>
   {% endblock main_content %}

--- a/src/views/features/update-acsp-details/what-is-your-email/what-is-your-email.njk
+++ b/src/views/features/update-acsp-details/what-is-your-email/what-is-your-email.njk
@@ -78,6 +78,6 @@
         })}}
         <a class="govuk-link" id="cancel-id" href={{previousPage}}>{{i18n.CancelUpdate}}</a>
     </div>
-
+    
     </form>
 {% endblock main_content %}


### PR DESCRIPTION
Changes made for ticket:
[IDVA5-1861](https://companieshouse.atlassian.net/browse/IDVA5-1861?atlOrigin=eyJpIjoiNDYwNjdkYjc1MTNiNDBkMmI4MTFjMzIwOGI4ZGFlNzgiLCJwIjoiaiJ9)

- Adding 'Cancel update' link to all screens where a user can update their details, which is checked against `{% if reqType === "updateAcsp" %}` on all applicable view files
- The above change excludes the 'Add AML Details' screens, as a user is adding new AML details and not updating existing details
- When a user interacts with the 'Cancel update' link, they will be routed to the main page of the Update ACSP Details service
- Removing the `res.locals.reqType = REQ_TYPE_UPDATE_ACSP;` line from individual controllers within the Update ACSP service
- Adding `res.locals.reqType = REQ_TYPE_UPDATE_ACSP;` to the `update_variables_middleware.ts` as this is now treated a common component across all views where a user can cancel updates
- Fixing some line formatting of code

[IDVA5-1861]: https://companieshouse.atlassian.net/browse/IDVA5-1861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ