### PR TITLE
Add/Remove AML date screen title fix and renaming to ACSP_UPDATE_PREVIOUS_PAGE_URL

### DIFF
--- a/src/common/__utils/constants.ts
+++ b/src/common/__utils/constants.ts
@@ -10,7 +10,6 @@ export const USER_DATA = "user";
 export const ACSP_DETAILS = "acspDetails";
 export const ACSP_DETAILS_UPDATED = "updatedAcspDetails";
 export const ACSP_DETAILS_UPDATE_IN_PROGRESS = "inProgressAcspDetails";
-export const ACSP_DETAILS_UPDATE_ELEMENT = "elementOfACSPUpdate";
 export const COMPANY: string = "company";
 export const CORRESPONDENCE_ADDRESS: string = "correspondenceAddress";
 export const UNINCORPORATED_CORRESPONDENCE_ADDRESS: string = "unincorporated correspondenceAddress";

--- a/src/common/__utils/sessionHelper.ts
+++ b/src/common/__utils/sessionHelper.ts
@@ -4,6 +4,7 @@ import {
     ACSP_DETAILS,
     ACSP_DETAILS_UPDATED,
     ACSP_DETAILS_UPDATE_IN_PROGRESS,
+    ACSP_UPDATE_PREVIOUS_PAGE_URL,
     ADDRESS_LIST,
     AML_REMOVED_BODY_DETAILS,
     APPLICATION_ID,
@@ -48,4 +49,5 @@ export const deleteAllSessionData = async (session: Session) => {
     session.deleteExtraData(ACSP_DETAILS_UPDATED);
     session.deleteExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS);
     session.deleteExtraData(AML_REMOVED_BODY_DETAILS);
+    session.deleteExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL);
 };

--- a/src/controllers/features/update-acsp/amlMembershipNumberController.ts
+++ b/src/controllers/features/update-acsp/amlMembershipNumberController.ts
@@ -1,9 +1,9 @@
 import { NextFunction, Request, Response } from "express";
-import { AML_MEMBERSHIP_NUMBER, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_ADD_AML_SUPERVISOR, UPDATE_DATE_OF_THE_CHANGE, UPDATE_SELECT_AML_SUPERVISOR, UPDATE_YOUR_ANSWERS } from "../../../types/pageURL";
+import { AML_MEMBERSHIP_NUMBER, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_AML_MEMBERSHIP_NUMBER, UPDATE_DATE_OF_THE_CHANGE, UPDATE_SELECT_AML_SUPERVISOR, UPDATE_YOUR_ANSWERS } from "../../../types/pageURL";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import * as config from "../../../config";
 import { Session } from "@companieshouse/node-session-handler";
-import { ADD_AML_BODY_UPDATE, NEW_AML_BODY, REQ_TYPE_UPDATE_ACSP, ACSP_DETAILS_UPDATED, ACSP_DETAILS_UPDATE_ELEMENT } from "../../../common/__utils/constants";
+import { ADD_AML_BODY_UPDATE, NEW_AML_BODY, REQ_TYPE_UPDATE_ACSP, ACSP_DETAILS_UPDATED, ACSP_UPDATE_PREVIOUS_PAGE_URL } from "../../../common/__utils/constants";
 import { resolveErrorMessage } from "../../../validation/validation";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { ValidationError, validationResult } from "express-validator";
@@ -71,7 +71,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 // Save new AML membership number to session
                 newAMLBody.membershipId = req.body.membershipNumber_1;
                 session.setExtraData(NEW_AML_BODY, newAMLBody);
-                session.setExtraData(ACSP_DETAILS_UPDATE_ELEMENT, UPDATE_ADD_AML_SUPERVISOR);
+                session.setExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL, UPDATE_AML_MEMBERSHIP_NUMBER);
 
                 const nextPageUrl = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE, lang);
                 res.redirect(nextPageUrl);

--- a/src/controllers/features/update-acsp/businessAddressConfirmController.ts
+++ b/src/controllers/features/update-acsp/businessAddressConfirmController.ts
@@ -4,7 +4,7 @@ import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../.
 import { UPDATE_BUSINESS_ADDRESS_CONFIRM, UPDATE_BUSINESS_ADDRESS_MANUAL, UPDATE_BUSINESS_ADDRESS_LOOKUP, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE, UPDATE_YOUR_ANSWERS } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS_UPDATE_ELEMENT, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_UPDATE_PREVIOUS_PAGE_URL, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -33,7 +33,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const lang = selectLang(req.query.lang);
         const session: Session = req.session as any as Session;
