### PR TITLE
Updating session data when cancelling all updates

### DIFF
--- a/src/controllers/features/update-acsp/cancelAllUpdatesController.ts
+++ b/src/controllers/features/update-acsp/cancelAllUpdatesController.ts
@@ -3,7 +3,7 @@ import * as config from "../../../config";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
 import { UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_CANCEL_ALL_UPDATES, AUTHORISED_AGENT } from "../../../types/pageURL";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -26,11 +26,10 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 export const post = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const session: Session = req.session as any as Session;
-        const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
 
-        if (acspUpdatedFullProfile) {
-            session.deleteExtraData(ACSP_DETAILS_UPDATED);
-        }
+        session.setExtraData(ACSP_DETAILS_UPDATED, acspFullProfile);
+
         res.redirect(AUTHORISED_AGENT);
     } catch (err) {
         next(err);


### PR DESCRIPTION
Ticket [IDVA5-2158](https://companieshouse.atlassian.net/browse/IDVA5-2168)

Updating ACSP_DETAILS_UPDATED session data to be equal to ACSP_DETAILS session data instead of deleting it when the user cancels all updates. This prevents the ACSP_DETAILS_UPDATED session object from becoming undefined.