### PR TITLE
ACSP Registration - Show Error and Allow User to use Manual Address Entry Screen for ''Border'' Postcode Lookup Issue

### DIFF
--- a/src/controllers/features/limited/correspondenceAddressAutoLookupController.ts
+++ b/src/controllers/features/limited/correspondenceAddressAutoLookupController.ts
@@ -82,23 +82,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 next(err);
             }
         }).catch((error) => {
-            let validationError: ValidationError;
-
-            if (error.message === "correspondenceLookUpAddressWithoutCountry") {
-                validationError = {
-                    value: postcode,
-                    msg: "correspondenceLookUpAddressWithoutCountry",
-                    param: "postCode",
-                    location: "body"
-                };
-            } else {
-                validationError = {
-                    value: postcode,
-                    msg: "correspondenceLookUpAddressInvalidAddressPostcode",
-                    param: "postCode",
-                    location: "body"
-                };
-            }
+            const validationError = addressLookUpService.getErrorMessage(error, postcode);
             const pageProperties = getPageProperties(formatValidationError([validationError], lang));
             res.status(400).render(config.AUTO_LOOKUP_ADDRESS, {
                 previousPage,

--- a/src/controllers/features/limited/correspondenceAddressAutoLookupController.ts
+++ b/src/controllers/features/limited/correspondenceAddressAutoLookupController.ts
@@ -81,14 +81,25 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 logger.error(POST_ACSP_REGISTRATION_DETAILS_ERROR + " " + JSON.stringify(err));
                 next(err);
             }
-        }).catch(() => {
-            const validationError : ValidationError[] = [{
-                value: postcode,
-                msg: "correspondenceLookUpAddressInvalidAddressPostcode",
-                param: "postCode",
-                location: "body"
-            }];
-            const pageProperties = getPageProperties(formatValidationError(validationError, lang));
+        }).catch((error) => {
+            let validationError: ValidationError;
+
+            if (error.message === "correspondenceLookUpAddressWithoutCountry") {
+                validationError = {
+                    value: postcode,
+                    msg: "correspondenceLookUpAddressWithoutCountry",
+                    param: "postCode",
+                    location: "body"
+                };
+            } else {
+                validationError = {
+                    value: postcode,
+                    msg: "correspondenceLookUpAddressInvalidAddressPostcode",
+                    param: "postCode",
+                    location: "body"
+                };
+            }
+            const pageProperties = getPageProperties(formatValidationError([validationError], lang));
             res.status(400).render(config.AUTO_LOOKUP_ADDRESS, {
                 previousPage,
                 ...getLocaleInfo(locales, lang),

--- a/src/controllers/features/sole-trader/correspondenceAddressAutoLookupController.ts
+++ b/src/controllers/features/sole-trader/correspondenceAddressAutoLookupController.ts
@@ -84,23 +84,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 next(err);
             }
         }).catch((error) => {
-            let validationError: ValidationError;
-
-            if (error.message === "correspondenceLookUpAddressWithoutCountry") {
-                validationError = {
-                    value: postcode,
-                    msg: "correspondenceLookUpAddressWithoutCountry",
-                    param: "postCode",
-                    location: "body"
-                };
-            } else {
-                validationError = {
-                    value: postcode,
-                    msg: "correspondenceLookUpAddressInvalidAddressPostcode",
-                    param: "postCode",
-                    location: "body"
-                };
-            }
+            const validationError = addressLookUpService.getErrorMessage(error, postcode);
             const pageProperties = getPageProperties(formatValidationError([validationError], lang));
             res.status(400).render(config.AUTO_LOOKUP_ADDRESS, {
                 previousPage,

--- a/src/controllers/features/sole-trader/correspondenceAddressAutoLookupController.ts
+++ b/src/controllers/features/sole-trader/correspondenceAddressAutoLookupController.ts
@@ -83,14 +83,25 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 logger.error(POST_ACSP_REGISTRATION_DETAILS_ERROR);
                 next(err);
             }
-        }).catch(() => {
-            const validationError: ValidationError[] = [{
-                value: postcode,
-                msg: "correspondenceLookUpAddressInvalidAddressPostcode",
-                param: "postCode",
-                location: "body"
-            }];
-            const pageProperties = getPageProperties(formatValidationError(validationError, lang));
+        }).catch((error) => {
+            let validationError: ValidationError;
+
+            if (error.message === "correspondenceLookUpAddressWithoutCountry") {
+                validationError = {
+                    value: postcode,
+                    msg: "correspondenceLookUpAddressWithoutCountry",
+                    param: "postCode",
+                    location: "body"
+                };
+            } else {
+                validationError = {
+                    value: postcode,
+                    msg: "correspondenceLookUpAddressInvalidAddressPostcode",
+                    param: "postCode",
+                    location: "body"
+                };
+            }
+            const pageProperties = getPageProperties(formatValidationError([validationError], lang));
             res.status(400).render(config.AUTO_LOOKUP_ADDRESS, {
                 previousPage,
                 ...getLocaleInfo(locales, lang),

--- a/src/controllers/features/unincorporated/businessAddressAutoLookupController.ts
+++ b/src/controllers/features/unincorporated/businessAddressAutoLookupController.ts
@@ -68,14 +68,25 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 logger.error(POST_ACSP_REGISTRATION_DETAILS_ERROR + " " + JSON.stringify(err));
                 next(err);
             }
-        }).catch(() => {
-            const validationError : ValidationError[] = [{
-                value: postcode,
-                msg: "correspondenceLookUpAddressInvalidAddressPostcode",
-                param: "postCode",
-                location: "body"
-            }];
-            const pageProperties = getPageProperties(formatValidationError(validationError, lang));
+        }).catch((error) => {
+            let validationError: ValidationError;
+
+            if (error.message === "correspondenceLookUpAddressWithoutCountry") {
+                validationError = {
+                    value: postcode,
+                    msg: "correspondenceLookUpAddressWithoutCountry",
+                    param: "postCode",
+                    location: "body"
+                };
+            } else {
+                validationError = {
+                    value: postcode,
+                    msg: "correspondenceLookUpAddressInvalidAddressPostcode",
+                    param: "postCode",
+                    location: "body"
+                };
+            }
+            const pageProperties = getPageProperties(formatValidationError([validationError], lang));
             buildErrorResponse(req, res, locales, lang, acspData, pageProperties);
         });
     }

--- a/src/controllers/features/unincorporated/businessAddressAutoLookupController.ts
+++ b/src/controllers/features/unincorporated/businessAddressAutoLookupController.ts
@@ -69,23 +69,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 next(err);
             }
         }).catch((error) => {
-            let validationError: ValidationError;
-
-            if (error.message === "correspondenceLookUpAddressWithoutCountry") {
-                validationError = {
-                    value: postcode,
-                    msg: "correspondenceLookUpAddressWithoutCountry",
-                    param: "postCode",
-                    location: "body"
-                };
-            } else {
-                validationError = {
-                    value: postcode,
-                    msg: "correspondenceLookUpAddressInvalidAddressPostcode",
-                    param: "postCode",
-                    location: "body"
-                };
-            }
+            const validationError = addressLookUpService.getErrorMessage(error, postcode);
             const pageProperties = getPageProperties(formatValidationError([validationError], lang));
             buildErrorResponse(req, res, locales, lang, acspData, pageProperties);
         });

