### PR TITLE
Updating business name validation and content ltd journey update acsp

### DIFF
--- a/locales/cy/what-is-the-business-name.json
+++ b/locales/cy/what-is-the-business-name.json
@@ -3,9 +3,17 @@
     "whatIsTheBusinessNameTitleInput" : "Cofnodwch enw'r busnes",
     "whatIsTheBusinessNameDifferentName" : "Enw gwahanol",
 
+    "whatIsTheCompanyNameTitle": "What is the name of the company? Welsh",
+    "whatIsTheCompanyNameInsetText": "This must be the same as the name that's: Welsh",
+    "whatIsTheCompanyNameShownOnThe": "shown on the Welsh",
+    "whatIsTheCompanyNameCompaniesHouseRegLink": "Companies House register (opens in a new tab) Welsh",
+    "whatIsTheCompanyNameHeldByAml": "held by the Anti-Money Laundering (AML) supervisory body Welsh",
+
     "error-whatIsTheBusinessNameSelectRadio" : "Dewiswch enw busnes",
     "error-whatIsTheBusinessNameNoName" : "Cofnodwch enw'r busnes",
     "error-whatIsTheBusinessNameInvalidCharacters" : "Rhaid i'r enw busnes gynnwys llythrennau a i z yn unig, a nodau arbennig cyffredin fel cysylltnodau, bylchau a chollnodau",
     "error-whatIsTheBusinessNameCharactersLimit" : "Rhaid i'r enw busnes fod yn 155 nod neu lai",
-    "error-whatIsTheBusinessNameNoChangeUpdateAcsp" : "Update the business name if it's changed or cancel the update Welsh"
+    "error-whatIsTheBusinessNameNoChangeUpdateAcsp" : "Update the business name if it's changed or cancel the update Welsh",
+    "error-whatIsTheBusinessNameNoChangeUpdateAcspLtd" : "Update the company name if it’s changed or cancel the update Welsh",
+    "error-whatIsTheBusinessNameNoNameUpdateAcspLtd" : "Enter the company name or cancel the update Welsh"
 }

--- a/locales/en/what-is-the-business-name.json
+++ b/locales/en/what-is-the-business-name.json
@@ -14,6 +14,6 @@
     "error-whatIsTheBusinessNameInvalidCharacters" : "Business name must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes",
     "error-whatIsTheBusinessNameCharactersLimit" : "Business name must be 155 characters or less",
     "error-whatIsTheBusinessNameNoChangeUpdateAcsp" : "Update the business name if it's changed or cancel the update",
-    "error-whatIsTheCompanyNameNoChangeUpdateAcspLtd" : "Update the company name if it’s changed or cancel the update",
+    "error-whatIsTheCompanyNameNoChangeUpdateAcspLtd" : "Update the company name if it's changed or cancel the update",
     "error-whatIsTheCompanyNameNoNameUpdateAcspLtd" : "Enter the company name or cancel the update"
 }

--- a/locales/en/what-is-the-business-name.json
+++ b/locales/en/what-is-the-business-name.json
@@ -3,9 +3,17 @@
     "whatIsTheBusinessNameTitleInput" : "Enter the business name",
     "whatIsTheBusinessNameDifferentName" : "A different name",
 
+    "whatIsTheCompanyNameTitle": "What is the name of the company?",
+    "whatIsTheCompanyNameInsetText": "This must be the same as the name that's:",
+    "whatIsTheCompanyNameShownOnThe": "shown on the ",
+    "whatIsTheCompanyNameCompaniesHouseRegLink": "Companies House register (opens in a new tab)",
+    "whatIsTheCompanyNameHeldByAml": "held by the Anti-Money Laundering (AML) supervisory body",
+
     "error-whatIsTheBusinessNameSelectRadio" : "Select business name",
     "error-whatIsTheBusinessNameNoName" : "Enter the business name",
     "error-whatIsTheBusinessNameInvalidCharacters" : "Business name must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes",
     "error-whatIsTheBusinessNameCharactersLimit" : "Business name must be 155 characters or less",
