### PR TITLE
Removing autocomplete attribute from date of change field

### DIFF
--- a/src/views/features/update-acsp-details/date-of-the-change/date-of-the-change.njk
+++ b/src/views/features/update-acsp-details/date-of-the-change/date-of-the-change.njk
@@ -51,7 +51,6 @@
             {
               name: "day",
               classes: "govuk-input--error govuk-input--width-2" if errors else "govuk-input--width-2",
-              autocomplete: "change-day",
               id: "change-day",
               value: payload["change-day"],
               label: i18n.day
@@ -59,7 +58,6 @@
             {
               name: "month",
               classes: "govuk-input--error govuk-input--width-2" if errors else "govuk-input--width-2",
-              autocomplete: "change-month",
               id: "change-month",
               value: payload["change-month"],
               label: i18n.month
@@ -67,7 +65,6 @@
             {
               name: "year",
               classes: "govuk-input--error govuk-input--width-4" if errors else "govuk-input--width-4",
-              autocomplete: "change-year",
               id: "change-year",
               value: payload["change-year"],
               label: i18n.year


### PR DESCRIPTION
Ticket [IDVA5-2085](https://companieshouse.atlassian.net/browse/IDVA5-2085)

Removing autocomplete attribute from date of change field as it does not match a valid autocomplete attribute value 
https://www.w3schools.com/tags/att_input_autocomplete.asp

[IDVA5-2085]: https://companieshouse.atlassian.net/browse/IDVA5-2085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