### PR TITLE
IDVA5-2082 Remove AML with date of change

### DIFF
--- a/src/common/__utils/constants.ts
+++ b/src/common/__utils/constants.ts
@@ -53,3 +53,6 @@ export const ACSP_UPDATE_CHANGE_DATE = {
     REGISTERED_OFFICE_ADDRESS: "registeredOfficeAddress",
     CORRESPONDENCE_ADDRESS: "correspondenceAddress"
 };
+export const AML_REMOVAL_INDEX = "amlRemovalIndex";
+export const AML_REMOVAL_BODY = "amlRemovalBody";
+export const AML_REMOVED_BODY_DETAILS = "amlRemovedBodyDetails";

--- a/src/common/__utils/sessionHelper.ts
+++ b/src/common/__utils/sessionHelper.ts
@@ -5,6 +5,7 @@ import {
     ACSP_DETAILS_UPDATED,
     ACSP_DETAILS_UPDATE_IN_PROGRESS,
     ADDRESS_LIST,
+    AML_REMOVED_BODY_DETAILS,
     APPLICATION_ID,
     COMPANY,
     COMPANY_DETAILS,
@@ -46,4 +47,5 @@ export const deleteAllSessionData = async (session: Session) => {
     session.deleteExtraData(ACSP_DETAILS);
     session.deleteExtraData(ACSP_DETAILS_UPDATED);
     session.deleteExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS);
+    session.deleteExtraData(AML_REMOVED_BODY_DETAILS);
 };

--- a/src/controllers/features/update-acsp/dateOfTheChangeController.ts
+++ b/src/controllers/features/update-acsp/dateOfTheChangeController.ts
@@ -7,7 +7,7 @@ import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../.
 import { getPreviousPageUrlDateOfChange, updateWithTheEffectiveDateAmendment } from "../../../services/update-acsp/dateOfTheChangeService";
 import { Session } from "@companieshouse/node-session-handler";
 import { AmlSupervisoryBody } from "@companieshouse/api-sdk-node/dist/services/acsp";
-import { AML_REMOVAL_BODY, AML_REMOVAL_INDEX, AML_REMOVED_BODY_DETAILS } from "../../../common/__utils/constants";
+import { ACSP_UPDATE_PREVIOUS_PAGE_URL, AML_REMOVAL_BODY, AML_REMOVAL_INDEX, AML_REMOVED_BODY_DETAILS } from "../../../common/__utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -51,8 +51,8 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const previousPage: string = addLangToUrl(prevUrl, lang);
         const amlRemovalIndex = session.getExtraData(AML_REMOVAL_INDEX);
         const amlRemovalBody = session.getExtraData(AML_REMOVAL_BODY);
-        const isAmlSupervisionStart = previousPage.includes(UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER);
-        const isAmlSupervisionEnd = previousPage.includes(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS);
+        const isAmlSupervisionStart = !!previousPage.includes(UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER);
+        const isAmlSupervisionEnd = !!previousPage.includes(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS);
         if (!errorList.isEmpty()) {
             const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
             res.status(400).render(config.UPDATE_DATE_OF_THE_CHANGE, {
@@ -83,7 +83,8 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                     }
                 ];
                 session.setExtraData(AML_REMOVED_BODY_DETAILS, updatedRemovedAMLDetails);
-                res.redirect(addLangToUrl(`${UPDATE_ACSP_DETAILS_BASE_URL + REMOVE_AML_SUPERVISOR}?amlindex=${amlRemovalIndex}&amlbody=${amlRemovalBody}`, lang));
+                session.deleteExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL);
+                res.redirect(addLangToUrl(`${UPDATE_ACSP_DETAILS_BASE_URL + REMOVE_AML_SUPERVISOR}?amlindex=${amlRemovalIndex}&amlbody=${amlRemovalBody}&return=your-updates`, lang));
             } else {
                 updateWithTheEffectiveDateAmendment(req, dateOfChange.toISOString());
                 res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CHECK_YOUR_UPDATES, lang));

