### PR TITLE
IDVA5-2101 Update ACSP - Your Updates - AML edit links

### DIFF
--- a/src/controllers/features/update-acsp/addAmlSupervisorController.ts
+++ b/src/controllers/features/update-acsp/addAmlSupervisorController.ts
@@ -14,11 +14,17 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const session = req.session as Session;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
-        const update: number | undefined = req.query.update as number | undefined;
+        const amlUpdateIndex = req.query.amlindex;
+        const amlUpdateBody = req.query.amlbody;
+        let indexForTheUpdate = -1;
         let amlBody = "";
-        if (update) {
-            amlBody = acspUpdatedFullProfile.amlDetails[update].supervisoryBody!;
-            session.setExtraData(ADD_AML_BODY_UPDATE, update);
+
+        if (amlUpdateIndex && amlUpdateBody) {
+            indexForTheUpdate = acspUpdatedFullProfile.amlDetails.findIndex(amlToBeUpdated => (
+                amlToBeUpdated.membershipDetails === amlUpdateIndex && amlToBeUpdated.supervisoryBody === amlUpdateBody
+            ));
+            amlBody = acspUpdatedFullProfile.amlDetails[indexForTheUpdate].supervisoryBody!;
+            session.setExtraData(ADD_AML_BODY_UPDATE, indexForTheUpdate);
         }
 
         const newAmlBodyData = session.getExtraData(NEW_AML_BODY);

--- a/src/views/features/update-acsp-details/update-your-details.njk
+++ b/src/views/features/update-acsp-details/update-your-details.njk
@@ -72,7 +72,7 @@
                 actions: {
                     items: [
                         {
-                            href: addAML + "&update=" + loop.index0,
+                            href: addAML + "&amlindex=" + bodyAdded.membershipDetails + "&amlbody=" + bodyAdded.supervisoryBody,
                             text: i18n.updateYourDetailsUpdate,
                             visuallyHiddenText: AMLSupervioryBodiesFormatted[bodyAdded.supervisoryBody]
                         },

--- a/src/views/partials/your-updates-add-aml.njk
+++ b/src/views/partials/your-updates-add-aml.njk
@@ -10,7 +10,7 @@
       actions: {
         items: [
           {
-            href: addAMLUrl + "&update=" + loop.index0,
+            href: addAMLUrl + "&amlindex=" + body.membershipNumber + "&amlbody=" + body.membershipName,
             text: i18n.Edit,
             visuallyHiddenText: AMLSupervioryBodiesFormatted[body.membershipName]
           },

--- a/test/src/controllers/updateAcspDetails/addAmlSupervisorController.test.ts
+++ b/test/src/controllers/updateAcspDetails/addAmlSupervisorController.test.ts
@@ -39,12 +39,39 @@ describe("GET" + UPDATE_ADD_AML_SUPERVISOR, () => {
         expect(mocks.mockUpdateAcspAuthenticationMiddleware).toHaveBeenCalled();
         expect(res.text).toContain("Which Anti-Money Laundering (AML) supervisory bodies are you registered with?");
     });
-    it("should return status 200", async () => {
-        const res = await router.get(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_ADD_AML_SUPERVISOR + "?update=0");
-        expect(res.status).toBe(200);
+    it("should update the session with the correct AML supervisory body index when amlUpdateIndex and amlUpdateBody are provided", async () => {
+        const mockAmlDetails = [
+            { membershipDetails: "12345", supervisoryBody: "Body A" },
+            { membershipDetails: "67890", supervisoryBody: "Body B" }
+        ];
+        session.getExtraData = jest.fn().mockImplementation(() => {
+            return { amlDetails: mockAmlDetails };
+        });
+
+        const response = await supertest(app)
+            .get(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_ADD_AML_SUPERVISOR)
+            .query({ amlUpdateIndex: "1", amlUpdateBody: "Body B" });
+
+        expect(response.status).toBe(200);
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
         expect(mocks.mockUpdateAcspAuthenticationMiddleware).toHaveBeenCalled();
-        expect(res.text).toContain("Which Anti-Money Laundering (AML) supervisory bodies are you registered with?");
+        expect(response.text).toContain("Which Anti-Money Laundering (AML) supervisory bodies are you registered with?");
+    });
+
+    it("should not update the session if amlUpdateIndex and amlUpdateBody do not match any AML details", async () => {
+        const mockAmlDetails = [
+            { membershipDetails: "12345", supervisoryBody: "Body A" },
+            { membershipDetails: "67890", supervisoryBody: "Body B" }
+        ];
+        session.getExtraData = jest.fn().mockImplementation(() => {
+            return { amlDetails: mockAmlDetails };
+        });
+
+        const response = await supertest(app)
+            .get(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_ADD_AML_SUPERVISOR)
+            .query({ amlUpdateIndex: "1", amlUpdateBody: "Body B" });
+
+        expect(response.status).toBe(200);
     });
     it("should set amlBody if NEW_AML_BODY is present in session", async () => {
         const amlSupervisoryBody = "Some Supervisory Body";


### PR DESCRIPTION
The edit option of a newly added AML wasn't working due to incorrect url formation with the wrong parameters. Fixed it by:

- Modifying the query strings
- Modifying the njks

https://companieshouse.atlassian.net/browse/IDVA5-2101