### PR TITLE
IDVA5-2116 - Add United Kingdom to list of countries for the registered office address manual entry screen

### DIFF
--- a/locales/cy/common-address-manual.json
+++ b/locales/cy/common-address-manual.json
@@ -16,7 +16,8 @@
     "northernIreland": "Gogledd Iwerddon",
     "wales": "Cymru",
     "selectCountry": "Dewiswch wlad",
-    
+    "unitedKingdom": "United Kingdom welsh",
+
     "error-noPropertyDetails": "Cofnodwch enw neu rif eiddo",
     "error-noAddressLine1": "Cofnodwch gyfeiriad",
     "error-noCityOrTown": "Cofnodwch ddinas neu dref",

--- a/locales/en/common-address-manual.json
+++ b/locales/en/common-address-manual.json
@@ -15,6 +15,7 @@
     "scotland": "Scotland",
     "northernIreland": "Northern Ireland",
     "wales": "Wales",
+    "unitedKingdom": "United Kingdom",
     "selectCountry": "Choose country",
 
     "error-noPropertyDetails": "Enter a property name or number",

--- a/src/views/features/unincorporated/business-address-manual-entry/business-address-manual-entry.njk
+++ b/src/views/features/unincorporated/business-address-manual-entry/business-address-manual-entry.njk
@@ -115,7 +115,11 @@
                 {
                     value: "Wales",
                     text: i18n.wales
-                }
+                },
+                {
+                    value: "United Kingdom",
+                    text: i18n.unitedKingdom
+                } if reqType === "updateAcsp"
             ]
         }) }}
         {{ govukInput({


### PR DESCRIPTION
Some limited businesses have ‘United Kingdom’ saved as the country field when they’re returned from the company profile API. 

We need to add ‘United Kingdom’ to the list of countries in the country drop down for the registered office address manual screen. 

Currently, the drop down has:

England

Northern Ireland

Scotland

Wales

But needs to have:

England

Northern Ireland

Scotland

Wales

United Kingdom