--- a/src/controllers/features/update-acsp/dateOfTheChangeController.ts
+++ b/src/controllers/features/update-acsp/dateOfTheChangeController.ts
@@ -2,27 +2,38 @@ import { NextFunction, Request, Response } from "express";
 import * as config from "../../../config";
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
-import { UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE, UPDATE_CHECK_YOUR_UPDATES, UPDATE_YOUR_ANSWERS, AML_MEMBERSHIP_NUMBER } from "../../../types/pageURL";
+import { UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE, UPDATE_CHECK_YOUR_UPDATES, UPDATE_YOUR_ANSWERS, AML_MEMBERSHIP_NUMBER, REMOVE_AML_SUPERVISOR } from "../../../types/pageURL";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { getPreviousPageUrlDateOfChange, updateWithTheEffectiveDateAmendment } from "../../../services/update-acsp/dateOfTheChangeService";
+import { Session } from "@companieshouse/node-session-handler";
+import { ACSP_DETAILS_UPDATED, AML_REMOVAL_BODY, AML_REMOVAL_INDEX, AML_REMOVED_BODY_DETAILS } from "../../../common/__utils/constants";
+import { AcspFullProfile } from "../../../model/AcspFullProfile";
+import { AmlSupervisoryBody } from "@companieshouse/api-sdk-node/dist/services/acsp";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
+        const session: Session = req.session as any as Session;
         const cancelTheUpdateUrl = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang);
         const prevUrl = getPreviousPageUrlDateOfChange(req) || UPDATE_ACSP_DETAILS_BASE_URL;
         const previousPage: string = addLangToUrl(prevUrl, lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE;
 
-        const isAmlSupervisionStart = previousPage.includes(UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER);
+        // Save the AML removal index and body to the session to send to remove aml url
+        session.setExtraData(AML_REMOVAL_INDEX, req.query.amlindex);
+        session.setExtraData(AML_REMOVAL_BODY, req.query.amlbody);
+
+        const isAmlSupervisionStart = !!previousPage.includes(UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER);
+        const isAmlSupervisionEnd = !!previousPage.includes(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS);
 
         res.render(config.UPDATE_DATE_OF_THE_CHANGE, {
             ...getLocaleInfo(locales, lang),
             previousPage,
             cancelTheUpdateUrl,
             currentUrl,
-            isAmlSupervisionStart
+            isAmlSupervisionStart,
+            isAmlSupervisionEnd
         });
     } catch (err) {
         next(err);
@@ -34,10 +45,16 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const errorList = validationResult(req);
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
+        const session: Session = req.session as any as Session;
         const cancelTheUpdateUrl = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang);
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE;
         const prevUrl = getPreviousPageUrlDateOfChange(req) || UPDATE_ACSP_DETAILS_BASE_URL;
         const previousPage: string = addLangToUrl(prevUrl, lang);
