### PR TITLE
Adding change of date to registered office address page

### DIFF
--- a/src/controllers/features/update-acsp/businessAddressAutoLookupController.ts
+++ b/src/controllers/features/update-acsp/businessAddressAutoLookupController.ts
@@ -70,7 +70,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             addressLookUpService.processAddressFromPostcodeUpdateJourney(req, postcode, inputPremise, acspUpdatedFullProfile, true,
                 UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_LIST).then(async (nextPageUrl) => {
 
-                session.setExtraData(ACSP_DETAILS_UPDATED, acspUpdatedFullProfile);
                 res.redirect(nextPageUrl);
             }).catch(() => {
                 const validationError : ValidationError[] = [{

--- a/src/controllers/features/update-acsp/businessAddressConfirmController.ts
+++ b/src/controllers/features/update-acsp/businessAddressConfirmController.ts
@@ -1,10 +1,10 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../../../config";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
-import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_MANUAL, UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_ANSWERS, CANCEL_AN_UPDATE } from "../../../types/pageURL";
+import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_MANUAL, UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_ANSWERS, CANCEL_AN_UPDATE, UPDATE_DATE_OF_THE_CHANGE } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATE_ELEMENT, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -21,7 +21,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             ...getLocaleInfo(locales, lang),
             currentUrl,
             cancelUpdateLink: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + CANCEL_AN_UPDATE, lang) + "&cancel=registeredOfficeAddress",
-            businessAddress: acspUpdatedFullProfile?.registeredOfficeAddress,
+            businessAddress: session.getExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS),
             typeOfBusiness: acspUpdatedFullProfile.type
         });
     } catch (err) {
@@ -32,7 +32,9 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 export const post = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const lang = selectLang(req.query.lang);
-        res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang));
+        const session: Session = req.session as any as Session;
+        session.setExtraData(ACSP_DETAILS_UPDATE_ELEMENT, UPDATE_BUSINESS_ADDRESS_CONFIRM);
+        res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE, lang));
     } catch (err) {
         next(err);
     }

--- a/src/controllers/features/update-acsp/businessAddressConfirmController.ts
+++ b/src/controllers/features/update-acsp/businessAddressConfirmController.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../../../config";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
-import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_MANUAL, UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_ANSWERS, CANCEL_AN_UPDATE, UPDATE_DATE_OF_THE_CHANGE } from "../../../types/pageURL";
+import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_MANUAL, UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_ACSP_DETAILS_BASE_URL, CANCEL_AN_UPDATE, UPDATE_DATE_OF_THE_CHANGE } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { ACSP_DETAILS_UPDATE_ELEMENT, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";

--- a/src/controllers/features/update-acsp/businessAddressListController.ts
+++ b/src/controllers/features/update-acsp/businessAddressListController.ts
@@ -1,7 +1,7 @@
 import { Session } from "@companieshouse/node-session-handler";
 import { NextFunction, Request, Response } from "express";
 import { validationResult } from "express-validator";
-import { ACSP_DETAILS_UPDATED, ADDRESS_LIST } from "../../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATE_IN_PROGRESS, ADDRESS_LIST } from "../../../common/__utils/constants";
 import * as config from "../../../config";
 import {
     CANCEL_AN_UPDATE,
@@ -9,7 +9,6 @@ import {
     UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_BUSINESS_ADDRESS_MANUAL
 } from "../../../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
-import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { Address } from "@companieshouse/api-sdk-node/dist/services/acsp";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 
@@ -41,7 +40,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const locales = getLocalesService();
         const currentUrl:string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LIST;
         const session: Session = req.session as any as Session;
-        const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
         const addressList: Address[] = session.getExtraData(ADDRESS_LIST)!;
         const errorList = validationResult(req);
         const previousPage:string = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP, lang);
@@ -60,8 +58,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             const selectedPremise = req.body.businessAddress;
             // Save selected address
             const businessAddress: Address = addressList.filter((address) => address.premises === selectedPremise)[0];
-            acspUpdatedFullProfile.registeredOfficeAddress = businessAddress;
-            session.setExtraData(ACSP_DETAILS_UPDATED, acspUpdatedFullProfile);
+            session.setExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS, businessAddress);
 
             // Redirect to the address confirmation page
             res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_CONFIRM, lang));