-    "error-whatIsTheBusinessNameNoChangeUpdateAcsp" : "Update the business name if it's changed or cancel the update"
+    "error-whatIsTheBusinessNameNoChangeUpdateAcsp" : "Update the business name if it's changed or cancel the update",
+    "error-whatIsTheCompanyNameNoChangeUpdateAcspLtd" : "Update the company name if it’s changed or cancel the update",
+    "error-whatIsTheCompanyNameNoNameUpdateAcspLtd" : "Enter the company name or cancel the update"
 }

--- a/src/common/__utils/constants.ts
+++ b/src/common/__utils/constants.ts
@@ -39,6 +39,11 @@ export const ACSP_PROFILE_TYPE_LIMITED_COMPANY:string = "limited-company";
 export const ACSP_PROFILE_TYPE_LIMITED_LIABILITY_PARTNERSHIP:string = "limited-liability-partnership";
 export const ACSP_PROFILE_TYPE_CORPORATE_BODY:string = "corporate-body";
 export const ACSP_PROFILE_TYPE_SOLE_TRADER:string = "sole-trader";
+export const LIMITED_BUSINESS_TYPES = [
+    ACSP_PROFILE_TYPE_LIMITED_COMPANY,
+    ACSP_PROFILE_TYPE_LIMITED_LIABILITY_PARTNERSHIP,
+    ACSP_PROFILE_TYPE_CORPORATE_BODY
+];
 export const UPDATE_DESCRIPTION: string = "Update the authorised agent's details";
 export const UPDATE_REFERENCE: string = "ACSP update details";
 export const UPDATE_SUBMISSION_ID: string = "updateSubmissionId";

--- a/src/common/__utils/constants.ts
+++ b/src/common/__utils/constants.ts
@@ -60,4 +60,3 @@ export const REGISTRATION = "registration";
 export const UPDATE = "update";
 export const SERVICE_ADDRESS = "serviceAddress";
 export const REGISTERED_OFFICE_ADDRESS = "registeredOfficeAddress";
-export const CH_REGISTER_URL: string = "https://find-and-update.company-information.service.gov.uk/";

--- a/src/common/__utils/constants.ts
+++ b/src/common/__utils/constants.ts
@@ -60,3 +60,4 @@ export const REGISTRATION = "registration";
 export const UPDATE = "update";
 export const SERVICE_ADDRESS = "serviceAddress";
 export const REGISTERED_OFFICE_ADDRESS = "registeredOfficeAddress";
+export const CH_REGISTER_URL: string = "https://find-and-update.company-information.service.gov.uk/";

--- a/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
+++ b/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
@@ -5,7 +5,7 @@ import { formatValidationError, getPageProperties } from "../../../validation/va
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS_UPDATE_ELEMENT, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATE_ELEMENT, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED, CH_REGISTER_URL } from "../../../common/__utils/constants";
 import { UPDATE_WHAT_IS_THE_BUSINESS_NAME, UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE } from "../../../types/pageURL";
 import { getBusinessName } from "../../../services/common";
 
