### PR TITLE
Refactor formatAddressIntoHTMLString replacing <br> with <p>

### DIFF
--- a/src/services/checkYourAnswersService.ts
+++ b/src/services/checkYourAnswersService.ts
@@ -140,19 +140,19 @@ const isThisYourCompanyAnswers = (req: Request, answers: Answers): Answers => {
     let businessAddressAnswer = company.registeredOfficeAddress?.addressLineOne;
 
     if (company.registeredOfficeAddress?.addressLineTwo) {
-        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress?.addressLineTwo + "</p>";
+        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress.addressLineTwo + "</p>";
     }
     if (company.registeredOfficeAddress?.locality) {
-        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress?.locality + "</p>";
+        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress.locality + "</p>";
     }
     if (company.registeredOfficeAddress?.region) {
-        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress?.region + "</p>";
+        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress.region + "</p>";
     }
     if (company.registeredOfficeAddress?.postalCode) {
-        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress?.postalCode + "</p>";
+        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress.postalCode + "</p>";
     }
     if (company.registeredOfficeAddress?.country) {
-        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress?.country + "</p>";
+        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress.country + "</p>";
     }
 
     answers.businessAddress = businessAddressAnswer;

--- a/src/services/checkYourAnswersService.ts
+++ b/src/services/checkYourAnswersService.ts
@@ -140,19 +140,19 @@ const isThisYourCompanyAnswers = (req: Request, answers: Answers): Answers => {
     let businessAddressAnswer = company.registeredOfficeAddress?.addressLineOne;
 
     if (company.registeredOfficeAddress?.addressLineTwo) {
-        businessAddressAnswer += "<br>" + company.registeredOfficeAddress?.addressLineTwo;
+        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress?.addressLineTwo + "</p>";
     }
     if (company.registeredOfficeAddress?.locality) {
-        businessAddressAnswer += "<br>" + company.registeredOfficeAddress?.locality;
+        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress?.locality + "</p>";
     }
     if (company.registeredOfficeAddress?.region) {
-        businessAddressAnswer += "<br>" + company.registeredOfficeAddress?.region;
+        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress?.region + "</p>";
     }
     if (company.registeredOfficeAddress?.postalCode) {
-        businessAddressAnswer += "<br>" + company.registeredOfficeAddress?.postalCode;
+        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress?.postalCode + "</p>";
     }
     if (company.registeredOfficeAddress?.country) {
-        businessAddressAnswer += "<br>" + company.registeredOfficeAddress?.country;
+        businessAddressAnswer += "<p class='govuk-body govuk-!-margin-bottom-0'>" + company.registeredOfficeAddress?.country + "</p>";
     }
 
     answers.businessAddress = businessAddressAnswer;

--- a/src/services/common.ts
+++ b/src/services/common.ts
@@ -69,19 +69,19 @@ export const formatAddressIntoHTMLString = (address: Address | undefined): strin
         addressString += (addressString ? " " : "") + address.addressLine1;
     }
     if (address.addressLine2) {
-        addressString += "<br>" + address.addressLine2;
+        addressString += `<p class="govuk-body govuk-!-margin-bottom-0">${address.addressLine2}</p>`;
     }
     if (address.locality) {
-        addressString += "<br>" + address.locality;
+        addressString += `<p class="govuk-body govuk-!-margin-bottom-0">${address.locality}</p>`;
     }
     if (address.region) {
-        addressString += "<br>" + address.region;
+        addressString += `<p class="govuk-body govuk-!-margin-bottom-0">${address.region}</p>`;
     }
     if (address.country) {
-        addressString += "<br>" + address.country;
+        addressString += `<p class="govuk-body govuk-!-margin-bottom-0">${address.country}</p>`;
     }
     if (address.postalCode) {
-        addressString += "<br>" + address.postalCode;
+        addressString += `<p class="govuk-body govuk-!-margin-bottom-0">${address.postalCode}</p>`;
     }
     return addressString;
 };