-        session.setExtraData(ACSP_DETAILS_UPDATE_ELEMENT, UPDATE_BUSINESS_ADDRESS_CONFIRM);
+        session.setExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL, UPDATE_BUSINESS_ADDRESS_CONFIRM);
         res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE, lang));
     } catch (err) {
         next(err);

--- a/src/controllers/features/update-acsp/correspondenceAddressConfirmController.ts
+++ b/src/controllers/features/update-acsp/correspondenceAddressConfirmController.ts
@@ -3,7 +3,7 @@ import * as config from "../../../config";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM, UPDATE_CORRESPONDENCE_ADDRESS_MANUAL, UPDATE_CORRESPONDENCE_ADDRESS_LOOKUP, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_ANSWERS, UPDATE_DATE_OF_THE_CHANGE } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { ACSP_DETAILS_UPDATE_ELEMENT, ACSP_DETAILS_UPDATE_IN_PROGRESS } from "../../../common/__utils/constants";
+import { ACSP_UPDATE_PREVIOUS_PAGE_URL, ACSP_DETAILS_UPDATE_IN_PROGRESS } from "../../../common/__utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -28,7 +28,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const lang = selectLang(req.query.lang);
         const session: Session = req.session as any as Session;
-        session.setExtraData(ACSP_DETAILS_UPDATE_ELEMENT, UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM);
+        session.setExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL, UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM);
         res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE, lang));
     } catch (err) {
         next(err);

--- a/src/controllers/features/update-acsp/dateOfTheChangeController.ts
+++ b/src/controllers/features/update-acsp/dateOfTheChangeController.ts
@@ -82,7 +82,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                     }
                 ];
                 session.setExtraData(AML_REMOVED_BODY_DETAILS, updatedRemovedAMLDetails);
-                session.deleteExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL);
                 res.redirect(addLangToUrl(`${UPDATE_ACSP_DETAILS_BASE_URL + REMOVE_AML_SUPERVISOR}?amlindex=${amlRemovalIndex}&amlbody=${amlRemovalBody}&return=your-updates`, lang));
             } else {
                 updateWithTheEffectiveDateAmendment(req, dateOfChange.toISOString());

--- a/src/controllers/features/update-acsp/updateYourDetailsController.ts
+++ b/src/controllers/features/update-acsp/updateYourDetailsController.ts
@@ -18,7 +18,7 @@ import { Session } from "@companieshouse/node-session-handler";
 import { getProfileDetails } from "../../../services/update-acsp/updateYourDetailsService";
 import {
     ACSP_DETAILS,
-    ACSP_DETAILS_UPDATE_ELEMENT,
+    ACSP_UPDATE_PREVIOUS_PAGE_URL,
     ACSP_DETAILS_UPDATE_IN_PROGRESS,
     ACSP_DETAILS_UPDATED,
     ACSP_UPDATE_CHANGE_DATE,
@@ -42,7 +42,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const currentUrl = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS;
         const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
-        session.deleteExtraData(ACSP_DETAILS_UPDATE_ELEMENT);
         session.deleteExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS);
         const changeDates = {
             name: formatDateIntoReadableString(new Date(session.getExtraData(ACSP_UPDATE_CHANGE_DATE.NAME) || "")),
@@ -76,6 +75,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             ...amlDetail,
             dateOfChange: amlDetail.dateOfChange ? formatDateIntoReadableString(new Date(amlDetail.dateOfChange)) : undefined
         }));
+
+        session.setExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL, UPDATE_YOUR_ANSWERS);
 
         res.render(config.UPDATE_YOUR_ANSWERS, {
             ...getLocaleInfo(locales, lang),

--- a/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
+++ b/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
@@ -6,7 +6,7 @@ import { getBusinessName, isLimitedBusinessType } from "../../../services/common
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS_UPDATE_ELEMENT, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_UPDATE_PREVIOUS_PAGE_URL, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 import { UPDATE_WHAT_IS_THE_BUSINESS_NAME, UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE, UPDATE_WHAT_IS_THE_COMPANY_NAME } from "../../../types/pageURL";
 import { CHS_URL } from "../../../utils/properties";
 
@@ -64,7 +64,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             });
         } else {
             session.setExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS, req.body.whatIsTheBusinessName);
