### PR TITLE
IDVA5-2161 Retain AML number when pressing back on 'when did this start' screen

### DIFF
--- a/src/controllers/features/update-acsp/addAmlSupervisorController.ts
+++ b/src/controllers/features/update-acsp/addAmlSupervisorController.ts
@@ -71,7 +71,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             });
         } else {
             // Save new AML body into session
-            if (!amlDetails || amlDetails.amlSupervisoryBody !== req.body["AML-supervisory-bodies"]) {
+            if (amlDetails?.amlSupervisoryBody !== req.body["AML-supervisory-bodies"]) {
                 session.setExtraData(NEW_AML_BODY, { amlSupervisoryBody: req.body["AML-supervisory-bodies"] });
             }
 

--- a/src/controllers/features/update-acsp/addAmlSupervisorController.ts
+++ b/src/controllers/features/update-acsp/addAmlSupervisorController.ts
@@ -7,6 +7,7 @@ import { UPDATE_ACSP_DETAILS_BASE_URL, AML_MEMBERSHIP_NUMBER, UPDATE_YOUR_ANSWER
 import { Session } from "@companieshouse/node-session-handler";
 import { NEW_AML_BODY, ADD_AML_BODY_UPDATE, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
+import { AmlSupervisoryBody } from "@companieshouse/api-sdk-node/dist/services/acsp";
 import { AMLSupervisoryBodies } from "../../../model/AMLSupervisoryBodies";
 import { AMLSupervioryBodiesFormatted } from "../../../model/AMLSupervisoryBodiesFormatted";
 
@@ -55,6 +56,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const locales = getLocalesService();
         const currentUrl = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_ADD_AML_SUPERVISOR;
         const session: Session = req.session as any as Session;
+        const amlDetails: AmlSupervisoryBody = session.getExtraData(NEW_AML_BODY)!;
         const errorList = validationResult(req);
 
         if (!errorList.isEmpty()) {
@@ -69,7 +71,9 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
             });
         } else {
             // Save new AML body into session
-            session.setExtraData(NEW_AML_BODY, { amlSupervisoryBody: req.body["AML-supervisory-bodies"] });
+            if (!amlDetails || amlDetails.amlSupervisoryBody !== req.body["AML-supervisory-bodies"]) {
+                session.setExtraData(NEW_AML_BODY, { amlSupervisoryBody: req.body["AML-supervisory-bodies"] });
+            }
 
             res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER, lang));
         }

--- a/src/controllers/features/update-acsp/amlMembershipNumberController.ts
+++ b/src/controllers/features/update-acsp/amlMembershipNumberController.ts
@@ -21,7 +21,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const currentUrl = `${UPDATE_ACSP_DETAILS_BASE_URL}${AML_MEMBERSHIP_NUMBER}`;
 
         const newAMLBody = session.getExtraData(NEW_AML_BODY) as AmlSupervisoryBody;
-        const updateBodyIndex = session.getExtraData(ADD_AML_BODY_UPDATE) as number | undefined;
+        const updateBodyIndex = session.getExtraData(ADD_AML_BODY_UPDATE) as number;
         const acspUpdatedFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED) as AcspFullProfile;
 
         const membershipId = newAMLBody.membershipId ||

--- a/src/controllers/features/update-acsp/amlMembershipNumberController.ts
+++ b/src/controllers/features/update-acsp/amlMembershipNumberController.ts
@@ -17,18 +17,17 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
-        const session: Session = req.session as any as Session;
-        const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER;
-        const newAMLBody: AmlSupervisoryBody = session.getExtraData(NEW_AML_BODY)!;
-        const updateBodyIndex: number | undefined = session.getExtraData(ADD_AML_BODY_UPDATE);
-        const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+        const session = req.session as Session;
+        const currentUrl = `${UPDATE_ACSP_DETAILS_BASE_URL}${AML_MEMBERSHIP_NUMBER}`;
 