--- a/src/views/features/update-acsp-details/your-updates/your-updates.njk
+++ b/src/views/features/update-acsp-details/your-updates/your-updates.njk
@@ -28,7 +28,7 @@
       classes: "govuk-!-width-one-third"
     },
     value: {
-      html: yourDetails.name.value + "<br><br> Changed on " + yourDetails.name.changedDate,
+      html: yourDetails.name.value + "<p class='govuk-body govuk-!-static-margin-top-5'> Changed on " + yourDetails.name.changedDate + "</p>",
       classes: "govuk-!-width-one-third"
     },
     actions: {
@@ -53,7 +53,7 @@
       classes: "govuk-!-width-one-third"
     },
     value: {
-      html: yourDetails.usualResidentialCountry.value + "<br><br> Changed on " + yourDetails.usualResidentialCountry.changedDate,
+      html: yourDetails.usualResidentialCountry.value + "<p class='govuk-body govuk-!-static-margin-top-5'> Changed on " + yourDetails.usualResidentialCountry.changedDate + "</p>",
       classes: "govuk-!-width-one-third"
     },
     actions: {
@@ -78,7 +78,7 @@
       classes: "govuk-!-width-one-third"
     },
     value: {
-      html: yourDetails.businessName.value + "<br><br> Changed on " + yourDetails.businessName.changedDate,
+      html: yourDetails.businessName.value + "<p class='govuk-body govuk-!-static-margin-top-5'> Changed on " + yourDetails.businessName.changedDate + "</p>",
       classes: "govuk-!-width-one-third"
     },
     actions: {
@@ -103,7 +103,7 @@
       classes: "govuk-!-width-one-third"
     },
     value: {
-      html: yourDetails.serviceAddress.value + "<br><br> Changed on " + yourDetails.serviceAddress.changedDate,
+      html: yourDetails.serviceAddress.value + "<p class='govuk-body govuk-!-static-margin-top-5'> Changed on " + yourDetails.serviceAddress.changedDate + "</p>",
       classes: "govuk-!-width-one-third"
     },
     actions: {
@@ -153,7 +153,7 @@
       classes: "govuk-!-width-one-third"
     },
     value: {
-      html: yourDetails.registeredOfficeAddress.value + "<br><br> Changed on " + yourDetails.registeredOfficeAddress.changedDate,
+      html: yourDetails.registeredOfficeAddress.value + "<p class='govuk-body govuk-!-static-margin-top-5'> Changed on " + yourDetails.registeredOfficeAddress.changedDate + "</p>",
       classes: "govuk-!-width-one-third"
     },
     actions: {
@@ -178,7 +178,7 @@
       classes: "govuk-!-width-one-third"
     },
     value: {
-      html: yourDetails.businessAddress.value + "<br><br> Changed on " + yourDetails.businessAddress.changedDate,
+      html: yourDetails.businessAddress.value + "<p class='govuk-body govuk-!-static-margin-top-5'> Changed on " + yourDetails.businessAddress.changedDate + "</p>",
       classes: "govuk-!-width-one-third"
     },
     actions: {

--- a/src/views/partials/your-updates-add-aml.njk
+++ b/src/views/partials/your-updates-add-aml.njk
@@ -5,7 +5,7 @@
         text:  AMLSupervioryBodiesFormatted[body.membershipName]
       },
       value: {
-        html:  body.membershipNumber + "<br><br> " +  i18n.yourUpdatesStarted + " " + body.changedDate
+        html:  body.membershipNumber + "<p class='govuk-body govuk-!-static-margin-top-5'> " +  i18n.yourUpdatesStarted + " " + body.changedDate + "</p>"
       },
       actions: {
         items: [

--- a/src/views/partials/your-updates-remove-aml.njk
+++ b/src/views/partials/your-updates-remove-aml.njk
@@ -5,7 +5,7 @@
           text:  AMLSupervioryBodiesFormatted[body.membershipName]
         },
         value: {
-          html:  body.membershipNumber + "<br><br> " +  i18n.yourUpdatesEnded + " " + body.changedDate
+          html:  body.membershipNumber + "<p class='govuk-body govuk-!-static-margin-top-5'> " +  i18n.yourUpdatesEnded + " " + body.changedDate + "</p>"
         },
         actions: {
           items: [

--- a/test/src/services/checkYourAnswersService.test.ts
+++ b/test/src/services/checkYourAnswersService.test.ts
@@ -173,4 +173,36 @@ describe("CheckYourAnswersService", () => {
             correspondenceEmail: undefined
         });
     });
+
+    it("should handle all address fields as undefined with just addressLineOne defined", () => {
+        const mockCompany = {
+            companyName: "Test Ltd",
+            companyNumber: "12345678",
+            registeredOfficeAddress: {
+                addressLineOne: "1 Main St",
+                addressLineTwo: undefined,
+                locality: undefined,
+                region: undefined,
+                postalCode: undefined,
+                country: undefined
+            }
+        };
+
+        const mockSession = {
+            getExtraData: (key: string) => {
+                if (key === COMPANY_DETAILS) return mockCompany;
+                return undefined;
+            }
+        };
+
+        const req: any = { session: mockSession };
+        const acspData = { typeOfBusiness: "LC" };
+        const i18n = {};
+
+        const answers = getAnswers(req, acspData as any, i18n);
+
+        expect(answers.businessName).toBe("Test Ltd");
+        expect(answers.companyNumber).toBe("12345678");
+        expect(answers.businessAddress).toBe("1 Main St");
+    });
 });