--- a/src/controllers/features/update-acsp/businessAddressManualController.ts
+++ b/src/controllers/features/update-acsp/businessAddressManualController.ts
@@ -58,8 +58,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         } else {
         // update acspUpdatedFullProfile
             const businessAddressService = new BusinessAddressService();
-            businessAddressService.saveBusinessAddressUpdate(req, acspFullProfile, acspUpdatedFullProfile);
-            session.setExtraData(ACSP_DETAILS_UPDATED, acspUpdatedFullProfile);
+            businessAddressService.saveBusinessAddressUpdate(req, acspFullProfile.registeredOfficeAddress.country!);
 
             // Redirect to the address confirmation page
             res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_CONFIRM, lang));

--- a/src/services/address/addressLookUp.ts
+++ b/src/services/address/addressLookUp.ts
@@ -1,7 +1,7 @@
 import { UKAddress } from "@companieshouse/api-sdk-node/dist/services/postcode-lookup/types";
 import { Session } from "@companieshouse/node-session-handler";
 import { Request } from "express";
-import { ADDRESS_LIST, USER_DATA } from "../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATE_IN_PROGRESS, ADDRESS_LIST, USER_DATA } from "../../common/__utils/constants";
 import { saveDataInSession } from "../../common/__utils/sessionHelper";
 import { AcspData, Address } from "@companieshouse/api-sdk-node/dist/services/acsp";
 import { getCountryFromKey } from "../../services/common";
