### PR TITLE
Updating page content adding welsh content and retaining lang on cancel

### DIFF
--- a/locales/cy/common.json
+++ b/locales/cy/common.json
@@ -10,7 +10,7 @@
     "AcceptAndContinue": "Derbyn a pharhau",
     "CommonTabTitle": "Gwneud cais i gofrestru fel asiant awdurdodedig Tŷ'r Cwmnïau - GOV.UK",
     "CommonTabTitleUpdateAcsp": "Gweld a diweddaru manylion yr asiant awdurdodedig - GOV.UK",
-    "CommonTabTitleCloseAcsp": "Close the authorised agent - Welcome to GOV.UK Welsh",
+    "CommonTabTitleCloseAcsp": "Cau'r asiant awdurdodedig - Croeso i GOV.UK",
     "Cancel": "Canslo",
     "CancelUpdate": "Canslo'r diweddariad",
     "Edit": "Golygu",

--- a/locales/en/close-acsp-confirm-you-want-to-close.json
+++ b/locales/en/close-acsp-confirm-you-want-to-close.json
@@ -1,5 +1,5 @@
 {
     "confirmYouWantToCloseACSPTitle": "Confirm you want to close the authorised agent account",
-    "youShouldOnlyConfirmIf": "You should only confirm if {BUSINESS_NAME} no longer needs to be registered as an authorised agent with Companies House. This is also known as an Authorised Corporate Service Provider (ACSP).",
+    "youShouldOnlyConfirmIf": "You should only confirm if {BUSINESS_NAME} no longer needs to be an authorised agent. This is also known as an Authorised Corporate Service Provider (ACSP).",
     "ifYouConfirmWarningText": "If you confirm, we will immediately close the authorised agent account. {BUSINESS_NAME} will no longer be an ACSP. You will not be able to cancel this."
 }

--- a/src/middleware/close-acsp/close_variables_middleware.ts
+++ b/src/middleware/close-acsp/close_variables_middleware.ts
@@ -1,5 +1,6 @@
 import { CLOSE_ACSP_BASE_URL, AUTHORISED_AGENT } from "../../types/pageURL";
 import { Handler } from "express";
+import { addLangToUrl } from "../../utils/localise";
 
 /**
  * Populates variables for use in templates that are used on multiple pages.
@@ -15,7 +16,7 @@ export const closeVariablesMiddleware: Handler = (req, res, next) => {
     res.locals.serviceName = "Close the authorised agent account";
     res.locals.serviceUrl = CLOSE_ACSP_BASE_URL;
     res.locals.tabTitleKey = "CommonTabTitleCloseAcsp";
-    res.locals.authorisedAgentDashboardUrl = AUTHORISED_AGENT;
+    res.locals.authorisedAgentDashboardUrl = addLangToUrl(AUTHORISED_AGENT, res.locals.lang);
 
     next();
 };


### PR DESCRIPTION
Fixing issue returned from test against ticket:
[IDVA5-1505](https://companieshouse.atlassian.net/browse/IDVA5-1505)

- Updating body text content to match the latest prototype
- **Additional change:** Adding in Welsh translated text for common tab title for close acsp service
- **Bug fix:** Fixing a bug where the language selected was not carried across to Authorised Agent dashboard when pressing 'Cancel' on close-acsp screens

[IDVA5-1505]: https://companieshouse.atlassian.net/browse/IDVA5-1505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