--- a/src/controllers/features/unincorporated/correspondenceAddressAutoLookupController.ts
+++ b/src/controllers/features/unincorporated/correspondenceAddressAutoLookupController.ts
@@ -73,14 +73,25 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 logger.error(POST_ACSP_REGISTRATION_DETAILS_ERROR + " " + JSON.stringify(err));
                 next(err);
             }
-        }).catch(() => {
-            const validationError : ValidationError[] = [{
-                value: postcode,
-                msg: "correspondenceLookUpAddressInvalidAddressPostcode",
-                param: "postCode",
-                location: "body"
-            }];
-            const pageProperties = getPageProperties(formatValidationError(validationError, lang));
+        }).catch((error) => {
+            let validationError: ValidationError;
+
+            if (error.message === "correspondenceLookUpAddressWithoutCountry") {
+                validationError = {
+                    value: postcode,
+                    msg: "correspondenceLookUpAddressWithoutCountry",
+                    param: "postCode",
+                    location: "body"
+                };
+            } else {
+                validationError = {
+                    value: postcode,
+                    msg: "correspondenceLookUpAddressInvalidAddressPostcode",
+                    param: "postCode",
+                    location: "body"
+                };
+            }
+            const pageProperties = getPageProperties(formatValidationError([validationError], lang));
             buildErrorResponse(req, res, next, locales, lang, acspData, pageProperties);
         });
     }

