### PR TITLE
ACSP Update - Show Error and Allow User to use Manual Address Entry Screen for ''Border'' Postcode Lookup Issue

### DIFF
--- a/src/controllers/features/update-acsp/businessAddressAutoLookupController.ts
+++ b/src/controllers/features/update-acsp/businessAddressAutoLookupController.ts
@@ -71,14 +71,9 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_LIST).then(async (nextPageUrl) => {
 
                 res.redirect(nextPageUrl);
-            }).catch(() => {
-                const validationError : ValidationError[] = [{
-                    value: postcode,
-                    msg: "correspondenceLookUpAddressInvalidAddressPostcode",
-                    param: "postCode",
-                    location: "body"
-                }];
-                const pageProperties = getPageProperties(formatValidationError(validationError, lang));
+            }).catch((error) => {
+                const validationError = addressLookUpService.getErrorMessage(error, postcode);
+                const pageProperties = getPageProperties(formatValidationError([validationError], lang));
                 res.status(400).render(config.UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP, {
                     previousPage,
                     ...getLocaleInfo(locales, lang),

--- a/src/controllers/features/update-acsp/correspondenceAddressAutoLookupController.ts
+++ b/src/controllers/features/update-acsp/correspondenceAddressAutoLookupController.ts
@@ -75,14 +75,9 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 UPDATE_CORRESPONDENCE_ADDRESS_LIST).then(async (nextPageUrl) => {
 
                 res.redirect(nextPageUrl);
-            }).catch(() => {
-                const validationError : ValidationError[] = [{
-                    value: postcode,
-                    msg: "correspondenceLookUpAddressInvalidAddressPostcode",
-                    param: "postCode",
-                    location: "body"
-                }];
-                const pageProperties = getPageProperties(formatValidationError(validationError, lang));
+            }).catch((error) => {
+                const validationError = addressLookUpService.getErrorMessage(error, postcode);
+                const pageProperties = getPageProperties(formatValidationError([validationError], lang));
                 res.status(400).render(config.AUTO_LOOKUP_ADDRESS, {
                     previousPage,
                     ...getLocaleInfo(locales, lang),

--- a/src/services/address/addressLookUp.ts
+++ b/src/services/address/addressLookUp.ts
@@ -97,6 +97,9 @@ export class AddressLookUpService {
     public processAddressFromPostcodeUpdateJourney (req: Request, postcode: string, inputPremise: string, ...nexPageUrls: string[]) : Promise<string> {
         const lang = selectLang(req.query.lang);
         return getAddressFromPostcode(postcode).then((ukAddresses) => {
+            if (ukAddresses.some(address => address.country === "")) {
+                throw new Error("correspondenceLookUpAddressWithoutCountry");
+            } else {
             if (inputPremise !== "" && ukAddresses.find((address) => address.premise === inputPremise)) {
                 this.saveAddressUpdateJourney(req, ukAddresses, inputPremise);
                 return addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + nexPageUrls[0], lang);
@@ -111,7 +114,7 @@ export class AddressLookUpService {
 
                 return addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + nexPageUrls[1], lang);
             }
-
+        }
         }).catch((err) => {
             throw err;
         });

--- a/src/services/address/addressLookUp.ts
+++ b/src/services/address/addressLookUp.ts
@@ -100,21 +100,21 @@ export class AddressLookUpService {
             if (ukAddresses.some(address => address.country === "")) {
                 throw new Error("correspondenceLookUpAddressWithoutCountry");
             } else {
-            if (inputPremise !== "" && ukAddresses.find((address) => address.premise === inputPremise)) {
-                this.saveAddressUpdateJourney(req, ukAddresses, inputPremise);
-                return addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + nexPageUrls[0], lang);
-            } else {
-                this.saveAddressListToSession(req, ukAddresses);
+                if (inputPremise !== "" && ukAddresses.find((address) => address.premise === inputPremise)) {
+                    this.saveAddressUpdateJourney(req, ukAddresses, inputPremise);
+                    return addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + nexPageUrls[0], lang);
+                } else {
+                    this.saveAddressListToSession(req, ukAddresses);
 
-                const address: Address = {
-                    postalCode: req.body.postCode
-                };
-                const session: Session = req.session as any as Session;
-                session.setExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS, address);
+                    const address: Address = {
+                        postalCode: req.body.postCode
+                    };
+                    const session: Session = req.session as any as Session;
+                    session.setExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS, address);
 
-                return addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + nexPageUrls[1], lang);
+                    return addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + nexPageUrls[1], lang);
+                }
             }
-        }
         }).catch((err) => {
             throw err;
         });

--- a/test/src/controllers/updateAcspDetails/businessAddressAutoLookupController.test.ts
+++ b/test/src/controllers/updateAcspDetails/businessAddressAutoLookupController.test.ts
@@ -82,7 +82,7 @@ describe("POST" + UPDATE_BUSINESS_ADDRESS_LOOKUP, () => {
         expect(res.status).toBe(400);
         expect(res.text).toContain("We cannot find this postcode. Enter a different one, or enter the address manually");
     });
-
+UPDATE_ACSP_DETAILS_BASE_URL
     it("should return status 400 for invalid postcode entered", async () => {
         const formData = {
             postCode: "S6",
@@ -114,6 +114,18 @@ describe("POST" + UPDATE_BUSINESS_ADDRESS_LOOKUP, () => {
         const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP).send(formData);
         expect(res.status).toBe(400);
         expect(res.text).toContain("Enter a UK postcode or cancel the update if you do not need to change the correspondence address");
+    });
+
+    it("should return status 400 for no country found", async () => {
+        const formData = {
+            postCode: "AB12CD",
+            premise: ""
+        };
+        (getAddressFromPostcode as jest.Mock).mockRejectedValueOnce(new Error("correspondenceLookUpAddressWithoutCountry"));
+
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_BUSINESS_ADDRESS_LOOKUP).send(formData);
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("We cannot find the full address from the postcode. Enter the address manually");
     });
 
     it("should return status 400 when data entered has not changed", async () => {

--- a/test/src/controllers/updateAcspDetails/businessAddressAutoLookupController.test.ts
+++ b/test/src/controllers/updateAcspDetails/businessAddressAutoLookupController.test.ts
@@ -82,7 +82,7 @@ describe("POST" + UPDATE_BUSINESS_ADDRESS_LOOKUP, () => {
         expect(res.status).toBe(400);
         expect(res.text).toContain("We cannot find this postcode. Enter a different one, or enter the address manually");
     });
-UPDATE_ACSP_DETAILS_BASE_URL
+    UPDATE_ACSP_DETAILS_BASE_URL;
     it("should return status 400 for invalid postcode entered", async () => {
         const formData = {
             postCode: "S6",

--- a/test/src/controllers/updateAcspDetails/correspondenceAddressAutoLookupController.test.ts
+++ b/test/src/controllers/updateAcspDetails/correspondenceAddressAutoLookupController.test.ts
@@ -131,7 +131,17 @@ describe("POST" + UPDATE_CORRESPONDENCE_ADDRESS_LOOKUP, () => {
         expect(res.text).toContain("Enter a UK postcode or cancel the update if you do not need to change the correspondence address");
         expect(res.text).toContain("Update the property name or number if it’s changed or cancel the update if you do not need to make any changes");
     });
+    it("should return status 400 for no country found", async () => {
+        const formData = {
+            postCode: "AB12CD",
+            premise: ""
+        };
+        (getAddressFromPostcode as jest.Mock).mockRejectedValueOnce(new Error("correspondenceLookUpAddressWithoutCountry"));
 
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CORRESPONDENCE_ADDRESS_LOOKUP).send(formData);
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("We cannot find the full address from the postcode. Enter the address manually");
+    });
     it("should show the error page if an error occurs", async () => {
         const formData = {
             postCode: "ST63LJ",


### PR DESCRIPTION
On a situation of a postcode search returning country value as "" we are throwing the exception as given below:

https://companieshouse.atlassian.net/browse/IDVA5-2104