### PR TITLE
IDVA5-2046 ACSP Registration - Show Error and Allow User to use Manual Address Entry Screen for ''Border'' Postcode Lookup Issue

### DIFF
--- a/locales/cy/address-look-up.json
+++ b/locales/cy/address-look-up.json
@@ -15,6 +15,7 @@
     "error-correspondenceLookUpAddressNoPostCode" : "Cofnodwch god post",
     "error-correspondenceLookUpAddressInvalidPropertyDetails" : "Rhaid i enw neu rif eiddo gynnwys llythrennau a i z a nodau arbennig cyffredin fel cysylltnodau, bylchau a chollnodau yn unig",
     "error-correspondenceLookUpAddressInvalidAddressPostcode" : "Ni allwn ddod o hyd i'r cod post hwn. Rhowch un gwahanol, neu rhowch y cyfeiriad â llaw",
+    "error-correspondenceLookUpAddressUndefinedCountry" : "We cannot find the full address from the postcode. Enter the address manually. Welsh",
     "error-invalidPostcodeFormat": "Rhaid i'r cod post gynnwys llythrennau a i z a rhifau a bylchau yn unig",
     "error-invalidAddressPostcode": "Cofnodwch  god post llawn yn y Deyrnas Unedig",
     "error-correspondenceLookUpAddresListNoRadioBtnSelected" : "Dewiswch y cyfeiriad gohebiaeth",

--- a/locales/en/address-look-up.json
+++ b/locales/en/address-look-up.json
@@ -15,6 +15,7 @@
     "error-correspondenceLookUpAddressNoPostCode" : "Enter a postcode",
     "error-correspondenceLookUpAddressInvalidPropertyDetails" : "Property name or number must only include letters a to z, numbers and common special characters such as hyphens, spaces and apostrophes",
     "error-correspondenceLookUpAddressInvalidAddressPostcode" : "We cannot find this postcode. Enter a different one, or enter the address manually",
+    "error-correspondenceLookUpAddressUndefinedCountry" : "We cannot find the full address from the postcode. Enter the address manually.",
     "error-invalidPostcodeFormat": "Postcode must only include letters a to z, numbers and spaces",
     "error-invalidAddressPostcode": "Enter a full UK postcode",
     "error-correspondenceLookUpAddresListNoRadioBtnSelected" : "Select the correspondence address", 

--- a/src/services/address/addressLookUp.ts
+++ b/src/services/address/addressLookUp.ts
@@ -7,7 +7,7 @@ import { AcspData, Address } from "@companieshouse/api-sdk-node/dist/services/ac
 import { getCountryFromKey } from "../../services/common";
 import { getAddressFromPostcode } from "../../services/postcode-lookup-service";
 import { addLangToUrl, selectLang } from "../../utils/localise";
