### PR TITLE
Fix to not track user email in Matomo from mobile navbar

### DIFF
--- a/src/views/partials/piwik.njk
+++ b/src/views/partials/piwik.njk
@@ -87,7 +87,12 @@
 
         //  The block below covers the Matomo analysis for the href clicks.
           $(document).on("click", "a", function() {
-            textOnHrefClick = $(this).text();
+            // Don't track email on click of mobile navbar
+            if ($(this).attr('href') && $(this).attr('href') === "#navigation") {
+              textOnHrefClick = $(this).children().text()
+            } else {
+              textOnHrefClick = $(this).text();
+            }
             if(textOnHrefClick){
               _paq.push(["trackEvent", eventCategory, textOnHrefClick]);
             }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2064

Same approach we did on Verify A Client to stop the tracking of the user email in Matomo when clicking it on the mobile navbar. Will now track as this:

![Screenshot 2025-04-24 at 11 12 23](https://github.com/user-attachments/assets/08ae8989-6997-4054-a82f-56577ce150e7)
