### PR TITLE
Updating aml validation to allow date of change edits and prevent form submission with no updates

### DIFF
--- a/locales/en/aml-body-number.json
+++ b/locales/en/aml-body-number.json
@@ -9,5 +9,5 @@
   
   "error-amlIDNumberInput": "Enter the details for ",
   "error-amlIdLength": "The Anti-Money Laundering (AML) membership number must be 256 characters or less for ",
-  "error-duplicatedAmlMembership": "The membership number you entered has already been added for this AML supervisory body. Enter a different membership number."
+  "error-duplicatedAmlMembership": "The membership number you entered has already been added for this AML supervisory body. Enter a different membership number"
 }

--- a/src/controllers/features/update-acsp/updateYourDetailsController.ts
+++ b/src/controllers/features/update-acsp/updateYourDetailsController.ts
@@ -52,10 +52,15 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             correspondenceAddress: formatDateIntoReadableString(new Date(session.getExtraData(ACSP_UPDATE_CHANGE_DATE.CORRESPONDENCE_ADDRESS) || ""))
         };
 
-        // Format dateOfChange in removedAMLDetails
-        const removedAMLDetails: AmlSupervisoryBody[] = (session.getExtraData(AML_REMOVED_BODY_DETAILS) ?? []);
+        const removedAMLDetails: AmlSupervisoryBody[] = session.getExtraData(AML_REMOVED_BODY_DETAILS) || [];
+        const updatedRemovedAMLDetails = [...removedAMLDetails, ...acspFullProfile.amlDetails.filter((aml) => !acspUpdatedFullProfile.amlDetails.some(
+            (updatedAML) =>
+                updatedAML.supervisoryBody === aml.supervisoryBody && updatedAML.membershipDetails === aml.membershipDetails)
+        )];
+        session.setExtraData(AML_REMOVED_BODY_DETAILS, updatedRemovedAMLDetails);
 
