### PR TITLE
adding validation for business name if no changes made

### DIFF
--- a/locales/cy/what-is-the-business-name.json
+++ b/locales/cy/what-is-the-business-name.json
@@ -6,5 +6,6 @@
     "error-whatIsTheBusinessNameSelectRadio" : "Dewiswch enw busnes",
     "error-whatIsTheBusinessNameNoName" : "Cofnodwch enw'r busnes",
     "error-whatIsTheBusinessNameInvalidCharacters" : "Rhaid i'r enw busnes gynnwys llythrennau a i z yn unig, a nodau arbennig cyffredin fel cysylltnodau, bylchau a chollnodau",
-    "error-whatIsTheBusinessNameCharactersLimit" : "Rhaid i'r enw busnes fod yn 155 nod neu lai"
+    "error-whatIsTheBusinessNameCharactersLimit" : "Rhaid i'r enw busnes fod yn 155 nod neu lai",
+    "error-whatIsTheBusinessNameNoChangeUpdateAcsp" : "Update the business name if it's changed or cancel the update Welsh"
 }

--- a/locales/en/what-is-the-business-name.json
+++ b/locales/en/what-is-the-business-name.json
@@ -6,5 +6,6 @@
     "error-whatIsTheBusinessNameSelectRadio" : "Select business name",
     "error-whatIsTheBusinessNameNoName" : "Enter the business name",
     "error-whatIsTheBusinessNameInvalidCharacters" : "Business name must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes",
-    "error-whatIsTheBusinessNameCharactersLimit" : "Business name must be 155 characters or less"
+    "error-whatIsTheBusinessNameCharactersLimit" : "Business name must be 155 characters or less",
+    "error-whatIsTheBusinessNameNoChangeUpdateAcsp" : "Update the business name if it's changed or cancel the update"
 }

--- a/src/validation/unicorporatedWhatIsTheBusinessName.ts
+++ b/src/validation/unicorporatedWhatIsTheBusinessName.ts
@@ -1,4 +1,6 @@
+import { Session } from "@companieshouse/node-session-handler";
 import { body } from "express-validator";