--- a/src/controllers/features/unincorporated/correspondenceAddressAutoLookupController.ts
+++ b/src/controllers/features/unincorporated/correspondenceAddressAutoLookupController.ts
@@ -74,23 +74,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 next(err);
             }
         }).catch((error) => {
-            let validationError: ValidationError;
-
-            if (error.message === "correspondenceLookUpAddressWithoutCountry") {
-                validationError = {
-                    value: postcode,
-                    msg: "correspondenceLookUpAddressWithoutCountry",
-                    param: "postCode",
-                    location: "body"
-                };
-            } else {
-                validationError = {
-                    value: postcode,
-                    msg: "correspondenceLookUpAddressInvalidAddressPostcode",
-                    param: "postCode",
-                    location: "body"
-                };
-            }
+            const validationError = addressLookUpService.getErrorMessage(error, postcode);
             const pageProperties = getPageProperties(formatValidationError([validationError], lang));
             buildErrorResponse(req, res, next, locales, lang, acspData, pageProperties);
         });

--- a/src/services/address/addressLookUp.ts
+++ b/src/services/address/addressLookUp.ts
@@ -1,5 +1,5 @@
 import { UKAddress } from "@companieshouse/api-sdk-node/dist/services/postcode-lookup/types";
-import { ValidationError, validationResult } from "express-validator";
+import { ValidationError } from "express-validator";
 import { Session } from "@companieshouse/node-session-handler";
 import { Request } from "express";
 import { ADDRESS_LIST, USER_DATA } from "../../common/__utils/constants";

--- a/src/services/address/addressLookUp.ts
+++ b/src/services/address/addressLookUp.ts
@@ -1,4 +1,5 @@
 import { UKAddress } from "@companieshouse/api-sdk-node/dist/services/postcode-lookup/types";
+import { ValidationError, validationResult } from "express-validator";
 import { Session } from "@companieshouse/node-session-handler";
 import { Request } from "express";
 import { ADDRESS_LIST, USER_DATA } from "../../common/__utils/constants";
@@ -71,6 +72,26 @@ export class AddressLookUpService {
         }).catch((err) => {
             throw err;
         });