--- a/test/src/services/checkYourAnswersService.test.ts
+++ b/test/src/services/checkYourAnswersService.test.ts
@@ -31,10 +31,10 @@ describe("CheckYourAnswersService", () => {
         const limitedAnswers = getAnswers(req, mockLimitedAcspData, locales.i18nCh.resolveNamespacesKeys(req.query.lang));
 
         expect(limitedAnswers).toStrictEqual({
-            businessAddress: "Address 1<br>Address 2<br>locality<br>region<br>AB1 2CD<br>country",
+            businessAddress: "Address 1<p class='govuk-body govuk-!-margin-bottom-0'>Address 2</p><p class='govuk-body govuk-!-margin-bottom-0'>locality</p><p class='govuk-body govuk-!-margin-bottom-0'>region</p><p class='govuk-body govuk-!-margin-bottom-0'>AB1 2CD</p><p class='govuk-body govuk-!-margin-bottom-0'>country</p>",
             businessName: "Test Company",
             companyNumber: "12345678",
-            correspondenceAddress: "premises addressLine1<br>addressLine2<br>locality<br>region<br>postalcode",
+            correspondenceAddress: "premises addressLine1<p class=\"govuk-body govuk-!-margin-bottom-0\">addressLine2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">locality</p><p class=\"govuk-body govuk-!-margin-bottom-0\">region</p><p class=\"govuk-body govuk-!-margin-bottom-0\">postalcode</p>",
             roleType: "I am a director",
             typeOfBusiness: "Limited company",
             workSector: "Auditors, insolvency practitioners, external accountants and tax advisers",
@@ -48,7 +48,7 @@ describe("CheckYourAnswersService", () => {
         const limitedAnswers = getAnswers(req, mockLLPAcspData, locales.i18nCh.resolveNamespacesKeys(req.query.lang));
 
         expect(limitedAnswers).toStrictEqual({
-            businessAddress: "Address 1<br>Address 2<br>locality<br>region<br>AB1 2CD<br>country",
+            businessAddress: "Address 1<p class='govuk-body govuk-!-margin-bottom-0'>Address 2</p><p class='govuk-body govuk-!-margin-bottom-0'>locality</p><p class='govuk-body govuk-!-margin-bottom-0'>region</p><p class='govuk-body govuk-!-margin-bottom-0'>AB1 2CD</p><p class='govuk-body govuk-!-margin-bottom-0'>country</p>",
             correspondenceAddress: "",
             businessName: "Test Company",
             companyNumber: "12345678",
@@ -64,7 +64,7 @@ describe("CheckYourAnswersService", () => {
 
         expect(soleTraderAnswers).toStrictEqual({
             businessName: "Test Business 123",
-            correspondenceAddress: "premises addressLine1<br>addressLine2<br>locality<br>region<br>postalcode",
+            correspondenceAddress: "premises addressLine1<p class=\"govuk-body govuk-!-margin-bottom-0\">addressLine2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">locality</p><p class=\"govuk-body govuk-!-margin-bottom-0\">region</p><p class=\"govuk-body govuk-!-margin-bottom-0\">postalcode</p>",
             roleType: "I am the sole trader",
             typeOfBusiness: "Sole trader",
             workSector: "Independent legal professionals",
@@ -115,8 +115,8 @@ describe("CheckYourAnswersService", () => {
 
         expect(unincorporatedAnswers).toStrictEqual({
             businessName: "Test Business 123",
-            correspondenceAddress: "premises addressLine1<br>addressLine2<br>locality<br>region<br>postalcode",
-            businessAddress: "premises addressLine1<br>addressLine2<br>locality<br>region<br>postalcode",
+            correspondenceAddress: "premises addressLine1<p class=\"govuk-body govuk-!-margin-bottom-0\">addressLine2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">locality</p><p class=\"govuk-body govuk-!-margin-bottom-0\">region</p><p class=\"govuk-body govuk-!-margin-bottom-0\">postalcode</p>",
+            businessAddress: "premises addressLine1<p class=\"govuk-body govuk-!-margin-bottom-0\">addressLine2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">locality</p><p class=\"govuk-body govuk-!-margin-bottom-0\">region</p><p class=\"govuk-body govuk-!-margin-bottom-0\">postalcode</p>",
             roleType: "I am a member",
             typeOfBusiness: "Partnership (not registered with Companies House)",
             workSector: "Trust or company service providers",
@@ -130,8 +130,8 @@ describe("CheckYourAnswersService", () => {
 
         expect(unincorporatedAnswers).toStrictEqual({
             businessName: "Test Business 123",
-            correspondenceAddress: "premises addressLine1<br>addressLine2<br>locality<br>region<br>postalcode",
-            businessAddress: "premises addressLine1<br>addressLine2<br>locality<br>region<br>postalcode",
+            correspondenceAddress: "premises addressLine1<p class=\"govuk-body govuk-!-margin-bottom-0\">addressLine2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">locality</p><p class=\"govuk-body govuk-!-margin-bottom-0\">region</p><p class=\"govuk-body govuk-!-margin-bottom-0\">postalcode</p>",
+            businessAddress: "premises addressLine1<p class=\"govuk-body govuk-!-margin-bottom-0\">addressLine2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">locality</p><p class=\"govuk-body govuk-!-margin-bottom-0\">region</p><p class=\"govuk-body govuk-!-margin-bottom-0\">postalcode</p>",
             roleType: "I am a member",
             typeOfBusiness: "Unincorporated entity",
             workSector: "Credit institutions",
@@ -147,10 +147,10 @@ describe("CheckYourAnswersService", () => {
         const limitedAnswers = getAnswers(req, mockLimitedAcspData, locales.i18nCh.resolveNamespacesKeys(req.query.lang));
 
         expect(limitedAnswers).toStrictEqual({
-            businessAddress: "Address 1<br>Address 2<br>locality<br>region<br>AB1 2CD<br>country",
+            businessAddress: "Address 1<p class='govuk-body govuk-!-margin-bottom-0'>Address 2</p><p class='govuk-body govuk-!-margin-bottom-0'>locality</p><p class='govuk-body govuk-!-margin-bottom-0'>region</p><p class='govuk-body govuk-!-margin-bottom-0'>AB1 2CD</p><p class='govuk-body govuk-!-margin-bottom-0'>country</p>",
             businessName: "Test Company",
             companyNumber: "12345678",
-            correspondenceAddress: "premises addressLine1<br>addressLine2<br>locality<br>region<br>postalcode",
+            correspondenceAddress: "premises addressLine1<p class=\"govuk-body govuk-!-margin-bottom-0\">addressLine2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">locality</p><p class=\"govuk-body govuk-!-margin-bottom-0\">region</p><p class=\"govuk-body govuk-!-margin-bottom-0\">postalcode</p>",
             roleType: "I am a director",
             typeOfBusiness: "Limited company",
             workSector: "Auditors, insolvency practitioners, external accountants and tax advisers",
@@ -163,8 +163,8 @@ describe("CheckYourAnswersService", () => {
 
         expect(unincorporatedAnswers).toStrictEqual({
             businessName: "Test Business 123",
-            correspondenceAddress: "premises addressLine1<br>addressLine2<br>locality<br>region<br>postalcode",
-            businessAddress: "premises addressLine1<br>addressLine2<br>locality<br>region<br>postalcode",
+            correspondenceAddress: "premises addressLine1<p class=\"govuk-body govuk-!-margin-bottom-0\">addressLine2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">locality</p><p class=\"govuk-body govuk-!-margin-bottom-0\">region</p><p class=\"govuk-body govuk-!-margin-bottom-0\">postalcode</p>",
+            businessAddress: "premises addressLine1<p class=\"govuk-body govuk-!-margin-bottom-0\">addressLine2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">locality</p><p class=\"govuk-body govuk-!-margin-bottom-0\">region</p><p class=\"govuk-body govuk-!-margin-bottom-0\">postalcode</p>",
             roleType: "I am a general partner",
             typeOfBusiness: "Limited partnership (LP)",
             workSector: "High value dealers",

--- a/test/src/services/common.test.ts
+++ b/test/src/services/common.test.ts
@@ -88,7 +88,7 @@ describe("formatAddressIntoHTMLString returns a formatted address string", () =>
             country: "Test Country",
             postalCode: "AB1 2CD"
         };
-        const expectedString = "11 Test Street<br>Test Area<br>Test City<br>Test Region<br>Test Country<br>AB1 2CD";
+        const expectedString = "11 Test Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Test Area</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Test City</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Test Region</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Test Country</p><p class=\"govuk-body govuk-!-margin-bottom-0\">AB1 2CD</p>";
         expect(formatAddressIntoHTMLString(address)).toBe(expectedString);
     });
 
@@ -98,7 +98,7 @@ describe("formatAddressIntoHTMLString returns a formatted address string", () =>
             locality: "Test City",
             country: "Test Country"
         };
-        const expectedString = "Test Street<br>Test City<br>Test Country";
+        const expectedString = "Test Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Test City</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Test Country</p>";
         expect(formatAddressIntoHTMLString(address)).toBe(expectedString);
     });
 

--- a/test/src/services/update_acsp/updateYourDetailsService.test.ts
+++ b/test/src/services/update_acsp/updateYourDetailsService.test.ts
@@ -37,8 +37,8 @@ describe("CheckYourAnswersService", () => {
             businessName: "Example ACSP Ltd",
             typeOfBusiness: "limited-company",
             correspondenceEmail: "john.doe@example.com",
-            registeredOfficeAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB",
-            serviceAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB"
+            registeredOfficeAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>",
+            serviceAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>"
         });
     });
 
@@ -53,8 +53,8 @@ describe("CheckYourAnswersService", () => {
             businessName: "John Doe",
             name: "John A. Doe",
             countryOfResidence: "united-kingdom",
-            serviceAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB",
-            registeredOfficeAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB"
+            serviceAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>",
+            registeredOfficeAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>"
         });
     });
 
@@ -67,8 +67,8 @@ describe("CheckYourAnswersService", () => {
             typeOfBusiness: "unincorporated-entity",
             correspondenceEmail: "john.doe@example.com",
             businessName: "John Doe",
-            registeredOfficeAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB",
-            serviceAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB"
+            registeredOfficeAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>",
+            serviceAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>"
         });
     });
 
@@ -81,8 +81,8 @@ describe("CheckYourAnswersService", () => {
             typeOfBusiness: "unincorporated-entity",
             correspondenceEmail: "john.doe@example.com",
             businessName: "John Doe",
-            registeredOfficeAddress: "456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB",
-            serviceAddress: "456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB"
+            registeredOfficeAddress: "456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>",
+            serviceAddress: "456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>"
         });
     });
 
@@ -95,8 +95,8 @@ describe("CheckYourAnswersService", () => {
             typeOfBusiness: "unincorporated-entity",
             correspondenceEmail: "john.doe@example.com",
             businessName: "John Doe",
-            registeredOfficeAddress: "Another Building<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB",
-            serviceAddress: "Another Building<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB"
+            registeredOfficeAddress: "Another Building<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>",
+            serviceAddress: "Another Building<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>"
         });
     });
 
@@ -109,8 +109,8 @@ describe("CheckYourAnswersService", () => {
             typeOfBusiness: "unincorporated-entity",
             correspondenceEmail: "john.doe@example.com",
             businessName: "John Doe",
-            registeredOfficeAddress: "Another Building 456 Another Street<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB",
-            serviceAddress: "Another Building 456 Another Street<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB"
+            registeredOfficeAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>",
+            serviceAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>"
         });
     });
 
@@ -123,8 +123,8 @@ describe("CheckYourAnswersService", () => {
             typeOfBusiness: "unincorporated-entity",
             correspondenceEmail: "john.doe@example.com",
             businessName: "John Doe",
-            registeredOfficeAddress: "Another Building 456 Another Street<br>Floor 2<br>Greater Manchester<br>united-kingdom<br>M1 2AB",
-            serviceAddress: "Another Building 456 Another Street<br>Floor 2<br>Greater Manchester<br>united-kingdom<br>M1 2AB"
+            registeredOfficeAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>",
+            serviceAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>"
         });
     });
 
@@ -137,8 +137,8 @@ describe("CheckYourAnswersService", () => {
             typeOfBusiness: "unincorporated-entity",
             correspondenceEmail: "john.doe@example.com",
             businessName: "John Doe",
-            registeredOfficeAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>united-kingdom<br>M1 2AB",
-            serviceAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>united-kingdom<br>M1 2AB"
+            registeredOfficeAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>",
+            serviceAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>"
         });
     });
 
@@ -151,8 +151,8 @@ describe("CheckYourAnswersService", () => {
             typeOfBusiness: "unincorporated-entity",
             correspondenceEmail: "john.doe@example.com",
             businessName: "John Doe",
-            registeredOfficeAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB",
-            serviceAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>M1 2AB"
+            registeredOfficeAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>",
+            serviceAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>"
         });
     });
 
@@ -165,8 +165,8 @@ describe("CheckYourAnswersService", () => {
             typeOfBusiness: "unincorporated-entity",
             correspondenceEmail: "john.doe@example.com",
             businessName: "John Doe",
-            registeredOfficeAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom",
-            serviceAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom"
+            registeredOfficeAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p>",
+            serviceAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p>"
         });
     });
 
@@ -179,7 +179,7 @@ describe("CheckYourAnswersService", () => {
             typeOfBusiness: "unincorporated-entity",
             correspondenceEmail: "john.doe@example.com",
             businessName: "John Doe",
-            registeredOfficeAddress: "Another Building 456 Another Street<br>Floor 2<br>Manchester<br>Greater Manchester<br>united-kingdom<br>M1 2AB",
+            registeredOfficeAddress: "Another Building 456 Another Street<p class=\"govuk-body govuk-!-margin-bottom-0\">Floor 2</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">Greater Manchester</p><p class=\"govuk-body govuk-!-margin-bottom-0\">united-kingdom</p><p class=\"govuk-body govuk-!-margin-bottom-0\">M1 2AB</p>",
             serviceAddress: ""
         });
     });


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2140

**Bug:** screen reader was encountering `<br>` tags mainly for formatted addresses in Update ACSP Update Your Details screen which was taking users out of the group and reading 'empty group' every time.

**Changes:** I've replaced `<br>` tags with `<p>` tags using govuk classes to keep the same formatting and spacing as `<br>`.

I also discovered this was happening on every field on the Your Updates screen before the 'Changed on 01 Jan 2025' lines so these `<br>` tags have also been replaced.

As I changed the formatAddressIntoHTMLString function which is also called in Register ACSP service on Check Your Answers screen, the tests for checkYourAnswersService have been updated as well.