+import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { ACSP_DETAILS } from "../common/__utils/constants";
 
 const businessNameFormat:RegExp = /^[A-Za-z0-9\-&'.\s]*$/;
@@ -11,8 +13,8 @@ export const unicorporatedWhatIsTheBusinessNameValidator = [
         .custom((inputBusinessName, { req }) => {
             // Custom validation used for Update ACSP Details service
             // Check if the business name has changed through comparing the inputted business against the existing business name
-            const session = req.session as any;
-            const acspDetails = session.getExtraData(ACSP_DETAILS);
+            const session = req.session as any as Session;
+            const acspDetails: AcspFullProfile | undefined = session.getExtraData(ACSP_DETAILS);
 
             if (acspDetails) {
                 // Trim leading and trailing spaces, convert business name to lowercase, and replace multiple spaces with a single space

--- a/src/validation/unicorporatedWhatIsTheBusinessName.ts
+++ b/src/validation/unicorporatedWhatIsTheBusinessName.ts
@@ -13,7 +13,7 @@ export const unicorporatedWhatIsTheBusinessNameValidator = [
         .custom((inputBusinessName, { req }) => {
             // Custom validation used for Update ACSP Details service
             // Check if the business name has changed through comparing the inputted business against the existing business name
-            const session = req.session as any as Session;
+            const session: Session = req.session as Session;
             const acspDetails: AcspFullProfile | undefined = session.getExtraData(ACSP_DETAILS);
 
             if (acspDetails) {

--- a/src/validation/unicorporatedWhatIsTheBusinessName.ts
+++ b/src/validation/unicorporatedWhatIsTheBusinessName.ts
@@ -1,4 +1,5 @@
 import { body } from "express-validator";
+import { ACSP_DETAILS } from "../common/__utils/constants";
 
 const businessNameFormat:RegExp = /^[A-Za-z0-9\-&'.\s]*$/;
 
@@ -6,5 +7,22 @@ export const unicorporatedWhatIsTheBusinessNameValidator = [
 
     body("whatIsTheBusinessName").trim().notEmpty().withMessage("whatIsTheBusinessNameNoName").bail()
         .matches(businessNameFormat).withMessage("whatIsTheBusinessNameInvalidCharacters").bail()
-        .isLength({ max: 155 }).withMessage("whatIsTheBusinessNameCharactersLimit")
+        .isLength({ max: 155 }).withMessage("whatIsTheBusinessNameCharactersLimit").bail()
+        .custom((inputBusinessName, { req }) => {
+            // Custom validation used for Update ACSP Details service
+            // Check if the business name has changed through comparing the inputted business against the existing business name
+            const session = req.session as any;
+            const acspDetails = session.getExtraData(ACSP_DETAILS);
+
+            if (acspDetails) {
+                // Trim leading and trailing spaces, convert business name to lowercase, and replace multiple spaces with a single space
+                const normalisedBusinessName = inputBusinessName.trim().toLowerCase().replace(/\s+/g, " ");
+                const existingBusinessName = acspDetails.name.trim().toLowerCase().replace(/\s+/g, " ");
+
+                if (normalisedBusinessName === existingBusinessName) {
+                    throw new Error("whatIsTheBusinessNameNoChangeUpdateAcsp");
+                }
+            }
+            return true;
+        })
 ];

--- a/test/src/controllers/updateAcspDetails/whatIsTheBusinessNameController.test.ts
+++ b/test/src/controllers/updateAcspDetails/whatIsTheBusinessNameController.test.ts
@@ -46,6 +46,15 @@ describe("POST" + UPDATE_WHAT_IS_THE_BUSINESS_NAME, () => {
         expect(res.status).toBe(400);
     });
 
+    it("should return status 400 after incorrect data entered", async () => {
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_BUSINESS_NAME)
+            .send({
+                whatIsTheBusinessName: "Test name"
+            });
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("Update the business name if it&#39;s changed or cancel the update");
+    });
+
     it("should return status 500 when an error occurs", async () => {
         const errorMessage = "Test error";
         jest.spyOn(localise, "selectLang").mockImplementationOnce(() => {

--- a/test/src/controllers/updateAcspDetails/whatIsTheBusinessNameController.test.ts
+++ b/test/src/controllers/updateAcspDetails/whatIsTheBusinessNameController.test.ts
@@ -46,7 +46,7 @@ describe("POST" + UPDATE_WHAT_IS_THE_BUSINESS_NAME, () => {
         expect(res.status).toBe(400);
     });
 
-    it("should return status 400 after incorrect data entered", async () => {
+    it("should return status 400 and display error message when no change has been made to business name", async () => {
         const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_BUSINESS_NAME)
             .send({
                 whatIsTheBusinessName: "Test name"


### PR DESCRIPTION
Changes made against ticket:
[IDVA5-2050](https://companieshouse.atlassian.net/browse/IDVA5-2050?atlOrigin=eyJpIjoiZDI5Y2JkN2RmMDUwNDY3MWJmOTIwMGRjZmJjZTU5ZTAiLCJwIjoiaiJ9)

- We use the existing unincorporatedWhatIsTheBusinessName validation for the Business Name validation within Update ACSP Details service
- Added custom validation that checks if no changes has been made to the original business name (ACSP_DETAILS) and the user attempts to press continue to the next page
- Before checking the existing value against the inputted data, both the inputted and existing business names are converted to lower case, leading and trialing spaces removed and additional spaces removed.

See below for some scenarios of the above:

Input Business Name | Existing Business Name | Result
-- | -- | --
"Business Name" | "Business Name" | Fail
"business name" | "Business Name" | Fail
"Business    Name  " | "Business Name" | Fail
"  Business Name" | "Business Name" | Fail
"Updated Business Name" | "Business Name" | Pass



[IDVA5-2050]: https://companieshouse.atlassian.net/browse/IDVA5-2050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