-            session.setExtraData(ACSP_DETAILS_UPDATE_ELEMENT, UPDATE_WHAT_IS_THE_BUSINESS_NAME);
+            session.setExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL, UPDATE_WHAT_IS_THE_BUSINESS_NAME);
             res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE, lang));
         }
     } catch (err) {

--- a/src/controllers/features/update-acsp/whatIsYourNameController.ts
+++ b/src/controllers/features/update-acsp/whatIsYourNameController.ts
@@ -10,7 +10,7 @@ import {
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { Session } from "@companieshouse/node-session-handler";
-import { ACSP_DETAILS_UPDATED, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATE_ELEMENT } from "../../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATED, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_UPDATE_PREVIOUS_PAGE_URL } from "../../../common/__utils/constants";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { soleTraderNameDetails } from "model/SoleTraderNameDetails";
 
@@ -59,7 +59,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             soleTraderDetails.surname = req.body["last-name"];
 
             session.setExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS, soleTraderDetails);
-            session.setExtraData(ACSP_DETAILS_UPDATE_ELEMENT, UPDATE_ACSP_WHAT_IS_YOUR_NAME);
+            session.setExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL, UPDATE_ACSP_WHAT_IS_YOUR_NAME);
             res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE, lang));
         }
     } catch (err) {

--- a/src/controllers/features/update-acsp/whereDoYouLiveController.ts
+++ b/src/controllers/features/update-acsp/whereDoYouLiveController.ts
@@ -8,7 +8,7 @@ import { UPDATE_WHERE_DO_YOU_LIVE, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_ANS
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { saveDataInSession } from "../../../common/__utils/sessionHelper";
 import { WhereDoYouLiveBodyService } from "../../../services/where-do-you-live/whereDoYouLive";
-import { ACSP_DETAILS_UPDATED, ACSP_DETAILS_UPDATE_ELEMENT, ACSP_DETAILS_UPDATE_IN_PROGRESS } from "../../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATED, ACSP_UPDATE_PREVIOUS_PAGE_URL, ACSP_DETAILS_UPDATE_IN_PROGRESS } from "../../../common/__utils/constants";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -55,7 +55,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 countryOfResidence = req.body.whereDoYouLiveRadio;
             }
             saveDataInSession(req, ACSP_DETAILS_UPDATE_IN_PROGRESS, countryOfResidence);
-            session.setExtraData(ACSP_DETAILS_UPDATE_ELEMENT, UPDATE_WHERE_DO_YOU_LIVE);
+            session.setExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL, UPDATE_WHERE_DO_YOU_LIVE);
             res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE, lang));
         }
     } catch (error) {

--- a/src/controllers/features/update-acsp/yourUpdatesController.ts
+++ b/src/controllers/features/update-acsp/yourUpdatesController.ts
@@ -7,7 +7,7 @@ import { Session } from "@companieshouse/node-session-handler";
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { getFormattedAddedAMLUpdates, getFormattedRemovedAMLUpdates, getFormattedUpdates } from "../../../services/update-acsp/yourUpdatesService";
-import { ACSP_DETAILS, ACSP_DETAILS_UPDATED, UPDATE_DESCRIPTION, UPDATE_REFERENCE, UPDATE_SUBMISSION_ID } from "../../../common/__utils/constants";
+import { ACSP_DETAILS, ACSP_UPDATE_PREVIOUS_PAGE_URL, ACSP_DETAILS_UPDATED, UPDATE_DESCRIPTION, UPDATE_REFERENCE, UPDATE_SUBMISSION_ID } from "../../../common/__utils/constants";
 import { AMLSupervioryBodiesFormatted } from "../../../model/AMLSupervisoryBodiesFormatted";
 import { closeTransaction } from "../../../services/transactions/transaction_service";
 import { AcspFullProfile } from "../../../model/AcspFullProfile";
@@ -106,6 +106,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 await closeTransaction(session, session.getExtraData(UPDATE_SUBMISSION_ID)!, UPDATE_DESCRIPTION, UPDATE_REFERENCE);
                 res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_APPLICATION_CONFIRMATION, lang));
             } else {
+                session.deleteExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL);
                 res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang));
             }
         }

