### PR TITLE
Allow dateOfChange to be updated and displayed after edit New AML

### DIFF
--- a/src/services/update-acsp/amlMembershipNumberService.ts
+++ b/src/services/update-acsp/amlMembershipNumberService.ts
@@ -46,6 +46,7 @@ export class AmlMembershipNumberService {
         if (updateBodyIndex !== undefined && updateBodyIndex >= 0) {
             acspUpdatedFullProfile.amlDetails[updateBodyIndex].supervisoryBody = newAMLBody.amlSupervisoryBody!;
             acspUpdatedFullProfile.amlDetails[updateBodyIndex].membershipDetails = newAMLBody.membershipId!;
+            acspUpdatedFullProfile.amlDetails[updateBodyIndex].dateOfChange = newAMLBody.dateOfChange!;
         } else {
             acspUpdatedFullProfile.amlDetails.push({
                 supervisoryBody: newAMLBody.amlSupervisoryBody!,

--- a/test/src/services/update_acsp/dateOfTheChangeService.test.ts
+++ b/test/src/services/update_acsp/dateOfTheChangeService.test.ts
@@ -194,6 +194,38 @@ describe("updateWithTheEffectiveDateAmendment", () => {
         expect(session.deleteExtraData).toHaveBeenCalledWith(ACSP_UPDATE_PREVIOUS_PAGE_URL);
 
     });
+
+    it("should update aml details when editing NEW_AML_BODY and push to acspUpdatedFullProfile when index exists", () => {
+        const dateOfChange = "2025-01-01T00:00:00.000Z";
+        const updatedDateOfChange = "2025-02-02T00:00:00.000Z";
+        const updateIndex = 0;
+        const acspUpdatedFullProfile: { amlDetails: AmlDetails[] } = {
+            amlDetails: [{
+                supervisoryBody: "association-of-chartered-certified-accountants-acca",
+                membershipDetails: "123456",
+                dateOfChange: dateOfChange
+            }]
+        };
+        const newAMLBody = {
+            amlSupervisoryBody: "hm-revenue-customs-hmrc",
+            membershipId: "654321",
+            dateOfChange: updatedDateOfChange
+        };
+
+        (session.getExtraData as jest.Mock).mockImplementation((key: string) => {
+            if (key === ACSP_DETAILS_UPDATE_ELEMENT) return UPDATE_ADD_AML_SUPERVISOR;
+            if (key === ADD_AML_BODY_UPDATE) return updateIndex;
+            if (key === NEW_AML_BODY) return newAMLBody;
+            if (key === ACSP_DETAILS_UPDATED) return acspUpdatedFullProfile;
+        });
+
+        updateWithTheEffectiveDateAmendment(req as Request, updatedDateOfChange);
+
+        expect(acspUpdatedFullProfile.amlDetails).toHaveLength(1);
+        expect(acspUpdatedFullProfile.amlDetails[0].supervisoryBody).toBe(newAMLBody.amlSupervisoryBody);
+        expect(acspUpdatedFullProfile.amlDetails[0].membershipDetails).toBe(newAMLBody.membershipId);
+        expect(acspUpdatedFullProfile.amlDetails[0].dateOfChange).toBe(newAMLBody.dateOfChange);
+    });
 });
 
 describe("getPreviousPageUrlDateOfChange", () => {


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-1849

When using 'Edit' link on Your Updates or 'Update' on Check Your Answers, the updated dateOfChange value was not being saved with the New AML Details. 

I've added this line in to allow it to be updated now.