### PR TITLE
Removing date of change text from email on your updates screen

### DIFF
--- a/locales/cy/your-updates.json
+++ b/locales/cy/your-updates.json
@@ -1,5 +1,5 @@
 {
-    "yourUpdatesHeading": "Your Updates Welsh",
+    "yourUpdatesHeading": "Your updates Welsh",
     "yourUpdatesPeningText": "The following updates are pending until you submit this filing, and we accept it. Welsh",
     "yourUpdatesDetails": "Eich manylion",
     "yourUpdatesName": "Enw",

--- a/locales/en/your-updates.json
+++ b/locales/en/your-updates.json
@@ -1,5 +1,5 @@
 {
-    "yourUpdatesHeading": "Your Updates",
+    "yourUpdatesHeading": "Your updates",
     "yourUpdatesPeningText": "The following updates are pending until you submit this filing, and we accept it.",
     "yourUpdatesDetails": "Your details",
     "yourUpdatesName": "Name",

--- a/src/views/features/update-acsp-details/your-updates/your-updates.njk
+++ b/src/views/features/update-acsp-details/your-updates/your-updates.njk
@@ -14,7 +14,7 @@
 {% endif %}
 
 {% block main_content %}
-<h1 class="govuk-heading-xl">{{ i18n.yourUpdatesHeading }}</h1>
+<h1 class="govuk-heading-l">{{ i18n.yourUpdatesHeading }}</h1>
 {{ govukInsetText({
   text: i18n.yourUpdatesPeningText
 }) }}
@@ -128,7 +128,7 @@
       classes: "govuk-!-width-one-third"
     },
     value: {
-      html: yourDetails.correspondenceEmail.value,
+      text: yourDetails.correspondenceEmail.value,
       classes: "govuk-!-width-one-third"
     },
     actions: {

--- a/src/views/features/update-acsp-details/your-updates/your-updates.njk
+++ b/src/views/features/update-acsp-details/your-updates/your-updates.njk
@@ -128,7 +128,7 @@
       classes: "govuk-!-width-one-third"
     },
     value: {
-      html: yourDetails.correspondenceEmail.value + "<br><br> Changed on " + yourDetails.correspondenceEmail.changedDate,
+      html: yourDetails.correspondenceEmail.value,
       classes: "govuk-!-width-one-third"
     },
     actions: {

--- a/test/src/controllers/updateAcspDetails/yourUpdatesController.test.ts
+++ b/test/src/controllers/updateAcspDetails/yourUpdatesController.test.ts
@@ -25,7 +25,7 @@ describe("GET " + UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CHECK_YOUR_UPDATES, () =
         const res = await router.get(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CHECK_YOUR_UPDATES);
         expect(mocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
         expect(mocks.mockUpdateAcspAuthenticationMiddleware).toHaveBeenCalled();
-        expect(res.text).toContain("Your Updates");
+        expect(res.text).toContain("Your updates");
         expect(res.status).toBe(200);
     });
 

--- a/test/src/controllers/updateAcspDetails/yourUpdatesController.test.ts
+++ b/test/src/controllers/updateAcspDetails/yourUpdatesController.test.ts
@@ -34,6 +34,7 @@ describe("GET " + UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CHECK_YOUR_UPDATES, () =
             throw new Error("Test error");
         });
         const res = await router.get(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CHECK_YOUR_UPDATES);
+
         expect(res.status).toBe(500);
         expect(res.text).toContain("Sorry we are experiencing technical difficulties");
     });


### PR DESCRIPTION
Fix for ticket:
[IDVA5-2119](https://companieshouse.atlassian.net/browse/IDVA5-2119?atlOrigin=eyJpIjoiMzlmNmEyOTIwMTk4NDVkOGFmMTM1NjI2MWVkMWJmZTMiLCJwIjoiaiJ9)

Also includes changes required for ticket:
[IDVA5-2121](https://companieshouse.atlassian.net/browse/IDVA5-2121)

- Removing 'Changed on' date text on Your Updates screen for Correspondence email address when an update has been made.
- It is no longer a requirement to include the changed on date when updating an email address
- Updating tab heading and page title from `Your Updates` -> `Your updates`
- Updating size of title text for Your updates, from xl to l

[IDVA5-2119]: https://companieshouse.atlassian.net/browse/IDVA5-2119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[IDVA5-2121]: https://companieshouse.atlassian.net/browse/IDVA5-2121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