-        let payload;
-        if (newAMLBody.membershipId) {
-            payload = { membershipNumber_1: newAMLBody.membershipId };
-        } else if (updateBodyIndex) {
-            payload = { membershipNumber_1: acspUpdatedFullProfile.amlDetails[updateBodyIndex].membershipDetails };
-        }
+        const newAMLBody = session.getExtraData(NEW_AML_BODY) as AmlSupervisoryBody;
+        const updateBodyIndex = session.getExtraData(ADD_AML_BODY_UPDATE) as number | undefined;
+        const acspUpdatedFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED) as AcspFullProfile;
+
+        const membershipId = newAMLBody.membershipId ||
+            (updateBodyIndex !== undefined ? acspUpdatedFullProfile.amlDetails[updateBodyIndex]?.membershipDetails : undefined);
+
+        const payload = membershipId ? { membershipNumber_1: membershipId } : undefined;
 
         res.render(config.AML_MEMBERSHIP_NUMBER, {
             ...getLocaleInfo(locales, lang),

--- a/src/controllers/features/update-acsp/amlMembershipNumberController.ts
+++ b/src/controllers/features/update-acsp/amlMembershipNumberController.ts
@@ -18,7 +18,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
         const session = req.session as Session;
-        const currentUrl = `${UPDATE_ACSP_DETAILS_BASE_URL}${AML_MEMBERSHIP_NUMBER}`;
+        const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER;
 
         const newAMLBody = session.getExtraData(NEW_AML_BODY) as AmlSupervisoryBody;
         const updateBodyIndex = session.getExtraData(ADD_AML_BODY_UPDATE) as number;

--- a/src/controllers/features/update-acsp/amlMembershipNumberController.ts
+++ b/src/controllers/features/update-acsp/amlMembershipNumberController.ts
@@ -24,7 +24,9 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
 
         let payload;
-        if (updateBodyIndex) {
+        if (newAMLBody.membershipId) {
+            payload = { membershipNumber_1: newAMLBody.membershipId };
+        } else if (updateBodyIndex) {
             payload = { membershipNumber_1: acspUpdatedFullProfile.amlDetails[updateBodyIndex].membershipDetails };
         }
 

--- a/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
+++ b/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
@@ -46,23 +46,55 @@ describe("GET " + AML_MEMBERSHIP_NUMBER, () => {
         expect(res.status).toBe(200);
         expect(res.text).toContain("What is the Anti-Money Laundering (AML) membership number?");
     });
-    it("should set payload with membershipNumber_1 if newAMLBody.membershipId is provided", async () => {
-        const newAMLBody = { membershipId: "123456" };
-        sessionMock.getExtraData = jest.fn()
-            .mockReturnValueOnce(newAMLBody)
-            .mockReturnValueOnce(undefined);
+    it("should set payload with membershipNumber_1 from acspUpdatedFullProfile when updateBodyIndex is defined", async () => {
+        const updateBodyIndex = 0;
+        const acspUpdatedFullProfile = {
+            amlDetails: [
+                { membershipDetails: "123456", supervisoryBody: "Some Body" }
+            ]
+        };
 
+        sessionMock.getExtraData = jest.fn()
+            .mockReturnValueOnce({})
+            .mockReturnValueOnce(updateBodyIndex)
+            .mockReturnValueOnce(acspUpdatedFullProfile);
         await get(req as Request, res as Response, next);
         expect(res.render).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
             payload: { membershipNumber_1: "123456" }
         }));
     });
 
-    it("should not set payload if newAMLBody.membershipId is not provided", async () => {
-        const newAMLBody = {};
+    it("should not set payload if updateBodyIndex is undefined", async () => {
+        const updateBodyIndex = undefined;
+        const acspUpdatedFullProfile = {
+            amlDetails: [
+                { membershipDetails: "123456", supervisoryBody: "Some Body" }
+            ]
+        };
+
         sessionMock.getExtraData = jest.fn()
-            .mockReturnValueOnce(newAMLBody)
-            .mockReturnValueOnce(undefined);
+            .mockReturnValueOnce({})
+            .mockReturnValueOnce(updateBodyIndex)
+            .mockReturnValueOnce(acspUpdatedFullProfile);
+        await get(req as Request, res as Response, next);
+        expect(res.render).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+            payload: undefined
+        }));
+    });
+
+    it("should not set payload if updateBodyIndex is out of bounds", async () => {
+        const updateBodyIndex = 5;
+        const acspUpdatedFullProfile = {
+            amlDetails: [
+                { membershipDetails: "123456", supervisoryBody: "Some Body" }
+            ]
+        };
+
+        sessionMock.getExtraData = jest.fn()
+            .mockReturnValueOnce({})
+            .mockReturnValueOnce(updateBodyIndex)
+            .mockReturnValueOnce(acspUpdatedFullProfile);
+
         await get(req as Request, res as Response, next);
         expect(res.render).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
             payload: undefined
@@ -196,7 +228,7 @@ describe("POST " + UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER, () => {
             }]
         });
 
-        customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        customMockSessionMiddleware.mockImplementation((req: Request, _res: Response, next: NextFunction) => {
             req.session = session;
             next();
         });
@@ -223,7 +255,7 @@ describe("POST " + UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER, () => {
                 }
             ]
         });
-        customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        customMockSessionMiddleware.mockImplementation((req: Request, _res: Response, next: NextFunction) => {
             req.session = session;
             next();
         });
@@ -247,7 +279,7 @@ describe("POST " + UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER, () => {
             }
         ]);
 
-        customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+        customMockSessionMiddleware.mockImplementation((req: Request, _res: Response, next: NextFunction) => {
             req.session = session;
             next();
         });
