### PR TITLE
Preventing details showing as updated when not updated

### DIFF
--- a/src/controllers/features/update-acsp/yourUpdatesController.ts
+++ b/src/controllers/features/update-acsp/yourUpdatesController.ts
@@ -27,8 +27,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const previousPage = getPreviousPageWithLang(req, UPDATE_ACSP_DETAILS_BASE_URL);
         const addedAMLBodies = getFormattedAddedAMLUpdates(acspFullProfile, acspUpdatedFullProfile);
         const removedAMLBodies = getFormattedRemovedAMLUpdates(session, acspFullProfile, acspUpdatedFullProfile);
-        const isLimitedBusiness = isLimitedBusinessType(acspFullProfile.type);
-        const editBusinessNameUrl = isLimitedBusiness
+        const editBusinessNameUrl = isLimitedBusinessType(acspFullProfile.type)
             ? addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_COMPANY_NAME, lang)
             : addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_BUSINESS_NAME, lang);
 
@@ -39,7 +38,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         res.render(config.UPDATE_CHECK_YOUR_UPDATES, {
             ...getLocaleInfo(locales, lang),
             currentUrl,
-            lang,
             AMLSupervioryBodiesFormatted,
             yourDetails,
             addedAMLBodies,
@@ -71,6 +69,10 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const addedAMLBodies = getFormattedAddedAMLUpdates(acspFullProfile, acspUpdatedFullProfile);
         const removedAMLBodies = getFormattedRemovedAMLUpdates(session, acspFullProfile, acspUpdatedFullProfile);
 
+        const editBusinessNameUrl = isLimitedBusinessType(acspFullProfile.type)
+            ? addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_COMPANY_NAME, lang)
+            : addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_WHAT_IS_THE_BUSINESS_NAME, lang);
+
         let redirectQuery = "your-updates";
         if (Object.keys(yourDetails).length + addedAMLBodies.length + removedAMLBodies.length === 1) {
             redirectQuery = "your-answers";
@@ -82,13 +84,13 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 ...getLocaleInfo(locales, lang),
                 ...pageProperties,
                 currentUrl,
-                lang,
                 AMLSupervioryBodiesFormatted,
                 yourDetails,
                 addedAMLBodies,
                 removedAMLBodies,
                 redirectQuery,
                 type: acspFullProfile.type,
+                editBusinessNameUrl,
                 previousPage: addLangToUrl(previousPage, lang),
                 cancelAllUpdatesUrl: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CANCEL_ALL_UPDATES, lang),
                 addAMLUrl: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_ADD_AML_SUPERVISOR, lang),