--- a/src/services/update-acsp/dateOfTheChangeService.ts
+++ b/src/services/update-acsp/dateOfTheChangeService.ts
@@ -1,7 +1,6 @@
 import { Session } from "@companieshouse/node-session-handler";
 import {
     ACSP_DETAILS_UPDATED,
-    ACSP_DETAILS_UPDATE_ELEMENT,
     ACSP_DETAILS_UPDATE_IN_PROGRESS,
     ACSP_PROFILE_TYPE_SOLE_TRADER,
     ACSP_UPDATE_CHANGE_DATE,
@@ -11,9 +10,8 @@ import {
 } from "../../common/__utils/constants";
 import { Request } from "express";
 import {
-    UPDATE_ACSP_DETAILS_BASE_URL,
     UPDATE_ACSP_WHAT_IS_YOUR_NAME,
-    UPDATE_ADD_AML_SUPERVISOR,
+    UPDATE_AML_MEMBERSHIP_NUMBER,
     UPDATE_BUSINESS_ADDRESS_CONFIRM,
     UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM,
     UPDATE_WHAT_IS_THE_BUSINESS_NAME,
@@ -27,7 +25,7 @@ import { AcspFullProfile } from "../../model/AcspFullProfile";
 export const updateWithTheEffectiveDateAmendment = (req: Request, dateOfChange: string): void => {
     const session: Session = req.session as any as Session;
     const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
-    const currentPage = session.getExtraData(ACSP_DETAILS_UPDATE_ELEMENT);
+    const currentPage = session.getExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL);
     const updateBodyIndex: number | undefined = session.getExtraData(ADD_AML_BODY_UPDATE);
     const newAMLBody: AmlSupervisoryBody = session.getExtraData(NEW_AML_BODY)!;
     const AmlMembershipNumberServiceInstance = new AmlMembershipNumberService();
@@ -54,7 +52,7 @@ export const updateWithTheEffectiveDateAmendment = (req: Request, dateOfChange: 
             acspUpdatedFullProfile.serviceAddress = session.getExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS)!;
         }
         session.setExtraData(ACSP_UPDATE_CHANGE_DATE.CORRESPONDENCE_ADDRESS, dateOfChange);
-    } else if (currentPage === UPDATE_ADD_AML_SUPERVISOR) {
+    } else if (currentPage === UPDATE_AML_MEMBERSHIP_NUMBER) {
         // Add the dateOfChange to the NEW_AML_BODY
         newAMLBody.dateOfChange = dateOfChange;
         session.setExtraData(NEW_AML_BODY, newAMLBody);
@@ -65,11 +63,10 @@ export const updateWithTheEffectiveDateAmendment = (req: Request, dateOfChange: 
         session.deleteExtraData(NEW_AML_BODY);
     }
     session.deleteExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS);
-    session.deleteExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL);
 };
 
 export const getPreviousPageUrlDateOfChange = (req: Request): string => {
     const session: Session = req.session as any as Session;
-    return session.getExtraData(ACSP_DETAILS_UPDATE_ELEMENT) || "";
+    return session.getExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL) || "";
 
 };

--- a/src/types/pageURL.ts
+++ b/src/types/pageURL.ts
@@ -206,6 +206,8 @@ export const CANCEL_AN_UPDATE = "/cancel-an-update";
 
 export const UPDATE_ADD_AML_SUPERVISOR = "/select-aml-supervisor";
 
+export const UPDATE_AML_MEMBERSHIP_NUMBER = "/aml-membership-number";
+
 export const REMOVE_AML_SUPERVISOR = "/remove-an-aml";
 
 export const UPDATE_SELECT_AML_SUPERVISOR = "/select-aml-supervisor";

