### PR TITLE
Updating error controllers handling of 401 error redirects

### DIFF
--- a/src/controllers/errorController.ts
+++ b/src/controllers/errorController.ts
@@ -4,15 +4,25 @@ import { ErrorService } from "../services/errorService";
 import { getLocalesService, selectLang } from "../utils/localise";
 import logger from "../utils/logger";
 import { CHS_URL } from "../utils/properties";
-import { BASE_URL, CHECK_SAVED_APPLICATION } from "../types/pageURL";
+import { BASE_URL, CHECK_SAVED_APPLICATION, CLOSE_ACSP_BASE_URL, UPDATE_ACSP_DETAILS_BASE_URL } from "../types/pageURL";
 
 export const httpErrorHandler: ErrorRequestHandler = (err: any, req: Request, res: Response, next: NextFunction) => {
     if (err.httpStatusCode === 401) {
+
+        let redirectUrl;
+        if (req.originalUrl.includes(UPDATE_ACSP_DETAILS_BASE_URL)) {
+            redirectUrl = UPDATE_ACSP_DETAILS_BASE_URL;
+        } else if (req.originalUrl.includes(CLOSE_ACSP_BASE_URL)) {
+            redirectUrl = CLOSE_ACSP_BASE_URL;
+        } else {
+            redirectUrl = BASE_URL + CHECK_SAVED_APPLICATION;
+        }
+
         logger.errorRequest(
             req,
-            `A ${err.httpStatusCode} error occurred when a ${req.method} request was made to ${req.originalUrl}. Re-directing to ${BASE_URL}${CHECK_SAVED_APPLICATION}`
+            `A ${err.httpStatusCode} error occurred when a ${req.method} request was made to ${req.originalUrl}. Re-directing to ${redirectUrl}`
         );
-        res.redirect(`${CHS_URL}/signin?return_to=${BASE_URL}${CHECK_SAVED_APPLICATION}`);
+        res.redirect(`${CHS_URL}/signin?return_to=${redirectUrl}`);
     } else {
         next(err);
     }

--- a/src/controllers/errorController.ts
+++ b/src/controllers/errorController.ts
@@ -20,7 +20,7 @@ export const httpErrorHandler: ErrorRequestHandler = (err: any, req: Request, re
 
         logger.errorRequest(
             req,
-            `A ${err.httpStatusCode} error occurred when a ${req.method} request was made to ${req.originalUrl}. Re-directing to ${redirectUrl}`
+            `A 401 error occurred when a ${req.method} request was made to ${req.originalUrl}. Re-directing to ${redirectUrl}`
         );
         res.redirect(`${CHS_URL}/signin?return_to=${redirectUrl}`);
     } else {

--- a/test/src/controllers/errorController.test.ts
+++ b/test/src/controllers/errorController.test.ts
@@ -7,7 +7,7 @@ import { mockResponse } from "../../mocks/response.mock";
 import { NextFunction } from "express";
 import { addLangToUrl } from "../../../src/utils/localise";
 import { CHS_URL } from "../../../src/utils/properties";
-import { BASE_URL, CHECK_SAVED_APPLICATION } from "../../../src/types/pageURL";
+import { BASE_URL, CHECK_SAVED_APPLICATION, CLOSE_ACSP_BASE_URL, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../src/types/pageURL";
 
 logger.error = jest.fn();
 const request = mockRequest();
@@ -21,7 +21,7 @@ describe("httpErrorHandler", () => {
     });
 
     it("should detect a 401 httpError and redirect to checked save application page", async () => {
-        const url = addLangToUrl("/originalUrl", "en");
+        const url = addLangToUrl(BASE_URL + "/originalUrl", "en");
         // Given
         request.originalUrl = url;
         request.method = "GET";
@@ -35,6 +35,40 @@ describe("httpErrorHandler", () => {
         httpErrorHandler(err, request, response, mockNext);
         // Then
         expect(response.redirect).toHaveBeenCalledWith(`${CHS_URL}/signin?return_to=${BASE_URL}${CHECK_SAVED_APPLICATION}`);
+    });
+
+    it("should detect a 401 httpError and redirect to checked save application page", async () => {
+        const url = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + "/originalUrl", "en");
+        // Given
+        request.originalUrl = url;
+        request.method = "GET";
+        request.query = {
+            lang: "en"
+        };
+
+        const err = createHttpError(401);
+        err.httpStatusCode = 401;
+        // When
+        httpErrorHandler(err, request, response, mockNext);
+        // Then
+        expect(response.redirect).toHaveBeenCalledWith(`${CHS_URL}/signin?return_to=${UPDATE_ACSP_DETAILS_BASE_URL}`);
+    });
+
+    it("should detect a 401 httpError and redirect to checked save application page", async () => {
+        const url = addLangToUrl(CLOSE_ACSP_BASE_URL + "/originalUrl", "en");
+        // Given
+        request.originalUrl = url;
+        request.method = "GET";
+        request.query = {
+            lang: "en"
+        };
+
+        const err = createHttpError(401);
+        err.httpStatusCode = 401;
+        // When
+        httpErrorHandler(err, request, response, mockNext);
+        // Then
+        expect(response.redirect).toHaveBeenCalledWith(`${CHS_URL}/signin?return_to=${CLOSE_ACSP_BASE_URL}`);
     });
 
     it("should ignore errors that are not 401 and pass them to next", async () => {

--- a/test/src/controllers/errorController.test.ts
+++ b/test/src/controllers/errorController.test.ts
@@ -20,7 +20,7 @@ describe("httpErrorHandler", () => {
         jest.clearAllMocks();
     });
 
-    it("should detect a 401 httpError and redirect to checked save application page", async () => {
+    it("should detect a 401 httpError and redirect to " + BASE_URL + CHECK_SAVED_APPLICATION, () => {
         const url = addLangToUrl(BASE_URL + "/originalUrl", "en");
         // Given
         request.originalUrl = url;
@@ -37,7 +37,7 @@ describe("httpErrorHandler", () => {
         expect(response.redirect).toHaveBeenCalledWith(`${CHS_URL}/signin?return_to=${BASE_URL}${CHECK_SAVED_APPLICATION}`);
     });
 
-    it("should detect a 401 httpError and redirect to checked save application page", async () => {
+    it("should detect a 401 httpError and redirect to " + UPDATE_ACSP_DETAILS_BASE_URL, () => {
         const url = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + "/originalUrl", "en");
         // Given
         request.originalUrl = url;
@@ -54,7 +54,7 @@ describe("httpErrorHandler", () => {
         expect(response.redirect).toHaveBeenCalledWith(`${CHS_URL}/signin?return_to=${UPDATE_ACSP_DETAILS_BASE_URL}`);
     });
 
-    it("should detect a 401 httpError and redirect to checked save application page", async () => {
+    it("should detect a 401 httpError and redirect to " + CLOSE_ACSP_BASE_URL, () => {
         const url = addLangToUrl(CLOSE_ACSP_BASE_URL + "/originalUrl", "en");
         // Given
         request.originalUrl = url;
@@ -71,7 +71,7 @@ describe("httpErrorHandler", () => {
         expect(response.redirect).toHaveBeenCalledWith(`${CHS_URL}/signin?return_to=${CLOSE_ACSP_BASE_URL}`);
     });
 
-    it("should ignore errors that are not 401 and pass them to next", async () => {
+    it("should ignore errors that are not 401 and pass them to next", () => {
         // Given
         request.originalUrl = "/originalUrl";
         request.method = "GET";
@@ -90,7 +90,7 @@ describe("csrfErrorHandler", () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
-    it("should detect a csrfError and render an error template", async () => {
+    it("should detect a csrfError and render an error template", () => {
         const url = addLangToUrl("/originalUrl", "en");
         // Given
         request.originalUrl = url;
@@ -105,7 +105,7 @@ describe("csrfErrorHandler", () => {
         expect(response.render).toHaveBeenCalled();
         expect(response.status).toHaveBeenCalledWith(403);
     });
-    it("should ignore errors that are not of type CsrfError and pass then to next", async () => {
+    it("should ignore errors that are not of type CsrfError and pass then to next", () => {
         // Given
         request.originalUrl = "/originalUrl";
         request.method = "GET";
@@ -125,7 +125,7 @@ describe("unhandledErrorHandler", () => {
         jest.clearAllMocks();
     });
 
-    it("should log the error and render the error page", async () => {
+    it("should log the error and render the error page", () => {
         const url = addLangToUrl("/originalUrl", "en");
         // Given
         request.originalUrl = url;


### PR DESCRIPTION
Ticket [IDVA5-2180](https://companieshouse.atlassian.net/browse/IDVA5-2180)

Updated the error controller when a 401 error is thrown. It now checks to see which service threw the 401 and redirects back to the base url for that service (except the registration service which redirects to check saved applications)

[IDVA5-2180]: https://companieshouse.atlassian.net/browse/IDVA5-2180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