@@ -78,7 +78,7 @@ export class AddressLookUpService {
         return getAddressFromPostcode(postcode).then((ukAddresses) => {
             if (inputPremise !== "" && ukAddresses.find((address) => address.premise === inputPremise)) {
                 if (businessAddress) {
-                    this.saveBusinessAddressUpdateJourney(ukAddresses, inputPremise, acspDetails);
+                    this.saveBusinessAddressUpdateJourney(req, ukAddresses, inputPremise);
                 } else {
                     this.saveCorrespondenceAddressUpdateJourney(ukAddresses, inputPremise, acspDetails);
                 }
@@ -87,19 +87,12 @@ export class AddressLookUpService {
             } else {
                 this.saveAddressListToSession(req, ukAddresses);
 
-                if (businessAddress) {
-                    // update acspDetails with postcode to save to DB
-                    const address: Address = {
-                        postalCode: req.body.postCode
-                    };
-                    acspDetails.registeredOfficeAddress = address;
-                } else {
-                    // update acspDetails with postcode to save to DB
-                    const correspondenceAddress: Address = {
-                        postalCode: req.body.postCode
-                    };
-                    acspDetails.serviceAddress = correspondenceAddress;
-                }
+                const address: Address = {
+                    postalCode: req.body.postCode
+                };
+                const session: Session = req.session as any as Session;
+                session.setExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS, address);
+
                 return addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + nexPageUrls[1], lang);
             }
 
@@ -145,8 +138,9 @@ export class AddressLookUpService {
         acspDetails.serviceAddress = this.getAddress(ukAddresses, inputPremise);
     }
 
-    public async saveBusinessAddressUpdateJourney (ukAddresses: UKAddress[], inputPremise: string, acspDetails: AcspFullProfile): Promise<void> {
-        acspDetails.registeredOfficeAddress = this.getAddress(ukAddresses, inputPremise);
+    public async saveBusinessAddressUpdateJourney (req: Request, ukAddresses: UKAddress[], inputPremise: string): Promise<void> {
+        const session: Session = req.session as any as Session;
+        session.setExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS, this.getAddress(ukAddresses, inputPremise));
     }
 
     private getAddress (ukAddresses: UKAddress[], inputPremise: string): Address {

--- a/src/services/business-address/businessAddressService.ts
+++ b/src/services/business-address/businessAddressService.ts
@@ -1,6 +1,8 @@
 import { Request } from "express";
 import { AcspData, Address } from "@companieshouse/api-sdk-node/dist/services/acsp";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
+import { ACSP_DETAILS_UPDATE_IN_PROGRESS } from "../../common/__utils/constants";
+import { Session } from "@companieshouse/node-session-handler";
 
 export class BusinessAddressService {
 
@@ -18,8 +20,7 @@ export class BusinessAddressService {
         acspData.registeredOfficeAddress = businessAddress;
     }
 
-    public saveBusinessAddressUpdate (req: Request, acspFullProfile: AcspFullProfile, acspUpdatedFullProfile: AcspFullProfile): void {
-        const originalCountry = acspFullProfile.registeredOfficeAddress.country;
+    public saveBusinessAddressUpdate (req: Request, originalCountry: string): void {
         // Extract business address details from request body
         const businessAddress: Address = {
             premises: req.body.addressPropertyDetails,
@@ -30,7 +31,8 @@ export class BusinessAddressService {
             country: req.body.addressCountry.toUpperCase() === originalCountry?.toUpperCase() ? originalCountry : req.body.addressCountry,
             postalCode: req.body.addressPostcode
         };
-        acspUpdatedFullProfile.registeredOfficeAddress = businessAddress;
+        const session: Session = req.session as any as Session;
+        session.setExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS, businessAddress);
     }
 
     public getBusinessManualAddress (acspData: AcspData | AcspFullProfile) {

--- a/src/services/update-acsp/yourUpdatesService.ts
+++ b/src/services/update-acsp/yourUpdatesService.ts
@@ -36,7 +36,7 @@ export const getFormattedUpdates = (session: Session, acspFullProfile: AcspFullP
         };
     }
     if (acspFullProfile.type === "limited-company" || acspFullProfile.type === "limited-liability-partnership" || acspFullProfile.type === "corporate-body") {
-        updates = limtedChanges(acspFullProfile, updatedFullProfile, updates);
+        updates = limtedChanges(session, acspFullProfile, updatedFullProfile, updates);
     } else if (acspFullProfile.type === "limited-partnership" || acspFullProfile.type === "unincorporated-entity" || acspFullProfile.type === "non-registered-partnership") {
         updates = unincorporatedChanges(session, acspFullProfile, updatedFullProfile, updates);
     } else {
@@ -45,11 +45,11 @@ export const getFormattedUpdates = (session: Session, acspFullProfile: AcspFullP
     return updates;
 };
 
-const limtedChanges = (acspFullProfile: AcspFullProfile, updatedFullProfile: AcspFullProfile, updates: YourUpdates): YourUpdates => {
+const limtedChanges = (session: Session, acspFullProfile: AcspFullProfile, updatedFullProfile: AcspFullProfile, updates: YourUpdates): YourUpdates => {
     if (JSON.stringify(acspFullProfile.registeredOfficeAddress) !== JSON.stringify(updatedFullProfile.registeredOfficeAddress)) {
         updates.registeredOfficeAddress = {
             value: formatAddressIntoHTMLString(updatedFullProfile.registeredOfficeAddress),
-            changedDate: formatDateIntoReadableString(new Date())
+            changedDate: formatDateIntoReadableString(new Date(session.getExtraData(ACSP_UPDATE_CHANGE_DATE.REGISTERED_OFFICE_ADDRESS)!))
         };
     }
     if (JSON.stringify(acspFullProfile.serviceAddress) !== JSON.stringify(updatedFullProfile.serviceAddress)) {
@@ -65,7 +65,7 @@ const unincorporatedChanges = (session: Session, acspFullProfile: AcspFullProfil
     if (JSON.stringify(acspFullProfile.registeredOfficeAddress) !== JSON.stringify(updatedFullProfile.registeredOfficeAddress)) {
         updates.businessAddress = {
             value: formatAddressIntoHTMLString(updatedFullProfile.registeredOfficeAddress),
-            changedDate: formatDateIntoReadableString(new Date())
+            changedDate: formatDateIntoReadableString(new Date(session.getExtraData(ACSP_UPDATE_CHANGE_DATE.REGISTERED_OFFICE_ADDRESS)!))
         };
     }
     if (JSON.stringify(acspFullProfile.serviceAddress) !== JSON.stringify(updatedFullProfile.serviceAddress)) {

--- a/src/views/partials/update-your-details/limited-answers.njk
+++ b/src/views/partials/update-your-details/limited-answers.njk
@@ -31,6 +31,7 @@
 {% if profileDetailsUpdated.registeredOfficeAddress !== profileDetails.registeredOfficeAddress %}
   {% set updateStatusTextForRegisteredOfficeAddress =
                 "<div class='govuk-!-static-padding-top-3'>
+                <p class='govuk-body govuk-!-static-margin-top-2'>"+i18n.updateYourDetailsModificationChangedOn+" "+changeDates.regOfficeAddress+"</p>
                 <strong class='govuk-tag govuk-tag--blue govuk-!-static-margin-bottom-1'>"+i18n.updatedWarningCaption+"</strong>
                 <p class='govuk-body-s'>"+i18n.updatedWarningNoteLineOne+"<br>"+i18n.updatedWarningNoteLineTwo+"</p>
                 </div>"

--- a/src/views/partials/update-your-details/unincorporated-answers.njk
+++ b/src/views/partials/update-your-details/unincorporated-answers.njk
@@ -32,6 +32,7 @@
 {% if profileDetailsUpdated.registeredOfficeAddress !== profileDetails.registeredOfficeAddress %}
   {% set updateStatusTextForBusinessAddress =
                 "<div class='govuk-!-static-padding-top-3'>
+                <p class='govuk-body govuk-!-static-margin-top-2'>"+i18n.updateYourDetailsModificationChangedOn+" "+changeDates.regOfficeAddress+"</p>
                 <strong class='govuk-tag govuk-tag--blue govuk-!-static-margin-bottom-1'>"+i18n.updatedWarningCaption+"</strong>
                 <p class='govuk-body-s'>"+i18n.updatedWarningNoteLineOne+"<br>"+i18n.updatedWarningNoteLineTwo+"</p>
                 </div>"

--- a/test/src/controllers/updateAcspDetails/businessAddressConfirmController.test.ts
+++ b/test/src/controllers/updateAcspDetails/businessAddressConfirmController.test.ts
@@ -2,7 +2,7 @@ import mocks from "../../../mocks/all_middleware_mock";
 import supertest from "supertest";
 import app from "../../../../src/app";
 import * as localise from "../../../../src/utils/localise";
-import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_ANSWERS } from "../../../../src/types/pageURL";
+import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE } from "../../../../src/types/pageURL";
 
 jest.mock("@companieshouse/api-sdk-node");
 const router = supertest(app);
@@ -32,7 +32,7 @@ describe("POST " + UPDATE_BUSINESS_ADDRESS_CONFIRM, () => {
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
         expect(mocks.mockUpdateAcspAuthenticationMiddleware).toHaveBeenCalled();
         expect(res.status).toBe(302);
-        expect(res.header.location).toBe(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS + "?lang=en");
+        expect(res.header.location).toBe(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE + "?lang=en");
     });
     it("should show the error page if an error occurs", async () => {
         const errorMessage = "Test error";

--- a/test/src/services/address/addressLookup.test.ts
+++ b/test/src/services/address/addressLookup.test.ts
@@ -3,15 +3,14 @@ import { createRequest, MockRequest } from "node-mocks-http";
 import { AddressLookUpService } from "../../../../src/services/address/addressLookUp";
 import { getSessionRequestWithPermission } from "../../../mocks/session.mock";
 import { ukAddress1, ukAddressList } from "../../../mocks/address.mock";
-import { ACSP_DETAILS_UPDATED, USER_DATA } from "../../../../src/common/__utils/constants";
+import { ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED, USER_DATA } from "../../../../src/common/__utils/constants";
 import { Session } from "@companieshouse/node-session-handler";
 import { getCountryFromKey } from "../../../../src/services/common";
 import { getAddressFromPostcode } from "../../../../src/services/postcode-lookup-service";
-import { BASE_URL, LIMITED_CORRESPONDENCE_ADDRESS_MANUAL, SOLE_TRADER_MANUAL_CORRESPONDENCE_ADDRESS, UNINCORPORATED_CORRESPONDENCE_ADDRESS_MANUAL, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../../src/types/pageURL";
+import { BASE_URL, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../../src/types/pageURL";
 import { dummyFullProfile } from "../../../mocks/acsp_profile.mock";
 import { UKAddress } from "@companieshouse/api-sdk-node/dist/services/postcode-lookup/types";
 import { AcspData } from "@companieshouse/api-sdk-node/dist/services/acsp";
-import { addLangToUrl } from "../../../../src/utils/localise";
 
 const service = new AddressLookUpService();
 
@@ -139,16 +138,13 @@ describe("addressLookupService tests", () => {
             const result = await service.processAddressFromPostcodeUpdateJourney(req, postalCode, "1", session.getExtraData(ACSP_DETAILS_UPDATED)!, true, "/nextPage1", "/nextPage2");
 
             expect(result).toBe(UPDATE_ACSP_DETAILS_BASE_URL + "/nextPage1?lang=en");
-            expect(session.getExtraData(ACSP_DETAILS_UPDATED)).toEqual({
-                ...dummyFullProfile,
-                registeredOfficeAddress: {
-                    premises: ukAddress1.premise,
-                    addressLine1: ukAddress1.addressLine1,
-                    addressLine2: ukAddress1.addressLine2,
-                    locality: ukAddress1.postTown,
-                    country: getCountryFromKey(ukAddress1.country!),
-                    postalCode: ukAddress1.postcode
-                }
+            expect(session.getExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS)).toEqual({
+                premises: ukAddress1.premise,
+                addressLine1: ukAddress1.addressLine1,
+                addressLine2: ukAddress1.addressLine2,
+                locality: ukAddress1.postTown,
+                country: getCountryFromKey(ukAddress1.country!),
+                postalCode: ukAddress1.postcode
             });
         });
         it("should return the first next page URL when a valid premise is found for correspondence address", async () => {
@@ -179,11 +175,8 @@ describe("addressLookupService tests", () => {
             const result = await service.processAddressFromPostcodeUpdateJourney(req, postalCode, "5", session.getExtraData(ACSP_DETAILS_UPDATED)!, true, "/nextPage1", "/nextPage2");
 
             expect(result).toBe(UPDATE_ACSP_DETAILS_BASE_URL + "/nextPage2?lang=en");
-            expect(session.getExtraData(ACSP_DETAILS_UPDATED)).toEqual({
-                ...dummyFullProfile,
-                registeredOfficeAddress: {
-                    postalCode: postalCode
-                }
+            expect(session.getExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS)).toEqual({
+                postalCode: postalCode
             });
         });
         it("should return the second next page URL when premise is not found in list for correspondence address", async () => {
@@ -194,11 +187,8 @@ describe("addressLookupService tests", () => {
             const result = await service.processAddressFromPostcodeUpdateJourney(req, postalCode, "5", session.getExtraData(ACSP_DETAILS_UPDATED)!, false, "/nextPage1", "/nextPage2");
 
             expect(result).toBe(UPDATE_ACSP_DETAILS_BASE_URL + "/nextPage2?lang=en");
-            expect(session.getExtraData(ACSP_DETAILS_UPDATED)).toEqual({
-                ...dummyFullProfile,
-                serviceAddress: {
-                    postalCode: postalCode
-                }
+            expect(session.getExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS)).toEqual({
+                postalCode: postalCode
             });
         });
         it("should throw an error when getAddressFromPostcode fails", async () => {


### PR DESCRIPTION
Ticket [IDVA5-1986](https://companieshouse.atlassian.net/browse/IDVA5-1986)

- Updated the routing for change of registered office address screens to take the user to when did this change
- Saving user input for registered office address change to the a temporary variable until they have entered the date of change
- Showing the date of change on the view and update details screen

[IDVA5-1986]: https://companieshouse.atlassian.net/browse/IDVA5-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