### PR TITLE
Adding the date of change to business name

### DIFF
--- a/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
+++ b/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
@@ -4,10 +4,9 @@ import * as config from "../../../config";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
-import { saveDataInSession } from "../../../common/__utils/sessionHelper";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS_UPDATED, REQ_TYPE_UPDATE_ACSP } from "../../../common/__utils/constants";
-import { UPDATE_WHAT_IS_THE_BUSINESS_NAME, UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../types/pageURL";
+import { ACSP_DETAILS_UPDATE_ELEMENT, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { UPDATE_WHAT_IS_THE_BUSINESS_NAME, UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE } from "../../../types/pageURL";
 import { getBusinessName } from "../../../services/common";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -36,23 +35,19 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const locales = getLocalesService();
         const errorList = validationResult(req);
         const session: Session = req.session as any as Session;
-        const previousPage = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang);
-        var acspDataUpdated: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
         if (!errorList.isEmpty()) {
             const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
             res.status(400).render(config.WHAT_IS_THE_BUSINESS_NAME, {
-                previousPage,
+                previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
                 payload: req.body,
                 ...getLocaleInfo(locales, lang),
                 currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_BUSINESS_NAME,
                 ...pageProperties
             });
         } else {
-            if (acspDataUpdated) {
-                acspDataUpdated.name = req.body.whatIsTheBusinessName;
-            }
-            saveDataInSession(req, ACSP_DETAILS_UPDATED, acspDataUpdated);
-            res.redirect(previousPage);
+            session.setExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS, req.body.whatIsTheBusinessName);
+            session.setExtraData(ACSP_DETAILS_UPDATE_ELEMENT, UPDATE_WHAT_IS_THE_BUSINESS_NAME);
+            res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE, lang));
         }
     } catch (err) {
         next(err);

--- a/src/services/update-acsp/yourUpdatesService.ts
+++ b/src/services/update-acsp/yourUpdatesService.ts
@@ -25,7 +25,7 @@ export const getFormattedUpdates = (session: Session, acspFullProfile: AcspFullP
     if (acspFullProfile.name !== updatedFullProfile.name) {
         updates.businessName = {
             value: updatedFullProfile.name,
-            changedDate: formatDateIntoReadableString(new Date())
+            changedDate: formatDateIntoReadableString(new Date(session.getExtraData(ACSP_UPDATE_CHANGE_DATE.NAME_OF_BUSINESS)!))
         };
     }
     // Email Address Changes

--- a/src/views/partials/update-your-details/limited-answers.njk
+++ b/src/views/partials/update-your-details/limited-answers.njk
@@ -22,6 +22,7 @@
 {% if profileDetailsUpdated.businessName !== profileDetails.businessName %}
   {% set updateStatusTextForBusinessName =
                 "<div class='govuk-!-static-padding-top-3'>
+                <p class='govuk-body govuk-!-static-margin-top-2'>"+i18n.updateYourDetailsModificationChangedOn+" "+changeDates.nameOfBusiness+"</p>
                 <strong class='govuk-tag govuk-tag--blue govuk-!-static-margin-bottom-1'>"+i18n.updatedWarningCaption+"</strong>
                 <p class='govuk-body-s'>"+i18n.updatedWarningNoteLineOne+"<br>"+i18n.updatedWarningNoteLineTwo+"</p>
                 </div>"

--- a/src/views/partials/update-your-details/sole-trader-answers.njk
+++ b/src/views/partials/update-your-details/sole-trader-answers.njk
@@ -40,6 +40,7 @@
 {% if profileDetailsUpdated.businessName !== profileDetails.businessName %}
   {% set updateStatusTextForBusinessName =
                 "<div class='govuk-!-static-padding-top-3'>
+                <p class='govuk-body govuk-!-static-margin-top-2'>"+i18n.updateYourDetailsModificationChangedOn+" "+changeDates.nameOfBusiness+"</p>
                 <strong class='govuk-tag govuk-tag--blue govuk-!-static-margin-bottom-1'>"+i18n.updatedWarningCaption+"</strong>
                 <p class='govuk-body-s'>"+i18n.updatedWarningNoteLineOne+"<br>"+i18n.updatedWarningNoteLineTwo+"</p>
                 </div>"

--- a/src/views/partials/update-your-details/unincorporated-answers.njk
+++ b/src/views/partials/update-your-details/unincorporated-answers.njk
@@ -40,6 +40,7 @@
 {% if profileDetailsUpdated.businessName !== profileDetails.businessName %}
   {% set updateStatusTextForBusinessName =
                 "<div class='govuk-!-static-padding-top-3'>
+                <p class='govuk-body govuk-!-static-margin-top-2'>"+i18n.updateYourDetailsModificationChangedOn+" "+changeDates.nameOfBusiness+"</p>
                 <strong class='govuk-tag govuk-tag--blue govuk-!-static-margin-bottom-1'>"+i18n.updatedWarningCaption+"</strong>
                 <p class='govuk-body-s'>"+i18n.updatedWarningNoteLineOne+"<br>"+i18n.updatedWarningNoteLineTwo+"</p>
                 </div>"

--- a/test/src/controllers/updateAcspDetails/whatIsTheBusinessNameController.test.ts
+++ b/test/src/controllers/updateAcspDetails/whatIsTheBusinessNameController.test.ts
@@ -2,7 +2,7 @@
 import mocks from "../../../mocks/all_middleware_mock";
 import supertest from "supertest";
 import app from "../../../../src/app";
-import { UPDATE_YOUR_ANSWERS, UPDATE_WHAT_IS_THE_BUSINESS_NAME, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../../src/types/pageURL";
+import { UPDATE_YOUR_ANSWERS, UPDATE_WHAT_IS_THE_BUSINESS_NAME, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE } from "../../../../src/types/pageURL";
 import * as localise from "../../../../src/utils/localise";
 
 jest.mock("@companieshouse/api-sdk-node");
@@ -37,7 +37,7 @@ describe("POST" + UPDATE_WHAT_IS_THE_BUSINESS_NAME, () => {
         expect(res.status).toBe(302);
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
         expect(mocks.mockUpdateAcspAuthenticationMiddleware).toHaveBeenCalled();
-        expect(res.header.location).toBe(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS + "?lang=en");
+        expect(res.header.location).toBe(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE + "?lang=en");
     });
 
     // Test for incorrect form details entered, will return 400.

--- a/test/src/services/update_acsp/yourUpdatesService.test.ts
+++ b/test/src/services/update_acsp/yourUpdatesService.test.ts
@@ -47,10 +47,11 @@ describe("yourUpdatesService", () => {
 
     it("should format updates when business name changes", () => {
         const session: Session = req.session as any as Session;
+        session.setExtraData(ACSP_UPDATE_CHANGE_DATE.NAME_OF_BUSINESS, new Date(2021, 1, 1).toISOString());
         const updates = getFormattedUpdates(session, acspFullProfile, updatedFullProfile);
         expect(updates.businessName).toEqual({
             value: "New Name",
-            changedDate: expect.any(String)
+            changedDate: "01 February 2021"
         });
     });
 


### PR DESCRIPTION
Ticket [IDVA5-1985](https://companieshouse.atlassian.net/browse/IDVA5-1985)

- Updated the routing for change of business name screen to take the user to when did this change
- Saving user input for date change to the a temporary variable until they have entered the date of change
- Showing the date of change on the view and update details screen

[IDVA5-1985]: https://companieshouse.atlassian.net/browse/IDVA5-1985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