### PR TITLE
Removing lang set to i18n to allow language to be retained across navbar links

### DIFF
--- a/src/views/partials/nav/navbar.njk
+++ b/src/views/partials/nav/navbar.njk
@@ -1,5 +1,4 @@
 {% from "navbar.njk" import addPredefinedNavbar %}
-{% set lang = i18n %}
 
 {% if userEmail %}
     <div class="govuk-!-padding-top-2">


### PR DESCRIPTION
Bug fix for ticket:
[IDVA5-2129](https://companieshouse.atlassian.net/browse/IDVA5-2129)

- Removing lang set to i18n within njk file as lang is retrieved from common_variables_middleware.ts file

[IDVA5-2129]: https://companieshouse.atlassian.net/browse/IDVA5-2129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