--- a/test/src/services/update_acsp/dateOfTheChangeService.test.ts
+++ b/test/src/services/update_acsp/dateOfTheChangeService.test.ts
@@ -4,7 +4,6 @@ import { Session } from "@companieshouse/node-session-handler";
 import { Request } from "express";
 import {
     ACSP_DETAILS_UPDATED,
-    ACSP_DETAILS_UPDATE_ELEMENT,
     ACSP_DETAILS_UPDATE_IN_PROGRESS,
     ACSP_UPDATE_CHANGE_DATE,
     ACSP_UPDATE_PREVIOUS_PAGE_URL,
@@ -12,9 +11,8 @@ import {
     NEW_AML_BODY
 } from "../../../../src/common/__utils/constants";
 import {
-    UPDATE_ACSP_DETAILS_BASE_URL,
     UPDATE_ACSP_WHAT_IS_YOUR_NAME,
-    UPDATE_ADD_AML_SUPERVISOR,
+    UPDATE_AML_MEMBERSHIP_NUMBER,
     UPDATE_BUSINESS_ADDRESS_CONFIRM,
     UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM,
     UPDATE_WHAT_IS_THE_BUSINESS_NAME,
@@ -51,7 +49,7 @@ describe("updateWithTheEffectiveDateAmendment", () => {
             .mockImplementation((key: string) => {
                 if (key === ACSP_DETAILS_UPDATE_IN_PROGRESS) return acspInProgress;
                 if (key === ACSP_DETAILS_UPDATED) return acspUpdated;
-                if (key === ACSP_DETAILS_UPDATE_ELEMENT) return UPDATE_WHAT_IS_THE_BUSINESS_NAME;
+                if (key === ACSP_UPDATE_PREVIOUS_PAGE_URL) return UPDATE_WHAT_IS_THE_BUSINESS_NAME;
             });
 
         updateWithTheEffectiveDateAmendment(req as Request, dateOfChange.toISOString());
@@ -87,7 +85,7 @@ describe("updateWithTheEffectiveDateAmendment", () => {
         (session.getExtraData as jest.Mock).mockImplementation((key: string) => {
             if (key === ACSP_DETAILS_UPDATE_IN_PROGRESS) return acspinProgressFullProfile;
             if (key === ACSP_DETAILS_UPDATED) return acspUpdatedFullProfile;
-            if (key === ACSP_DETAILS_UPDATE_ELEMENT) return UPDATE_ACSP_WHAT_IS_YOUR_NAME;
+            if (key === ACSP_UPDATE_PREVIOUS_PAGE_URL) return UPDATE_ACSP_WHAT_IS_YOUR_NAME;
         });
 
         updateWithTheEffectiveDateAmendment(req as Request, dateOfChange.toISOString());
@@ -108,7 +106,7 @@ describe("updateWithTheEffectiveDateAmendment", () => {
             .mockImplementation((key: string) => {
                 if (key === ACSP_DETAILS_UPDATE_IN_PROGRESS) return acspInProgress;
                 if (key === ACSP_DETAILS_UPDATED) return acspUpdated;
-                if (key === ACSP_DETAILS_UPDATE_ELEMENT) return UPDATE_WHERE_DO_YOU_LIVE;
+                if (key === ACSP_UPDATE_PREVIOUS_PAGE_URL) return UPDATE_WHERE_DO_YOU_LIVE;
             });
 
         updateWithTheEffectiveDateAmendment(req as Request, dateOfChange.toISOString());
@@ -126,7 +124,7 @@ describe("updateWithTheEffectiveDateAmendment", () => {
             .mockImplementation((key: string) => {
                 if (key === ACSP_DETAILS_UPDATE_IN_PROGRESS) return acspInProgress;
                 if (key === ACSP_DETAILS_UPDATED) return acspUpdated;
-                if (key === ACSP_DETAILS_UPDATE_ELEMENT) return UPDATE_BUSINESS_ADDRESS_CONFIRM;
+                if (key === ACSP_UPDATE_PREVIOUS_PAGE_URL) return UPDATE_BUSINESS_ADDRESS_CONFIRM;
             });
 
         updateWithTheEffectiveDateAmendment(req as Request, dateOfChange.toISOString());
@@ -148,7 +146,7 @@ describe("updateWithTheEffectiveDateAmendment", () => {
         (session.getExtraData as jest.Mock).mockImplementation((key: string) => {
             if (key === ACSP_DETAILS_UPDATE_IN_PROGRESS) return acspinProgressFullProfile;
             if (key === ACSP_DETAILS_UPDATED) return acspUpdatedFullProfile;
-            if (key === ACSP_DETAILS_UPDATE_ELEMENT) return UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM;
+            if (key === ACSP_UPDATE_PREVIOUS_PAGE_URL) return UPDATE_CORRESPONDENCE_ADDRESS_CONFIRM;
         });
 
         updateWithTheEffectiveDateAmendment(req as Request, dateOfChange.toISOString());
@@ -169,7 +167,7 @@ describe("updateWithTheEffectiveDateAmendment", () => {
         };
 
         (session.getExtraData as jest.Mock).mockImplementation((key: string) => {
-            if (key === ACSP_DETAILS_UPDATE_ELEMENT) return UPDATE_ADD_AML_SUPERVISOR;
+            if (key === ACSP_UPDATE_PREVIOUS_PAGE_URL) return UPDATE_AML_MEMBERSHIP_NUMBER;
             if (key === NEW_AML_BODY) return newAMLBody;
             if (key === ACSP_DETAILS_UPDATED) return acspUpdatedFullProfile;
         });
@@ -190,8 +188,6 @@ describe("updateWithTheEffectiveDateAmendment", () => {
         expect(session.deleteExtraData).toHaveBeenCalledWith(ADD_AML_BODY_UPDATE);
         expect(session.deleteExtraData).toHaveBeenCalledWith(NEW_AML_BODY);
         expect(session.deleteExtraData).toHaveBeenCalledWith(ACSP_DETAILS_UPDATE_IN_PROGRESS);
-        expect(session.deleteExtraData).toHaveBeenCalledWith(ACSP_UPDATE_PREVIOUS_PAGE_URL);
-
     });
 
     it("should update aml details when editing NEW_AML_BODY and push to acspUpdatedFullProfile when index exists", () => {
@@ -212,7 +208,7 @@ describe("updateWithTheEffectiveDateAmendment", () => {
         };
 
         (session.getExtraData as jest.Mock).mockImplementation((key: string) => {
-            if (key === ACSP_DETAILS_UPDATE_ELEMENT) return UPDATE_ADD_AML_SUPERVISOR;
+            if (key === ACSP_UPDATE_PREVIOUS_PAGE_URL) return UPDATE_AML_MEMBERSHIP_NUMBER;
             if (key === ADD_AML_BODY_UPDATE) return updateIndex;
             if (key === NEW_AML_BODY) return newAMLBody;
             if (key === ACSP_DETAILS_UPDATED) return acspUpdatedFullProfile;
@@ -248,7 +244,7 @@ describe("getPreviousPageUrlDateOfChange", () => {
     it("should return the value from ACSP_UPDATE_PREVIOUS_PAGE_URL if it exists in the session", () => {
         const previousPageUrl = "/some-previous-page";
         (session.getExtraData as jest.Mock).mockImplementation((key: string) => {
-            if (key === ACSP_DETAILS_UPDATE_ELEMENT) {
+            if (key === ACSP_UPDATE_PREVIOUS_PAGE_URL) {
                 return previousPageUrl;
             }
             return null;
@@ -257,7 +253,7 @@ describe("getPreviousPageUrlDateOfChange", () => {
         const result = getPreviousPageUrlDateOfChange(req as Request);
 
         expect(result).toBe(previousPageUrl);
-        expect(session.getExtraData).toHaveBeenCalledWith(ACSP_DETAILS_UPDATE_ELEMENT);
+        expect(session.getExtraData).toHaveBeenCalledWith(ACSP_UPDATE_PREVIOUS_PAGE_URL);
         expect(session.setExtraData).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2113
https://companieshouse.atlassian.net/browse/IDVA5-2114

- Removed ACSP_DETAILS_UPDATE_ELEMENT constant and renamed all references to use ACSP_UPDATE_PREVIOUS_PAGE_URL as these values are storing urls and used for navigation back from dateOfChange screen
- For Add AML, I set ACSP_UPDATE_PREVIOUS_PAGE_URL to the AML Membership number screen url (/aml-membership-number) and I check this to set the dateOfChange title.
- For Remove AML, I set the value of ACSP_UPDATE_PREVIOUS_PAGE_URL to the Update Your Details screen url (/update-your-details) as this is the only screen prior to the dateOfChange for the Remove AML flow.
- I delete ACSP_UPDATE_PREVIOUS_PAGE_URL from the session when selecting to either add more updates or submit the updates from the Your Updates screen.
- Removed some unused imports in these files