+    }
+
+    public getErrorMessage (error:Error, postcode:any) :ValidationError {
+        let validationError: ValidationError;
+        if (error.message === "correspondenceLookUpAddressWithoutCountry") {
+            validationError = {
+                value: postcode,
+                msg: "correspondenceLookUpAddressWithoutCountry",
+                param: "postCode",
+                location: "body"
+            };
+        } else {
+            validationError = {
+                value: postcode,
+                msg: "correspondenceLookUpAddressInvalidAddressPostcode",
+                param: "postCode",
+                location: "body"
+            };
+        }
+        return validationError;
     }
 
     public processAddressFromPostcodeUpdateJourney (req: Request, postcode: string, inputPremise: string, acspDetails: AcspFullProfile, businessAddress: boolean, ...nexPageUrls: string[]) : Promise<string> {

--- a/test/src/controllers/limited/correspondenceAddressLookUp.test.ts
+++ b/test/src/controllers/limited/correspondenceAddressLookUp.test.ts
@@ -164,6 +164,17 @@ describe("POST" + LIMITED_CORRESPONDENCE_ADDRESS_LOOKUP, () => {
             postCode: "AB12CD",
             premise: ""
         };
+        (getAddressFromPostcode as jest.Mock).mockRejectedValueOnce(new Error("correspondenceLookUpAddressWithoutCountry"));
+
+        const res = await router.post(BASE_URL + LIMITED_CORRESPONDENCE_ADDRESS_LOOKUP).send(formData);
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("We cannot find the full address from the postcode. Enter the address manually");
+    });
+    it("should return status 400 for no postcode found", async () => {
+        const formData = {
+            postCode: "AB12CD",
+            premise: ""
+        };
         (getAddressFromPostcode as jest.Mock).mockRejectedValueOnce(new Error("Postcode not found"));
 
         const res = await router.post(BASE_URL + LIMITED_CORRESPONDENCE_ADDRESS_LOOKUP).send(formData);

--- a/test/src/controllers/limited/correspondenceAddressLookUp.test.ts
+++ b/test/src/controllers/limited/correspondenceAddressLookUp.test.ts
@@ -159,7 +159,7 @@ describe("POST" + LIMITED_CORRESPONDENCE_ADDRESS_LOOKUP, () => {
         expect(res.text).toContain("Enter a postcode");
     });
 
-    it("should return status 400 for no postcode found", async () => {
+    it("should return status 400 for no country found", async () => {
         const formData = {
             postCode: "AB12CD",
             premise: ""

--- a/test/src/controllers/soleTrader/correspondenceAddressAutoLookupController.test.ts
+++ b/test/src/controllers/soleTrader/correspondenceAddressAutoLookupController.test.ts
@@ -198,6 +198,18 @@ describe("POST" + SOLE_TRADER_AUTO_LOOKUP_ADDRESS, () => {
     it("should return status 400 for no postcode found", async () => {
         const formData = {
             postCode: "AB12CD",
+            premise: ""
+        };
+        (getAddressFromPostcode as jest.Mock).mockRejectedValueOnce(new Error("correspondenceLookUpAddressWithoutCountry"));
+
+        const res = await router.post(BASE_URL + SOLE_TRADER_AUTO_LOOKUP_ADDRESS).send(formData);
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("We cannot find the full address from the postcode. Enter the address manually");
+    });
+
+    it("should return status 400 for no postcode found", async () => {
+        const formData = {
+            postCode: "AB12CD",
             premise: "",
             applicantDetails: {
                 firstName: "JOHN",

--- a/test/src/controllers/unincorporated/businessAddressLookUpController.test.ts
+++ b/test/src/controllers/unincorporated/businessAddressLookUpController.test.ts
@@ -114,6 +114,18 @@ describe("POST" + UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP, () => {
         expect(res.text).toContain("We cannot find this postcode. Enter a different one, or enter the address manually");
     });
 
+    it("should return status 400 for no postcode found", async () => {
+        const formData = {
+            postCode: "AB12CD",
+            premise: ""
+        };
+        (getAddressFromPostcode as jest.Mock).mockRejectedValueOnce(new Error("correspondenceLookUpAddressWithoutCountry"));
+
+        const res = await router.post(BASE_URL + UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP).send(formData);
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("We cannot find the full address from the postcode. Enter the address manually");
+    });
+
     it("should return status 400 for invalid postcode entered", async () => {
         const formData = {
             postCode: "S6",

--- a/test/src/controllers/unincorporated/businessAddressLookUpController.test.ts
+++ b/test/src/controllers/unincorporated/businessAddressLookUpController.test.ts
@@ -107,7 +107,7 @@ describe("POST" + UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP, () => {
             premise: ""
         };
 
-        (getAddressFromPostcode as jest.Mock).mockRejectedValueOnce(null);
+        (getAddressFromPostcode as jest.Mock).mockRejectedValueOnce(new Error("Postcode not found"));
 
         const res = await router.post(BASE_URL + UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP).send(formData);
         expect(res.status).toBe(400);

--- a/test/src/controllers/unincorporated/correspondenceAddressLookUpController.test.ts
+++ b/test/src/controllers/unincorporated/correspondenceAddressLookUpController.test.ts
@@ -104,7 +104,7 @@ describe("POST" + UNINCORPORATED_CORRESPONDENCE_ADDRESS_LOOKUP, () => {
             premise: ""
         };
 
-        (getAddressFromPostcode as jest.Mock).mockRejectedValueOnce(null);
+        (getAddressFromPostcode as jest.Mock).mockRejectedValueOnce(new Error("Postcode not found"));
 
         const res = await router.post(BASE_URL + UNINCORPORATED_CORRESPONDENCE_ADDRESS_LOOKUP).send(formData);
         expect(res.status).toBe(400);

--- a/test/src/controllers/unincorporated/correspondenceAddressLookUpController.test.ts
+++ b/test/src/controllers/unincorporated/correspondenceAddressLookUpController.test.ts
@@ -122,6 +122,18 @@ describe("POST" + UNINCORPORATED_CORRESPONDENCE_ADDRESS_LOOKUP, () => {
         expect(res.text).toContain("Enter a full UK postcode");
     });
 
+    it("should return status 400 for no postcode found", async () => {
+        const formData = {
+            postCode: "AB12CD",
+            premise: ""
+        };
+        (getAddressFromPostcode as jest.Mock).mockRejectedValueOnce(new Error("correspondenceLookUpAddressWithoutCountry"));
+
+        const res = await router.post(BASE_URL + UNINCORPORATED_CORRESPONDENCE_ADDRESS_LOOKUP).send(formData);
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("We cannot find the full address from the postcode. Enter the address manually");
+    });
+
     it("should return status 400 for no postcode entered", async () => {
         const formData = {
             postCode: "",


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2046

fixing the test issue
The exception thrown was overwritten by the default catch call, implementing the conditional catch