@@ -20,7 +20,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         };
         res.render(config.WHAT_IS_THE_BUSINESS_NAME, {
             typeOfBusiness: acspUpdatedFullProfile.type,
-            companiesHouseRegisterLink: "https://find-and-update.company-information.service.gov.uk/",
+            companiesHouseRegisterLink: CH_REGISTER_URL,
             previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
             ...getLocaleInfo(locales, lang),
             payload,

--- a/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
+++ b/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
@@ -19,6 +19,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             whatIsTheBusinessName: getBusinessName(acspUpdatedFullProfile.name)
         };
         res.render(config.WHAT_IS_THE_BUSINESS_NAME, {
+            typeOfBusiness: acspUpdatedFullProfile.type,
+            companiesHouseRegisterLink: "https://find-and-update.company-information.service.gov.uk/",
             previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
             ...getLocaleInfo(locales, lang),
             payload,
@@ -35,11 +37,13 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const locales = getLocalesService();
         const errorList = validationResult(req);
         const session: Session = req.session as any as Session;
+        const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
         if (!errorList.isEmpty()) {
             const pageProperties = getPageProperties(formatValidationError(errorList.array(), lang));
             res.status(400).render(config.WHAT_IS_THE_BUSINESS_NAME, {
                 previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
                 payload: req.body,
+                typeOfBusiness: acspUpdatedFullProfile.type,
                 ...getLocaleInfo(locales, lang),
                 currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_BUSINESS_NAME,
                 ...pageProperties

--- a/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
+++ b/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
@@ -50,6 +50,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 isLimitedBusiness,
                 typeOfBusiness: acspUpdatedFullProfile.type,
                 ...getLocaleInfo(locales, lang),
+                companiesHouseRegisterLink: CHS_URL,
                 currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_BUSINESS_NAME,
                 ...pageProperties
             });

--- a/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
+++ b/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
@@ -5,9 +5,10 @@ import { formatValidationError, getPageProperties } from "../../../validation/va
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS_UPDATE_ELEMENT, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED, CH_REGISTER_URL } from "../../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATE_ELEMENT, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 import { UPDATE_WHAT_IS_THE_BUSINESS_NAME, UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE } from "../../../types/pageURL";
 import { getBusinessName } from "../../../services/common";
+import { CHS_URL } from "../../../utils/properties";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -20,7 +21,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         };
         res.render(config.WHAT_IS_THE_BUSINESS_NAME, {
             typeOfBusiness: acspUpdatedFullProfile.type,
-            companiesHouseRegisterLink: CH_REGISTER_URL,
+            companiesHouseRegisterLink: CHS_URL,
             previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),
             ...getLocaleInfo(locales, lang),
             payload,

--- a/src/services/common.ts
+++ b/src/services/common.ts
@@ -1,4 +1,5 @@
 import { AcspData, Address } from "@companieshouse/api-sdk-node/dist/services/acsp";
+import { LIMITED_BUSINESS_TYPES } from "../common/__utils/constants";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 
 /**
@@ -90,4 +91,8 @@ export const trimAndLowercaseString = (name: string | undefined): string => {
         return "";
     }
     return name.trim().toLowerCase().replace(/\s+/g, " ");
+};
+
+export const isLimitedBusinessType = (type: string | undefined, businessTypes: string[] = LIMITED_BUSINESS_TYPES): boolean => {
+    return type ? businessTypes.includes(type) : false;
 };

--- a/src/validation/unicorporatedWhatIsTheBusinessName.ts
+++ b/src/validation/unicorporatedWhatIsTheBusinessName.ts
@@ -1,27 +1,38 @@
 import { Session } from "@companieshouse/node-session-handler";
 import { body } from "express-validator";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
+import { trimAndLowercaseString } from "../services/common";
 import { ACSP_DETAILS } from "../common/__utils/constants";
 
-const businessNameFormat:RegExp = /^[A-Za-z0-9\-&'.\s]*$/;
+const businessNameFormat: RegExp = /^[A-Za-z0-9\-&'.\s]*$/;
+const limitedBusinessTypes = ["limited-company", "limited-liability-partnership", "corporate-body"];
 
 export const unicorporatedWhatIsTheBusinessNameValidator = [
 
-    body("whatIsTheBusinessName").trim().notEmpty().withMessage("whatIsTheBusinessNameNoName").bail()
+    body("whatIsTheBusinessName").trim().notEmpty().withMessage((value, { req }) => {
+        const session: Session = req.session as Session;
+        const acspDetails: AcspFullProfile | undefined = session.getExtraData(ACSP_DETAILS);
+
+        if (acspDetails && limitedBusinessTypes.includes(acspDetails.type)) {
+            return "whatIsTheCompanyNameNoNameUpdateAcspLtd";
+        }
+        return "whatIsTheBusinessNameNoName";
+    }).bail()
         .matches(businessNameFormat).withMessage("whatIsTheBusinessNameInvalidCharacters").bail()
         .isLength({ max: 155 }).withMessage("whatIsTheBusinessNameCharactersLimit").bail()
-        .custom((inputBusinessName, { req }) => {
+        .custom((value, { req }) => {
             // Custom validation used for Update ACSP Details service
             // Check if the business name has changed through comparing the inputted business against the existing business name
             const session: Session = req.session as Session;
             const acspDetails: AcspFullProfile | undefined = session.getExtraData(ACSP_DETAILS);
 
             if (acspDetails) {
-                // Trim leading and trailing spaces, convert business name to lowercase, and replace multiple spaces with a single space
-                const normalisedBusinessName = inputBusinessName.trim().toLowerCase().replace(/\s+/g, " ");
-                const existingBusinessName = acspDetails.name.trim().toLowerCase().replace(/\s+/g, " ");
+                const normalisedBusinessName = trimAndLowercaseString(value);
+                const existingBusinessName = trimAndLowercaseString(acspDetails.name);
 
-                if (normalisedBusinessName === existingBusinessName) {
+                if (normalisedBusinessName === existingBusinessName && limitedBusinessTypes.includes(acspDetails.type)) {
+                    throw new Error("whatIsTheCompanyNameNoChangeUpdateAcspLtd");
+                } else if (normalisedBusinessName === existingBusinessName) {
                     throw new Error("whatIsTheBusinessNameNoChangeUpdateAcsp");
                 }
             }

--- a/src/validation/unicorporatedWhatIsTheBusinessName.ts
+++ b/src/validation/unicorporatedWhatIsTheBusinessName.ts
@@ -1,11 +1,10 @@
 import { Session } from "@companieshouse/node-session-handler";
 import { body } from "express-validator";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { trimAndLowercaseString } from "../services/common";
+import { trimAndLowercaseString, isLimitedBusinessType, getBusinessName } from "../services/common";
 import { ACSP_DETAILS } from "../common/__utils/constants";
 
 const businessNameFormat: RegExp = /^[A-Za-z0-9\-&'.\s]*$/;
-const limitedBusinessTypes = ["limited-company", "limited-liability-partnership", "corporate-body"];
 
 export const unicorporatedWhatIsTheBusinessNameValidator = [
 
@@ -13,7 +12,7 @@ export const unicorporatedWhatIsTheBusinessNameValidator = [
         const session: Session = req.session as Session;
         const acspDetails: AcspFullProfile | undefined = session.getExtraData(ACSP_DETAILS);
 
-        if (acspDetails && limitedBusinessTypes.includes(acspDetails.type)) {
+        if (acspDetails && isLimitedBusinessType(acspDetails.type)) {
             return "whatIsTheCompanyNameNoNameUpdateAcspLtd";
         }
         return "whatIsTheBusinessNameNoName";
@@ -28,9 +27,9 @@ export const unicorporatedWhatIsTheBusinessNameValidator = [
 
             if (acspDetails) {
                 const normalisedBusinessName = trimAndLowercaseString(value);
-                const existingBusinessName = trimAndLowercaseString(acspDetails.name);
+                const existingBusinessName = trimAndLowercaseString(getBusinessName(acspDetails.name));
 
-                if (normalisedBusinessName === existingBusinessName && limitedBusinessTypes.includes(acspDetails.type)) {
+                if (normalisedBusinessName === existingBusinessName && isLimitedBusinessType(acspDetails.type)) {
                     throw new Error("whatIsTheCompanyNameNoChangeUpdateAcspLtd");
                 } else if (normalisedBusinessName === existingBusinessName) {
                     throw new Error("whatIsTheBusinessNameNoChangeUpdateAcsp");

--- a/src/views/common/what-is-the-business-name/what-is-the-business-name.njk
+++ b/src/views/common/what-is-the-business-name/what-is-the-business-name.njk
@@ -3,13 +3,25 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% extends "layouts/default.njk" %}
 
-{% set title = i18n.whatIsTheBusinessNameTitle %}
+{% if reqType === "updateAcsp" and (typeOfBusiness === "limited-company" or typeOfBusiness === "limited-liability-partnership" or typeOfBusiness === "corporate-body") %}
+  {% set insetTextForLimitedJourneyUpdateAcsp = govukInsetText({
+    html: "<p class='govuk-body'>" + i18n.whatIsTheCompanyNameInsetText + "</p><ul class='govuk-list govuk-list--bullet'><li>" + i18n.whatIsTheCompanyNameShownOnThe + 
+          "<a class='govuk-link' id='companies-house-register-link' href='" + companiesHouseRegisterLink + "' target='_blank'>" + i18n.whatIsTheCompanyNameCompaniesHouseRegLink + "</a></li><li>" + 
+          i18n.whatIsTheCompanyNameHeldByAml + "</li></ul>"
+  }) %}
+  {% set title = i18n.whatIsTheCompanyNameTitle %}
+  {% set pageHeadingTitle = i18n.whatIsTheCompanyNameTitle %}
+{% else %}
+  {% set title = i18n.whatIsTheBusinessNameTitle %}
+  {% set pageHeadingTitle = i18n.whatIsTheBusinessNameTitle %}
+{% endif %}
+
 {% block main_content %}
   <form action="{{ currentUrl }}?lang={{ lang }}" method="POST">  
-    {% include "partials/csrf_token.njk" %}  
+    {% include "partials/csrf_token.njk" %}
     {{ govukInput({
       label: {
-        text: i18n.whatIsTheBusinessNameTitle,
+        text: pageHeadingTitle,
         classes: "govuk-label--l",
         isPageHeading: true
       },
@@ -23,6 +35,9 @@
     }) }}
     
     {% if reqType === "updateAcsp" %}
+      {% if insetTextForLimitedJourneyUpdateAcsp %}
+        {{ insetTextForLimitedJourneyUpdateAcsp }}
+      {% endif %}
       <div class="govuk-button-group">
         {{ govukButton({
           text: i18n.Continue,

--- a/src/views/common/what-is-the-business-name/what-is-the-business-name.njk
+++ b/src/views/common/what-is-the-business-name/what-is-the-business-name.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% extends "layouts/default.njk" %}
 
-{% if reqType === "updateAcsp" and (typeOfBusiness === "limited-company" or typeOfBusiness === "limited-liability-partnership" or typeOfBusiness === "corporate-body") %}
+{% if reqType === "updateAcsp" and isLimitedBusiness %}
   {% set insetTextForLimitedJourneyUpdateAcsp = govukInsetText({
     html: "<p class='govuk-body'>" + i18n.whatIsTheCompanyNameInsetText + "</p><ul class='govuk-list govuk-list--bullet'><li>" + i18n.whatIsTheCompanyNameShownOnThe + 
           "<a class='govuk-link' id='companies-house-register-link' href='" + companiesHouseRegisterLink + "' target='_blank'>" + i18n.whatIsTheCompanyNameCompaniesHouseRegLink + "</a></li><li>" + 

--- a/test/src/controllers/updateAcspDetails/whatIsTheBusinessNameController.test.ts
+++ b/test/src/controllers/updateAcspDetails/whatIsTheBusinessNameController.test.ts
@@ -71,7 +71,7 @@ describe("POST" + UPDATE_WHAT_IS_THE_BUSINESS_NAME, () => {
         expect(res.text).toContain("Enter the company name or cancel the update");
     });
 
-    it("should return status 400 and display error message when no change has been made to company name as a ltd company", async () => {
+    it("should return status 400 and display error message when no change has been made to ltd company name", async () => {
         mocks.mockSessionMiddleware.mockImplementation((req, res, next) => {
             req.session = {
                 getExtraData: jest.fn().mockReturnValue(mockLimitedAcspFullProfile)

--- a/test/src/controllers/updateAcspDetails/whatIsTheBusinessNameController.test.ts
+++ b/test/src/controllers/updateAcspDetails/whatIsTheBusinessNameController.test.ts
@@ -1,8 +1,9 @@
 /* eslint-disable import/first */
 import mocks from "../../../mocks/all_middleware_mock";
+import { mockLimitedAcspFullProfile } from "../../../mocks/update_your_details.mock";
 import supertest from "supertest";
 import app from "../../../../src/app";
-import { UPDATE_YOUR_ANSWERS, UPDATE_WHAT_IS_THE_BUSINESS_NAME, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE } from "../../../../src/types/pageURL";
+import { UPDATE_WHAT_IS_THE_BUSINESS_NAME, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE } from "../../../../src/types/pageURL";
 import * as localise from "../../../../src/utils/localise";
 
 jest.mock("@companieshouse/api-sdk-node");
@@ -53,6 +54,36 @@ describe("POST" + UPDATE_WHAT_IS_THE_BUSINESS_NAME, () => {
             });
         expect(res.status).toBe(400);
         expect(res.text).toContain("Update the business name if it&#39;s changed or cancel the update");
+    });
+
+    it("should return status 400 and display error message when no company name entered as a ltd company", async () => {
+        mocks.mockSessionMiddleware.mockImplementation((req, res, next) => {
+            req.session = {
+                getExtraData: jest.fn().mockReturnValue(mockLimitedAcspFullProfile)
+            };
+            next();
+        });
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_BUSINESS_NAME)
+            .send({
+                whatIsTheBusinessName: ""
+            });
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("Enter the company name or cancel the update");
+    });
+
+    it("should return status 400 and display error message when no change has been made to company name as a ltd company", async () => {
+        mocks.mockSessionMiddleware.mockImplementation((req, res, next) => {
+            req.session = {
+                getExtraData: jest.fn().mockReturnValue(mockLimitedAcspFullProfile)
+            };
+            next();
+        });
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_BUSINESS_NAME)
+            .send({
+                whatIsTheBusinessName: "Example ACSP Ltd"
+            });
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("Update the company name if it&#39;s changed or cancel the update");
     });
 
     it("should return status 500 when an error occurs", async () => {


### PR DESCRIPTION
Changes for ticket: 
[IDVA5-2054](https://companieshouse.atlassian.net/browse/IDVA5-2054?atlOrigin=eyJpIjoiNjkwNDQ1MWFmMGRkNGVmYzkwYmNmM2JmYjE5ZmQ2NWYiLCJwIjoiaiJ9)

- Updating Business name validation for Ltd companies
- Adding constant array of limited business types.
- Creating common service that checks if the business type is of limited types.
- Re-using new service function for normalising data for validation
- If no Company name is entered and user attempts to continue as a Ltd company then specific validation is flagged
- When ACSP profiles are approved by CHIPS, the string ‘ACSP’ is appended to the business name, however, we trim this string for display on the front end of our service. 
- Calling getBusinessName function on the existing business name before comparison, which trims the ‘ACSP’ string from the business name.
- If Company name hasn't been updated and user attempts to continue as a Ltd company then specific validation is flagged
- Updating front end view for Business name page on Update service when viewing service as a Ltd company
- Adding inset text to Business name page that is only visible to Ltd companies when viewing this page
- Adding unit tests

[IDVA5-2054]: https://companieshouse.atlassian.net/browse/IDVA5-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