-        const formattedRemovedAMLDetails = removedAMLDetails.map(amlDetail => ({
+        // Format dateOfChange in removedAMLDetails
+        const formattedRemovedAMLDetails = updatedRemovedAMLDetails.map(amlDetail => ({
             ...amlDetail,
             dateOfChange: amlDetail.dateOfChange ? formatDateIntoReadableString(new Date(amlDetail.dateOfChange)) : undefined
         }));

--- a/src/controllers/features/update-acsp/updateYourDetailsController.ts
+++ b/src/controllers/features/update-acsp/updateYourDetailsController.ts
@@ -52,15 +52,10 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             correspondenceAddress: formatDateIntoReadableString(new Date(session.getExtraData(ACSP_UPDATE_CHANGE_DATE.CORRESPONDENCE_ADDRESS) || ""))
         };
 
-        const removedAMLDetails: AmlSupervisoryBody[] = session.getExtraData(AML_REMOVED_BODY_DETAILS) || [];
-        const updatedRemovedAMLDetails = [...removedAMLDetails, ...acspFullProfile.amlDetails.filter((aml) => !acspUpdatedFullProfile.amlDetails.some(
-            (updatedAML) =>
-                updatedAML.supervisoryBody === aml.supervisoryBody && updatedAML.membershipDetails === aml.membershipDetails)
-        )];
-        session.setExtraData(AML_REMOVED_BODY_DETAILS, updatedRemovedAMLDetails);
+        const removedAMLDetails: AmlSupervisoryBody[] = session.getExtraData(AML_REMOVED_BODY_DETAILS) ?? [];
 
         // Format dateOfChange in removedAMLDetails
-        const formattedRemovedAMLDetails = updatedRemovedAMLDetails.map(amlDetail => ({
+        const formattedRemovedAMLDetails = removedAMLDetails.map(amlDetail => ({
             ...amlDetail,
             dateOfChange: amlDetail.dateOfChange ? formatDateIntoReadableString(new Date(amlDetail.dateOfChange)) : undefined
         }));

--- a/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
+++ b/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
@@ -5,7 +5,7 @@ import { getSessionRequestWithPermission } from "../../../mocks/session.mock";
 import supertest from "supertest";
 import app from "../../../../src/app";
 import { AML_MEMBERSHIP_NUMBER, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE } from "../../../../src/types/pageURL";
-import { ACSP_DETAILS_UPDATED, NEW_AML_BODY, ADD_AML_BODY_UPDATE } from "../../../../src/common/__utils/constants";
+import { ACSP_DETAILS_UPDATED, NEW_AML_BODY, ADD_AML_BODY_UPDATE, AML_REMOVED_BODY_DETAILS } from "../../../../src/common/__utils/constants";
 import * as localise from "../../../../src/utils/localise";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { get } from "../../../../src/controllers/features/update-acsp/amlMembershipNumberController";
@@ -141,6 +141,78 @@ describe("POST " + UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER, () => {
         expect(mocks.mockUpdateAcspAuthenticationMiddleware).toHaveBeenCalled();
         expect(res.status).toBe(400);
         expect(res.text).toContain("The membership number you entered has already been added for this AML supervisory body. Enter a different membership number");
+    });
+
+    it("should return status 400 for duplicate AML when not editing an existing AML (updateBodyIndex is undefined)", async () => {
+        const session = getSessionRequestWithPermission();
+        session.setExtraData(ADD_AML_BODY_UPDATE, undefined);
+        session.setExtraData(NEW_AML_BODY, { amlSupervisoryBody: "hm-revenue-customs-hmrc" });
+        session.setExtraData(ACSP_DETAILS_UPDATED, {
+            amlDetails: [{
+                supervisoryBody: "hm-revenue-customs-hmrc",
+                membershipDetails: "123456"
+            }]
+        });
+
+        customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+            req.session = session;
+            next();
+        });
+
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER).send({ membershipNumber_1: "123456" });
+
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("The membership number you entered has already been added for this AML supervisory body");
+    });
+
+    it("should return status 400 for duplicate AML when editing a different AML (index !== updateBodyIndex)", async () => {
+        const session = getSessionRequestWithPermission();
+        session.setExtraData(ADD_AML_BODY_UPDATE, 1);
+        session.setExtraData(NEW_AML_BODY, { amlSupervisoryBody: "hm-revenue-customs-hmrc" });
+        session.setExtraData(ACSP_DETAILS_UPDATED, {
+            amlDetails: [
+                {
+                    supervisoryBody: "hm-revenue-customs-hmrc",
+                    membershipDetails: "123456"
+                },
+                {
+                    supervisoryBody: "hm-revenue-customs-hmrc",
+                    membershipDetails: "789012"
+                }
+            ]
+        });
+        customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+            req.session = session;
+            next();
+        });
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER).send({ membershipNumber_1: "123456" });
+
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("The membership number you entered has already been added for this AML supervisory body");
+    });
+
+    it("should return status 400 if user attempts to re-add a previously removed AML", async () => {
+        const session = getSessionRequestWithPermission();
+        session.setExtraData(ADD_AML_BODY_UPDATE, undefined);
+        session.setExtraData(NEW_AML_BODY, { amlSupervisoryBody: "hm-revenue-customs-hmrc" });
+        session.setExtraData(ACSP_DETAILS_UPDATED, {
+            amlDetails: []
+        });
+        session.setExtraData(AML_REMOVED_BODY_DETAILS, [
+            {
+                amlSupervisoryBody: "hm-revenue-customs-hmrc",
+                membershipId: "123456"
+            }
+        ]);
+
+        customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+            req.session = session;
+            next();
+        });
+        const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER).send({ membershipNumber_1: "123456" });
+
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("The membership number you entered has already been added for this AML supervisory body");
     });
 
     it("should return status 500 after calling POST endpoint and failing", async () => {

--- a/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
+++ b/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
@@ -140,7 +140,7 @@ describe("POST " + UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER, () => {
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
         expect(mocks.mockUpdateAcspAuthenticationMiddleware).toHaveBeenCalled();
         expect(res.status).toBe(400);
-        expect(res.text).toContain("The membership number you entered has already been added for this AML supervisory body. Enter a different membership number.");
+        expect(res.text).toContain("The membership number you entered has already been added for this AML supervisory body. Enter a different membership number");
     });
 
     it("should return status 500 after calling POST endpoint and failing", async () => {


### PR DESCRIPTION
Fixes for AML bug tickets:
[IDVA5-2107](https://companieshouse.atlassian.net/browse/IDVA5-2107)
[IDVA5-2135](https://companieshouse.atlassian.net/browse/IDVA5-2135)

[IDVA5-2107]: https://companieshouse.atlassian.net/browse/IDVA5-2107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


- Exclude validation check to allow users to navigate to the 'When did AML supervision start?' date page only when editing/updating a new AML body that was added, this allows users to keep the existing aml number and make changes to the date entry.
- Validation captures duplicate aml body name/number if the user attempts to add new aml details for an aml that was previously added in ther journey
- Uses the existing AML_REMOVED_BODY_DETAILS session object to check for the edge case when a user removes aml details from the original acspFullProfile object and attempts to manually re-add the same details to acspUpdatedFullProfile - this now triggers the same error message as when duplicate aml entries are found (spoke with the PM and have agreed that this error message may change to better suit the edge case)
- Added unit tests 

[IDVA5-2135]: https://companieshouse.atlassian.net/browse/IDVA5-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