-import { BASE_URL, LIMITED_CORRESPONDENCE_ADDRESS_MANUAL, SOLE_TRADER_MANUAL_CORRESPONDENCE_ADDRESS, UNINCORPORATED_CORRESPONDENCE_ADDRESS_MANUAL, UPDATE_ACSP_DETAILS_BASE_URL } from "../../types/pageURL";
+import { BASE_URL, UPDATE_ACSP_DETAILS_BASE_URL } from "../../types/pageURL";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 
 export class AddressLookUpService {
@@ -37,7 +37,7 @@ export class AddressLookUpService {
         const lang = selectLang(req.query.lang);
         return getAddressFromPostcode(postcode).then((ukAddresses) => {
             if (ukAddresses.some(address => address.country === "")) {
-                return addLangToUrl(this.getManualAddressEntryNextPageURL(acspData), lang);
+                throw new Error("correspondenceLookUpAddressUndefinedCountry");
             } else {
                 if (inputPremise !== "" && ukAddresses.find((address) => address.premise === inputPremise)) {
                     if (businessAddress) {
@@ -51,13 +51,13 @@ export class AddressLookUpService {
                     this.saveAddressListToSession(req, ukAddresses);
 
                     if (businessAddress) {
-                    // update ascpData with postcode to save to DB
+                        // update ascpData with postcode to save to DB
                         const address: Address = {
                             postalCode: req.body.postCode
                         };
                         acspData.registeredOfficeAddress = address;
                     } else {
-                    // update ascpData with postcode to save to DB
+                        // update ascpData with postcode to save to DB
                         const correspondenceAddress: Address = {
                             postalCode: req.body.postCode
                         };
@@ -159,17 +159,5 @@ export class AddressLookUpService {
             country: getCountryFromKey(address?.country!),
             postalCode: address?.postcode
         };
-    }
-
-    private getManualAddressEntryNextPageURL (acspData: AcspData): string {
-        let nexPageUrl = BASE_URL;
-        if (acspData.typeOfBusiness === "LC" || acspData.typeOfBusiness === "LLP" || acspData.typeOfBusiness === "CORPORATE_BODY") {
-            nexPageUrl += LIMITED_CORRESPONDENCE_ADDRESS_MANUAL;
-        } else if (acspData.typeOfBusiness === "LP" || acspData.typeOfBusiness === "PARTNERSHIP" || acspData.typeOfBusiness === "UNINCORPORATED") {
-            nexPageUrl += UNINCORPORATED_CORRESPONDENCE_ADDRESS_MANUAL;
-        } else if (acspData.typeOfBusiness === "SOLE_TRADER") {
-            nexPageUrl += SOLE_TRADER_MANUAL_CORRESPONDENCE_ADDRESS;
-        }
-        return nexPageUrl;
     }
 }

--- a/test/src/services/address/addressLookup.test.ts
+++ b/test/src/services/address/addressLookup.test.ts
@@ -232,39 +232,8 @@ describe("AddressLookUpService - getAddressFromPostcode", () => {
             { premise: "1", addressLine1: "High Street", postTown: "London", country: "", postcode: "SW1A 1AA" }
         ];
         (getAddressFromPostcode as jest.Mock).mockResolvedValueOnce(ukAddresses);
-        acspData.typeOfBusiness = "LC";
-
-        const result = await addressLookUpService.getAddressFromPostcode(req as Request, "SW1A 1AA", "", acspData, false, LIMITED_CORRESPONDENCE_ADDRESS_MANUAL, "");
-
-        expect(result).toBe(`${BASE_URL}${LIMITED_CORRESPONDENCE_ADDRESS_MANUAL}?lang=en`);
-        expect(addLangToUrl).toHaveBeenCalledWith(`${BASE_URL}${LIMITED_CORRESPONDENCE_ADDRESS_MANUAL}`, "en");
-    });
-
-    it("should return UNINCORPORATED_CORRESPONDENCE_ADDRESS_MANUAL URL when typeOfBusiness is PARTNERSHIP and country is empty", async () => {
-        const ukAddresses: UKAddress[] = [
-            { premise: "1", addressLine1: "High Street", postTown: "London", country: "", postcode: "SW1A 1AA" }
-        ];
-        (getAddressFromPostcode as jest.Mock).mockResolvedValueOnce(ukAddresses);
-        acspData.typeOfBusiness = "PARTNERSHIP";
-
-        const result = await addressLookUpService.getAddressFromPostcode(req as Request, "SW1A 1AA", "", acspData, false, "", UNINCORPORATED_CORRESPONDENCE_ADDRESS_MANUAL);
-
-        expect(result).toBe(`${BASE_URL}${UNINCORPORATED_CORRESPONDENCE_ADDRESS_MANUAL}?lang=en`);
-        expect(addLangToUrl).toHaveBeenCalledWith(`${BASE_URL}${UNINCORPORATED_CORRESPONDENCE_ADDRESS_MANUAL}`, "en");
-    });
-
-    it("should return SOLE_TRADER_MANUAL_CORRESPONDENCE_ADDRESS URL when typeOfBusiness is SOLE_TRADER and country is empty", async () => {
-        const ukAddresses: UKAddress[] = [
-            { premise: "1", addressLine1: "High Street", postTown: "London", country: "", postcode: "SW1A 1AA" }
-        ];
-        (getAddressFromPostcode as jest.Mock).mockResolvedValueOnce([
-            { premise: "1", addressLine1: "High Street", postTown: "London", country: "", postcode: "SW1A 1AA" }
-        ]);
-        acspData.typeOfBusiness = "SOLE_TRADER";
-
-        const result = await addressLookUpService.getAddressFromPostcode(req as Request, "SW1A 1AA", "", acspData, false, "", SOLE_TRADER_MANUAL_CORRESPONDENCE_ADDRESS);
-
-        expect(result).toBe(`${BASE_URL}${SOLE_TRADER_MANUAL_CORRESPONDENCE_ADDRESS}?lang=en`);
-        expect(addLangToUrl).toHaveBeenCalledWith(`${BASE_URL}${SOLE_TRADER_MANUAL_CORRESPONDENCE_ADDRESS}`, "en");
+        await expect(
+            addressLookUpService.getAddressFromPostcode(req as Request, "SW1A 1AA", "", {}, false, "")
+        ).rejects.toThrow("correspondenceLookUpAddressUndefinedCountry");
     });
 });


### PR DESCRIPTION
On a situation of a postcode search returning country value as "" we are throwing the exception as given below:
https://companieshouse.atlassian.net/browse/IDVA5-2046