@@ -272,7 +304,7 @@ function createMockSessionMiddleware () {
     const session = getSessionRequestWithPermission();
     session.setExtraData(NEW_AML_BODY, { amlSupervisoryBody: "hm-revenue-customs-hmrc" });
     session.setExtraData(ACSP_DETAILS_UPDATED, { ...dummyFullProfile });
-    customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
+    customMockSessionMiddleware.mockImplementation((req: Request, _res: Response, next: NextFunction) => {
         req.session = session;
         next();
     });

--- a/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
+++ b/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
@@ -83,7 +83,28 @@ describe("amlMembershipNumberController", () => {
 
         expect(payload).toEqual({ membershipNumber_1: "New Membership ID" });
     });
+    it("should set payload with membershipNumber_1 if newAMLBody.membershipId is provided", async () => {
+        const newAMLBody = { membershipId: "123456" };
+        const acspUpdatedFullProfile: AcspFullProfile = {
+            amlDetails: [
+                { supervisoryBody: "Old Supervisory Body", membershipDetails: "Old Membership ID" }
+            ]
+        } as AcspFullProfile;
 
+        session.getExtraData = jest.fn()
+            .mockReturnValueOnce(newAMLBody)
+            .mockReturnValueOnce(undefined)
+            .mockReturnValueOnce(acspUpdatedFullProfile);
+
+        let payload;
+        if (newAMLBody.membershipId) {
+            payload = { membershipNumber_1: newAMLBody.membershipId };
+        }
+
+        await get(req, res, next);
+
+        expect(payload).toEqual({ membershipNumber_1: "123456" });
+    });
     it("should not set payload if updateBodyIndex is not provided", async () => {
         const updateBodyIndex = undefined;
         const acspUpdatedFullProfile: AcspFullProfile = {

--- a/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
+++ b/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
@@ -255,7 +255,7 @@ describe("POST " + UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER, () => {
                 }
             ]
         });
-        customMockSessionMiddleware.mockImplementation((req: Request, _res: Response, next: NextFunction) => {
+        customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
             req.session = session;
             next();
         });
@@ -279,7 +279,7 @@ describe("POST " + UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER, () => {
             }
         ]);
 
-        customMockSessionMiddleware.mockImplementation((req: Request, _res: Response, next: NextFunction) => {
+        customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
             req.session = session;
             next();
         });
@@ -304,7 +304,7 @@ function createMockSessionMiddleware () {
     const session = getSessionRequestWithPermission();
     session.setExtraData(NEW_AML_BODY, { amlSupervisoryBody: "hm-revenue-customs-hmrc" });
     session.setExtraData(ACSP_DETAILS_UPDATED, { ...dummyFullProfile });
-    customMockSessionMiddleware.mockImplementation((req: Request, _res: Response, next: NextFunction) => {
+    customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
         req.session = session;
         next();
     });

--- a/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
+++ b/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
@@ -228,7 +228,7 @@ describe("POST " + UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER, () => {
             }]
         });
 
-        customMockSessionMiddleware.mockImplementation((req: Request, _res: Response, next: NextFunction) => {
+        customMockSessionMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => {
             req.session = session;
             next();
         });

--- a/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
+++ b/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
@@ -47,32 +47,23 @@ describe("GET " + AML_MEMBERSHIP_NUMBER, () => {
         expect(res.text).toContain("What is the Anti-Money Laundering (AML) membership number?");
     });
     it("should set payload with membershipNumber_1 if newAMLBody.membershipId is provided", async () => {
-        // Mock session data
         const newAMLBody = { membershipId: "123456" };
         sessionMock.getExtraData = jest.fn()
-            .mockReturnValueOnce(newAMLBody) // Mock newAMLBody
-            .mockReturnValueOnce(undefined); // Mock updateBodyIndex
+            .mockReturnValueOnce(newAMLBody)
+            .mockReturnValueOnce(undefined);
 
-        // Call the controller
         await get(req as Request, res as Response, next);
-
-        // Assertions
         expect(res.render).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
             payload: { membershipNumber_1: "123456" }
         }));
     });
 
     it("should not set payload if newAMLBody.membershipId is not provided", async () => {
-        // Mock session data
         const newAMLBody = {};
         sessionMock.getExtraData = jest.fn()
-            .mockReturnValueOnce(newAMLBody) // Mock newAMLBody
-            .mockReturnValueOnce(undefined); // Mock updateBodyIndex
-
-        // Call the controller
+            .mockReturnValueOnce(newAMLBody)
+            .mockReturnValueOnce(undefined);
         await get(req as Request, res as Response, next);
-
-        // Assertions
         expect(res.render).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
             payload: undefined
         }));


### PR DESCRIPTION
Modified AML controllers:

-- Added a check if aml details exist in the session before initiating for aml body and aml number controllers.
-- Added the tests.

https://companieshouse.atlassian.net/browse/IDVA5-2161