### PR TITLE
hiding inset text display reg office address unincorporated

### DIFF
--- a/src/views/features/unincorporated/business-address-auto-lookup/auto-lookup-address.njk
+++ b/src/views/features/unincorporated/business-address-auto-lookup/auto-lookup-address.njk
@@ -59,23 +59,25 @@
                 }
             }) }}
       </div>
-      {% if reqType === "updateAcsp" %}
+    {% if reqType === "updateAcsp" %}
+      {% if insetTextForLimitedJourneyUpdateAcsp %}
         {{ govukInsetText({
           html: insetTextForLimitedJourneyUpdateAcsp
         }) }}
-        <div class="govuk-button-group">
-          {{ govukButton({
-            text: i18n.correspondenceLookUpAddressFindAddressBtn,
-            id: "find-address-id"
-          })}}
-          <a class="govuk-link" id="cancel-id" href={{previousPage}}>{{i18n.CancelUpdate}}</a>
-        </div>
-      {% else %}
+      {% endif %}
+      <div class="govuk-button-group">
         {{ govukButton({
           text: i18n.correspondenceLookUpAddressFindAddressBtn,
-          id:"find-address-id"
-        }) }}
-      {% endif %}
+          id: "find-address-id"
+        })}}
+        <a class="govuk-link" id="cancel-id" href={{previousPage}}>{{i18n.CancelUpdate}}</a>
+      </div>
+    {% else %}
+      {{ govukButton({
+        text: i18n.correspondenceLookUpAddressFindAddressBtn,
+        id:"find-address-id"
+      }) }}
+    {% endif %}
       <p>
         <a href={{ businessAddressManualLink }} class="govuk-link" id="manual-address-id">{{ i18n.correspondenceLookUpAddressManuallyBtn }}</a>
       </p>


### PR DESCRIPTION
Fix for ticket:
[IDVA5-2027](https://companieshouse.atlassian.net/browse/IDVA5-2027?atlOrigin=eyJpIjoiNThkYTRlMzlhNDcxNGYwMDg3MGU3ZWQ0ZGJlNDQ1YjMiLCJwIjoiaiJ9)

- Fixing issue where the inset styling for text was appearing on Unincorporated Business Address lookup screen

[IDVA5-2027]: https://companieshouse.atlassian.net/browse/IDVA5-2027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