--- a/src/services/common.ts
+++ b/src/services/common.ts
@@ -96,3 +96,25 @@ export const trimAndLowercaseString = (name: string | undefined): string => {
 export const isLimitedBusinessType = (type: string | undefined, businessTypes: string[] = LIMITED_BUSINESS_TYPES): boolean => {
     return type ? businessTypes.includes(type) : false;
 };
+
+export const deepEquals = (obj1: any, obj2: any): boolean => {
+    if (obj1 === obj2) return true;
+
+    if (obj1 == null || obj2 == null || typeof obj1 !== "object" || typeof obj2 !== "object") {
+        return false;
+    }
+
+    const keys1 = Object.keys(obj1);
+    const keys2 = Object.keys(obj2);
+
+    if (keys1.length !== keys2.length) return false;
+
+    for (const key of keys1) {
+        if (!keys2.includes(key) || !deepEquals(obj1[key], obj2[key])) {
+            return false;
+        }
+    }
+
+    return true;
+
+};

--- a/src/services/update-acsp/yourUpdatesService.ts
+++ b/src/services/update-acsp/yourUpdatesService.ts
@@ -1,5 +1,5 @@
 import { Session } from "@companieshouse/node-session-handler";
-import { formatAddressIntoHTMLString, formatDateIntoReadableString, getFullNameACSPFullProfileDetails } from "../../services/common";
+import { deepEquals, formatAddressIntoHTMLString, formatDateIntoReadableString, getFullNameACSPFullProfileDetails } from "../../services/common";
 import { ACSP_UPDATE_CHANGE_DATE, AML_REMOVED_BODY_DETAILS } from "../../common/__utils/constants";
 import { AcspFullProfile } from "../../model/AcspFullProfile";
 import { AmlSupervisoryBody } from "@companieshouse/api-sdk-node/dist/services/acsp";
@@ -46,13 +46,13 @@ export const getFormattedUpdates = (session: Session, acspFullProfile: AcspFullP
 };
 
 const limtedChanges = (session: Session, acspFullProfile: AcspFullProfile, updatedFullProfile: AcspFullProfile, updates: YourUpdates): YourUpdates => {
-    if (JSON.stringify(acspFullProfile.registeredOfficeAddress) !== JSON.stringify(updatedFullProfile.registeredOfficeAddress)) {
+    if (!deepEquals(acspFullProfile.registeredOfficeAddress, updatedFullProfile.registeredOfficeAddress)) {
         updates.registeredOfficeAddress = {
             value: formatAddressIntoHTMLString(updatedFullProfile.registeredOfficeAddress),
             changedDate: formatDateIntoReadableString(new Date(session.getExtraData(ACSP_UPDATE_CHANGE_DATE.REGISTERED_OFFICE_ADDRESS)!))
         };
     }
-    if (JSON.stringify(acspFullProfile.serviceAddress) !== JSON.stringify(updatedFullProfile.serviceAddress)) {
+    if (!deepEquals(acspFullProfile.serviceAddress, updatedFullProfile.serviceAddress)) {
         updates.serviceAddress = {
             value: formatAddressIntoHTMLString(updatedFullProfile.serviceAddress),
             changedDate: formatDateIntoReadableString(new Date(session.getExtraData(ACSP_UPDATE_CHANGE_DATE.CORRESPONDENCE_ADDRESS)!))
@@ -62,13 +62,13 @@ const limtedChanges = (session: Session, acspFullProfile: AcspFullProfile, updat
 };
 
 const unincorporatedChanges = (session: Session, acspFullProfile: AcspFullProfile, updatedFullProfile: AcspFullProfile, updates: YourUpdates): YourUpdates => {
-    if (JSON.stringify(acspFullProfile.registeredOfficeAddress) !== JSON.stringify(updatedFullProfile.registeredOfficeAddress)) {
+    if (!deepEquals(acspFullProfile.registeredOfficeAddress, updatedFullProfile.registeredOfficeAddress)) {
         updates.businessAddress = {
             value: formatAddressIntoHTMLString(updatedFullProfile.registeredOfficeAddress),
             changedDate: formatDateIntoReadableString(new Date(session.getExtraData(ACSP_UPDATE_CHANGE_DATE.REGISTERED_OFFICE_ADDRESS)!))
         };
     }
-    if (JSON.stringify(acspFullProfile.serviceAddress) !== JSON.stringify(updatedFullProfile.serviceAddress)) {
+    if (!deepEquals(acspFullProfile.serviceAddress, updatedFullProfile.serviceAddress)) {
         updates.serviceAddress = {
             value: formatAddressIntoHTMLString(updatedFullProfile.serviceAddress),
             changedDate: formatDateIntoReadableString(new Date(session.getExtraData(ACSP_UPDATE_CHANGE_DATE.CORRESPONDENCE_ADDRESS)!))
@@ -87,7 +87,7 @@ const unincorporatedChanges = (session: Session, acspFullProfile: AcspFullProfil
 };
 
 const soleTraderChanges = (session: Session, acspFullProfile: AcspFullProfile, updatedFullProfile: AcspFullProfile, updates: YourUpdates): YourUpdates => {
-    if (JSON.stringify(acspFullProfile.registeredOfficeAddress) !== JSON.stringify(updatedFullProfile.registeredOfficeAddress)) {
+    if (!deepEquals(acspFullProfile.registeredOfficeAddress, updatedFullProfile.registeredOfficeAddress)) {
         updates.serviceAddress = {
             value: formatAddressIntoHTMLString(updatedFullProfile.registeredOfficeAddress),
             changedDate: formatDateIntoReadableString(new Date(session.getExtraData(ACSP_UPDATE_CHANGE_DATE.CORRESPONDENCE_ADDRESS)!))


### PR DESCRIPTION
Ticket [IDVA5-2170](https://companieshouse.atlassian.net/browse/IDVA5-2170)

Refactored both update controllers and created new deepEquals function to compare if the updated details are the same as the original when checking the updateFlag in updateYourDetailsController and when comparing addresses in yourUpdatesService