### PR TITLE
Updating dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.252",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.252.tgz",
-      "integrity": "sha512-pVyejYiGRbaGmCvPZsd2LdIG7WWk9uHrZbuAmCdP6vKAlAN+HDSyJEObH8kjEMq1VP8kl9xCwDEXtHRT5GuM+A==",
+      "version": "2.0.255",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.255.tgz",
+      "integrity": "sha512-fW8FCY7/Tu7BfiOeAvgfIQH2YKlSygd1+Lm2sf7O5jtRKw6PwSUX/v2XXg2gKWGMFoX9RM5VxzOfmffaJPyw6g==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -619,9 +619,9 @@
       }
     },
     "node_modules/@companieshouse/ch-node-utils": {
-      "version": "1.3.21",
-      "resolved": "https://registry.npmjs.org/@companieshouse/ch-node-utils/-/ch-node-utils-1.3.21.tgz",
-      "integrity": "sha512-sm2+yc42J54Rsze4MkAf9mmogDIyJpHuSNC3pQy7oYu9KtkKdMCPUIptFLtEh7CWwY9+R7dBJxlM2Flcr0J3oQ==",
+      "version": "1.3.23",
+      "resolved": "https://registry.npmjs.org/@companieshouse/ch-node-utils/-/ch-node-utils-1.3.23.tgz",
+      "integrity": "sha512-9wAYIH6wFlAFn7z7JYVR7MeWfIlthhl94WAdpAdHyt1+hEJz3kCGxEtjTmeYCkMRCRY52EshNWRBg1PL4YC3iQ==",
       "license": "MIT",
       "dependencies": {
         "@companieshouse/node-session-handler": "^5.1.4",
@@ -731,19 +731,19 @@
       }
     },
     "node_modules/@companieshouse/ch-node-utils/node_modules/eslint": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.24.0.tgz",
-      "integrity": "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==",
+      "version": "9.25.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.25.1.tgz",
+      "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.0",
-        "@eslint/core": "^0.12.0",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.13.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.24.0",
-        "@eslint/plugin-kit": "^0.2.7",
+        "@eslint/js": "9.25.1",
+        "@eslint/plugin-kit": "^0.2.8",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -1097,9 +1097,9 @@
       }
     },
     "node_modules/@companieshouse/web-security-node": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.6.tgz",
-      "integrity": "sha512-2mvgMecghIJlVoiAcnQ5TKLQyELvqRtSGEwvYSb6rfdSGeIc5Ig2i6IjXro6nj93lNv6mtEx7+Pk1P24ql06Cw==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.7.tgz",
+      "integrity": "sha512-dqmg6zJrHNtwYSFJG7CDxZhoDkkr88mBq3ug88XLOOXuHBQYLDaKQLVp3Tc2janWDOymbpfo1BxyEeXy/nZJqQ==",
       "license": "MIT",
       "dependencies": {
         "@companieshouse/node-session-handler": "~5.2.0",
@@ -1173,9 +1173,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.0.tgz",
-      "integrity": "sha512-WhCn7Z7TauhBtmzhvKpoQs0Wwb/kBcy4CwpuI0/eEIr2Lx2auxmulAzLr91wVZJaz47iUZdkXOK7WlAfxGKCnA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
+      "integrity": "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==",
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -1235,9 +1235,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -1350,9 +1350,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.24.0.tgz",
-      "integrity": "sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==",
+      "version": "9.25.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.1.tgz",
+      "integrity": "sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1375,18 +1375,6 @@
       "dependencies": {
         "@eslint/core": "^0.13.0",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
-      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2445,6 +2433,29 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -4019,9 +4030,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001713",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
-      "integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
+      "version": "1.0.30001715",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
+      "integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
       "dev": true,
       "funding": [
         {
@@ -5142,9 +5153,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.136",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.136.tgz",
-      "integrity": "sha512-kL4+wUTD7RSA5FHx5YwWtjDnEEkIIikFgWHR4P6fqjw1PPLlqYkxeOb++wAauAssat0YClCy8Y3C5SxgSkjibQ==",
+      "version": "1.5.140",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.140.tgz",
+      "integrity": "sha512-o82Rj+ONp4Ip7Cl1r7lrqx/pXhbp/lh9DpKcMNscFJdh8ebyRofnc7Sh01B4jx403RI0oqTBvlZ7OBIZLMr2+Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -6464,14 +6475,15 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.3.tgz",
+      "integrity": "sha512-vDI5JjeALeGXpyL8v71ZG2VgHY5zD6qg1IvypU7aJCYvREZyhawrYJxMdsWO+m5DIGLiMiDH71yEN8RO4wQAMQ==",
+      "deprecated": "ACTION REQUIRED: SWITCH TO v3 - v1 and v2 are VULNERABLE AND DEPRECATED FOR OVER 2 YEARS! Use formidable@latest or try formidable-mini for fresh projects",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
         "once": "^1.4.0",
         "qs": "^6.11.0"
       },
@@ -7392,16 +7404,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/hexoid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
-      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/homedir-polyfill": {
@@ -13891,9 +13893,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/type-fest": {
-      "version": "4.39.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
-      "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
+      "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "@companieshouse/api-sdk-node": "^2.0.248",
-    "@companieshouse/ch-node-utils": "^1.3.5",
+    "@companieshouse/ch-node-utils": "^1.3.23",
     "@companieshouse/node-session-handler": "^5.1.4",
     "@companieshouse/structured-logging-node": "^1.0.8",
     "@companieshouse/web-security-node": "^4.3.1",


### PR DESCRIPTION
Updating dependencies to pull the latest navbar changes for DAC ticket as also needed for Update ACSP Service:
[IDVA5-2015](https://companieshouse.atlassian.net/browse/IDVA5-2015?atlOrigin=eyJpIjoiZjMwOWY5NDY5M2IxNGVhOTg2NTIyZmIyZGE1ZDVhYjgiLCJwIjoiaiJ9)

This is needed to pull through the merged PR from Team Inugami's navbar changes here:
[ch-node-utils-navbar](https://github.com/companieshouse/ch-node-utils/pull/28)

[IDVA5-2015]: https://companieshouse.atlassian.net/browse/IDVA5-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