### PR TITLE
Fixing an issue with tab and matomo text update acsp details service

### DIFF
--- a/locales/cy/common.json
+++ b/locales/cy/common.json
@@ -7,6 +7,7 @@
     "SignOut": "Allgofnodi",
     "AcceptAndContinue": "Derbyn a pharhau",
     "CommonTabTitle": "Gwneud cais i gofrestru fel asiant awdurdodedig Tŷ'r Cwmnïau - GOV.UK",
+    "CommonTabTitleUpdateAcsp": "View and update the authorised agent's details - GOV.UK Welsh",
     "Cancel": "Canslo",
     "openInNewTab": "opens in a new tab Welsh"
 }

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -7,6 +7,7 @@
     "SignOut": "Sign out",
     "AcceptAndContinue": "Accept and continue",
     "CommonTabTitle": "Apply to register as a Companies House authorised agent - GOV.UK",
+    "CommonTabTitleUpdateAcsp": "View and update the authorised agent's details - GOV.UK",
     "Cancel": "Cancel",
     "CancelUpdate": "Cancel update",
     "Edit": "Edit",

--- a/src/middleware/registration_variables_middleware.ts
+++ b/src/middleware/registration_variables_middleware.ts
@@ -15,6 +15,7 @@ export const registrationVariablesMiddleware: Handler = (req, res, next) => {
     res.locals.serviceName = "Apply to register as a Companies House authorised agent";
     res.locals.serviceUrl = "/register-as-companies-house-authorised-agent";
     res.locals.journeyType = AcspType.REGISTER_ACSP;
+    res.locals.tabTitleKey = "CommonTabTitle";
 
     next();
 };

--- a/src/middleware/update-acsp/update_variables_middleware.ts
+++ b/src/middleware/update-acsp/update_variables_middleware.ts
@@ -15,6 +15,7 @@ export const updateVariablesMiddleware: Handler = (req, res, next) => {
     res.locals.serviceName = "View and update the authorised agent's details";
     res.locals.serviceUrl = "/view-and-update-the-authorised-agents-details";
     res.locals.reqType = REQ_TYPE_UPDATE_ACSP;
+    res.locals.tabTitleKey = "CommonTabTitleUpdateAcsp";
 
     next();
 };

--- a/src/views/features/update-acsp-details/update-your-details.njk
+++ b/src/views/features/update-acsp-details/update-your-details.njk
@@ -96,7 +96,7 @@
 </h3>
 {% endset %}
 
-{% set title = i18n.updateYourDetailsHeading %}
+{% set title = "" %}
 {% block defaultLayout %}
 <div class="govuk-grid-column-three-quarters" id="main-page-content">
 {% block main_content %}
@@ -106,7 +106,7 @@
 }) }}
     <form action="{{ currentUrl }}?lang={{ lang }}" method="post">
         {% include "partials/csrf_token.njk" %}
-        <h1 class="govuk-heading-xl">{{ i18n.updateYourDetailsHeading }}</h1>
+        <h1 class="govuk-heading-l">{{ i18n.updateYourDetailsHeading }}</h1>
         {% if acspFullProfile.type === "sole-trader" %}
             {% include "partials/update-your-details/sole-trader-answers.njk" %}
         {% elif acspFullProfile.type === "limited-company" or acspFullProfile.type === "limited-liability-partnership"  or acspFullProfile.type === "corporate-body"%}

--- a/src/views/partials/__meta_header.njk
+++ b/src/views/partials/__meta_header.njk
@@ -1,7 +1,23 @@
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta charset="utf-8"/>
-    <title>{% if errors %}{{ i18n.error }}: {% endif %}{% if title %}{{ title }} -{% endif %} {{i18n.CommonTabTitle}}</title>
+    
+    {% set tabTitle = "" %}
+    {% if errors %}
+        {% set tabTitle = tabTitle + i18n.error + ": " %}
+    {% endif %}
+    
+    {% if title %}
+        {% set tabTitle = tabTitle + title + " - " %}
+    {% endif %}
+
+    {% if serviceUrl == "/view-and-update-the-authorised-agents-details" %}
+        {% set tabTitle = tabTitle + i18n.CommonTabTitleUpdateAcsp %}
+    {% else %}
+        {% set tabTitle = tabTitle + i18n.CommonTabTitle %}
+    {% endif %}
+
+    <title>{{ tabTitle }}</title>
     <link rel="stylesheet" href="{{cdnHost}}/stylesheets/accessible-autocomplete/autocomplete.min.css" />
     <link href="{{cdnHost}}/stylesheets/extensions/languages-nav.css" rel="stylesheet"/>
     <link href="{{ cdnUrlCss }}/app.min.css" media="all" rel="stylesheet" type="text/css"/>

--- a/src/views/partials/__meta_header.njk
+++ b/src/views/partials/__meta_header.njk
@@ -4,18 +4,14 @@
     
     {% set tabTitle = "" %}
     {% if errors %}
-        {% set tabTitle = tabTitle + i18n.error + ": " %}
+        {% set tabTitle = i18n.error + ": " %}
     {% endif %}
-    
+
     {% if title %}
         {% set tabTitle = tabTitle + title + " - " %}
     {% endif %}
 
-    {% if serviceUrl == "/view-and-update-the-authorised-agents-details" %}
-        {% set tabTitle = tabTitle + i18n.CommonTabTitleUpdateAcsp %}
-    {% else %}
-        {% set tabTitle = tabTitle + i18n.CommonTabTitle %}
-    {% endif %}
+    {% set tabTitle = tabTitle + i18n[tabTitleKey] %}
 
     <title>{{ tabTitle }}</title>
     <link rel="stylesheet" href="{{cdnHost}}/stylesheets/accessible-autocomplete/autocomplete.min.css" />


### PR DESCRIPTION
Changes made for ticket:
[IDVA5-2022](https://companieshouse.atlassian.net/browse/IDVA5-2022?atlOrigin=eyJpIjoiMWZkNWViMDUzNDcxNDVmY2I0MmVkYTA5YjAyMzQ2MDUiLCJwIjoiaiJ9)

- Splitting out the Nunjucks logic within the <title> tag of the meta_header.njk 
- Assigning the common tab titles within <service_name>_variables_middleware for each service to avoid hard coded serviceUrl check in njk file
- Updating the size of the heading display on the main page on Update your details (reduced from extra large to large text)
- These changes fix the display issue seen on Matomo when interacting with the Update ACSP Details service, as it will now show the correct service title depending on the service the user is interacting with

[IDVA5-2022]: https://companieshouse.atlassian.net/browse/IDVA5-2022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