+        const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+        const amlRemovalIndex = session.getExtraData(AML_REMOVAL_INDEX);
+        const amlRemovalBody = session.getExtraData(AML_REMOVAL_BODY);
+        const isAmlSupervisionStart = previousPage.includes(UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER);
+        const isAmlSupervisionEnd = previousPage.includes(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS);
         if (!errorList.isEmpty()) {
             const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
             res.status(400).render(config.UPDATE_DATE_OF_THE_CHANGE, {
@@ -46,7 +63,9 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 currentUrl,
                 cancelTheUpdateUrl,
                 pageProperties: pageProperties,
-                payload: req.body
+                payload: req.body,
+                isAmlSupervisionStart,
+                isAmlSupervisionEnd
             });
         } else {
             const dateOfChange = new Date(
@@ -54,7 +73,34 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 req.body["change-month"] - 1,
                 req.body["change-day"]);
             updateWithTheEffectiveDateAmendment(req, dateOfChange.toISOString());
-            res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CHECK_YOUR_UPDATES, lang));
+
+            if (amlRemovalIndex && amlRemovalBody) {
+                // Store the dateOfChange in acspUpdatedFullProfile
+                const indexAML = acspUpdatedFullProfile.amlDetails.findIndex(aml => (
+                    aml.membershipDetails === amlRemovalIndex && aml.supervisoryBody === amlRemovalBody
+                ));
+
+                if (indexAML >= 0) {
+                    acspUpdatedFullProfile.amlDetails[indexAML].dateOfChange = dateOfChange;
+                    session.setExtraData(ACSP_DETAILS_UPDATED, acspUpdatedFullProfile);
+                }
+
+                // Store the dateOfChange separately in REMOVED_AML_DETAILS
+                const removedAMLDetails: AmlSupervisoryBody[] = session.getExtraData(AML_REMOVED_BODY_DETAILS) ?? [];
+                const updatedRemovedAMLDetails = [
+                    ...removedAMLDetails,
+                    {
+                        amlSupervisoryBody: amlRemovalBody,
+                        membershipId: amlRemovalIndex,
+                        dateOfChange: dateOfChange.toISOString()
+                    }
+                ];
+                session.setExtraData(AML_REMOVED_BODY_DETAILS, updatedRemovedAMLDetails);
+
+                res.redirect(addLangToUrl(`${UPDATE_ACSP_DETAILS_BASE_URL + REMOVE_AML_SUPERVISOR}?amlindex=${amlRemovalIndex}&amlbody=${amlRemovalBody}`, lang));
+            } else {
+                res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CHECK_YOUR_UPDATES, lang));
+            }
         }
     } catch (err) {
         next(err);

--- a/src/controllers/features/update-acsp/yourUpdatesController.ts
+++ b/src/controllers/features/update-acsp/yourUpdatesController.ts
@@ -23,7 +23,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
         const yourDetails = getFormattedUpdates(session, acspFullProfile, acspUpdatedFullProfile);
         const addedAMLBodies = getFormattedAddedAMLUpdates(acspFullProfile, acspUpdatedFullProfile);
-        const removedAMLBodies = getFormattedRemovedAMLUpdates(acspFullProfile, acspUpdatedFullProfile);
+        const removedAMLBodies = getFormattedRemovedAMLUpdates(session, acspFullProfile, acspUpdatedFullProfile);
 
         let redirectQuery = "your-updates";
         if (Object.keys(yourDetails).length + addedAMLBodies.length + removedAMLBodies.length === 1) {
@@ -60,7 +60,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const errorList = validationResult(req);
         const yourDetails = getFormattedUpdates(session, acspFullProfile, acspUpdatedFullProfile);
         const addedAMLBodies = getFormattedAddedAMLUpdates(acspFullProfile, acspUpdatedFullProfile);
-        const removedAMLBodies = getFormattedRemovedAMLUpdates(acspFullProfile, acspUpdatedFullProfile);
+        const removedAMLBodies = getFormattedRemovedAMLUpdates(session, acspFullProfile, acspUpdatedFullProfile);
 
         let redirectQuery = "your-updates";
         if (Object.keys(yourDetails).length + addedAMLBodies.length + removedAMLBodies.length === 1) {

--- a/src/services/update-acsp/amlSupervisorService.ts
+++ b/src/services/update-acsp/amlSupervisorService.ts
@@ -1,7 +1,8 @@
 import { Session } from "@companieshouse/node-session-handler";
-import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../common/__utils/constants";
+import { ACSP_DETAILS, ACSP_DETAILS_UPDATED, AML_REMOVED_BODY_DETAILS } from "../../common/__utils/constants";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { Request } from "express";
+import { AmlSupervisoryBody } from "@companieshouse/api-sdk-node/dist/services/acsp";
 
 export const amlSupervisor = (req: Request): void => {
     const amlRemovalIndex = req.query.amlindex;
@@ -9,6 +10,7 @@ export const amlSupervisor = (req: Request): void => {
     const session: Session = req.session as any as Session;
     const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
     const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+    const removedAMLDetails: AmlSupervisoryBody[] = session.getExtraData(AML_REMOVED_BODY_DETAILS) ?? [];
     if (amlRemovalIndex && amlRemovalBody) {
         const indexAMLForRemoval = acspUpdatedFullProfile.amlDetails.findIndex(tmpRemovedAml => (
             tmpRemovedAml.membershipDetails === amlRemovalIndex && tmpRemovedAml.supervisoryBody === amlRemovalBody
@@ -23,6 +25,12 @@ export const amlSupervisor = (req: Request): void => {
                 ? acspUpdatedFullProfile.amlDetails.splice(indexAMLForRemoval, 1) : acspUpdatedFullProfile.amlDetails.pop();
         } else if (indexAMLForUndoRemoval >= 0) {
             acspUpdatedFullProfile.amlDetails.splice(indexAMLForUndoRemoval, 0, acspFullProfile.amlDetails[indexAMLForUndoRemoval]);
+
+            // Remove the corresponding entry from AML_REMOVED_BODY_DETAILS
+            const updatedRemovedAMLDetails = removedAMLDetails.filter(removedDetail =>
+                !(removedDetail.membershipId === amlRemovalIndex && removedDetail.amlSupervisoryBody === amlRemovalBody)
+            );
+            session.setExtraData(AML_REMOVED_BODY_DETAILS, updatedRemovedAMLDetails);
         }
     }
 };

--- a/src/views/features/update-acsp-details/date-of-the-change/date-of-the-change.njk
+++ b/src/views/features/update-acsp-details/date-of-the-change/date-of-the-change.njk
@@ -8,6 +8,9 @@
 {% if isAmlSupervisionStart %}
   {% set pageTitle = i18n.updateDateAMLSupervisionStart %}
   {% set pageHintText = i18n.dateOfChangeAMLSupervisionStartHint %}
+{% elif isAmlSupervisionEnd %}
+  {% set pageTitle = i18n.updateDateAMLSupervisionEnd %}
+  {% set pageHintText = i18n.dateOfChangeAMLSupervisionEndHint %}
 {% else %}
   {% set pageTitle = i18n.updateDateThisChanged %}
   {% set pageHintText = i18n.dateOfChangeHint %}

--- a/src/views/features/update-acsp-details/update-your-details.njk
+++ b/src/views/features/update-acsp-details/update-your-details.njk
@@ -6,7 +6,16 @@
 {% for body in acspFullProfile.amlDetails %}
     {% set chkFlagForAMLRemoval = true %}
     {% set updateAMLDetailsStatusText = "" %}
+    {% set dateOfChange = "" %}
     {% set amlActionText = i18n.updateYourDetailsRemove %}
+    {% set amlActionLink = dateOfChangeUrl %}
+
+    {% for removedAml in formattedRemovedAMLDetails %}
+        {% if body.supervisoryBody === removedAml.amlSupervisoryBody and body.membershipDetails === removedAml.membershipId %}
+            {% set dateOfChange = removedAml.dateOfChange %}
+        {% endif %}
+    {% endfor %}
+
     {% if chkFlagForAMLRemoval === true %}
         {% for bodyUpdated in acspUpdatedFullProfile.amlDetails %}
             {% if body.supervisoryBody === bodyUpdated.supervisoryBody and body.membershipDetails === bodyUpdated.membershipDetails%}
@@ -16,8 +25,10 @@
     {%endif%}
         {% if chkFlagForAMLRemoval %}
             {% set amlActionText = i18n.updateYourDetailsCancel %}
+            {% set amlActionLink = removeAMLUrl %}
             {% set updateAMLDetailsStatusText =
                             "<div class='govuk-!-static-padding-top-3'>
+                            <p class='govuk-body govuk-!-static-margin-top-2'>"+i18n.updateYourDetailsEndedOn+" "+dateOfChange+"</p>
                             <p class='govuk-tag govuk-tag--red govuk-!-static-margin-bottom-1'>"+i18n.updateAMLDetailsRemoved+"</p>
                             <p class='govuk-body-s'>"+i18n.updateAMLDetailsStatusLineOne+"<br>"+i18n.updateAMLDetailsStatusLineTwo+"</p>
                             </div>"
@@ -35,7 +46,7 @@
         actions: {
             items: [
             {
-                href: removeAMLUrl + "&amlindex=" + body.membershipDetails + "&amlbody=" + body.supervisoryBody,
+                href: amlActionLink + "&amlindex=" + body.membershipDetails + "&amlbody=" + body.supervisoryBody,
                 text: amlActionText,
                 visuallyHiddenText: AMLSupervioryBodiesFormatted[body.supervisoryBody]
             }],

--- a/test/src/services/update_acsp/yourUpdatesService.test.ts
+++ b/test/src/services/update_acsp/yourUpdatesService.test.ts
@@ -166,9 +166,10 @@ describe("yourUpdatesService", () => {
     });
 
     it("should format removed AML updates", () => {
+        const session: Session = req.session as any as Session;
         acspFullProfile.amlDetails = [{ supervisoryBody: "association-of-chartered-certified-accountants-acca", membershipDetails: "123" }];
         updatedFullProfile.amlDetails = [];
-        const removedAMLUpdates = getFormattedRemovedAMLUpdates(acspFullProfile, updatedFullProfile);
+        const removedAMLUpdates = getFormattedRemovedAMLUpdates(session, acspFullProfile, updatedFullProfile);
         expect(removedAMLUpdates).toEqual([{
             membershipName: "association-of-chartered-certified-accountants-acca",
             membershipNumber: "123",


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2082

- Added dateOfChange screen to the flow for Remove AML. The 'Remove' links on Update Your Details previously called the removeAmlSupervisorController but now go to dateOfChange for pre-existing AML bodies, and retains the removeAmlSupervisorController url for newly added AML bodies.
- The amlIndex and amlBody are being passed as query params as before but to dateOfChange screen where they are saved in the session.
- As the AML body details are removed from acspUpdatedFullProfile I created a session variable AML_REMOVED_BODY_DETAILS to store the body, membershipId and dateOfChange which can then be accessed on the views to display to the user.
- If an AML is removed and then this is cancelled, AML_REMOVED_BODY_DETAILS is updated to remove these details from the array to keep it updated.
- AML_REMOVED_BODY_DETAILS is cleared upon success confirmation screen