### PR TITLE
IDVA5-2161 Retain AML number when pressing back on 'when did this sta…

### DIFF
--- a/src/controllers/features/update-acsp/addAmlSupervisorController.ts
+++ b/src/controllers/features/update-acsp/addAmlSupervisorController.ts
@@ -15,6 +15,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const session = req.session as Session;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+        const updateBodyIndex: number | undefined = session.getExtraData(ADD_AML_BODY_UPDATE);
+        const newAmlBodyData = session.getExtraData(NEW_AML_BODY);
         const amlUpdateIndex = req.query.amlindex;
         const amlUpdateBody = req.query.amlbody;
         let indexForTheUpdate = -1;
@@ -28,9 +30,10 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             session.setExtraData(ADD_AML_BODY_UPDATE, indexForTheUpdate);
         }
 
-        const newAmlBodyData = session.getExtraData(NEW_AML_BODY);
         if (newAmlBodyData) {
             amlBody = (newAmlBodyData as { amlSupervisoryBody: string }).amlSupervisoryBody;
+        } else if (updateBodyIndex !== undefined) {
+            amlBody = acspUpdatedFullProfile.amlDetails[updateBodyIndex].supervisoryBody;
         }
 
         const lang = selectLang(req.query.lang);

--- a/src/controllers/features/update-acsp/amlMembershipNumberController.ts
+++ b/src/controllers/features/update-acsp/amlMembershipNumberController.ts
@@ -17,17 +17,18 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
-        const session = req.session as Session;
+        const session: Session = req.session as any as Session;
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER;
+        const newAMLBody: AmlSupervisoryBody = session.getExtraData(NEW_AML_BODY)!;
+        const updateBodyIndex: number | undefined = session.getExtraData(ADD_AML_BODY_UPDATE);
+        const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
 
-        const newAMLBody = session.getExtraData(NEW_AML_BODY) as AmlSupervisoryBody;
-        const updateBodyIndex = session.getExtraData(ADD_AML_BODY_UPDATE) as number;
-        const acspUpdatedFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED) as AcspFullProfile;
-
-        const membershipId = newAMLBody.membershipId ||
-            (updateBodyIndex !== undefined ? acspUpdatedFullProfile.amlDetails[updateBodyIndex]?.membershipDetails : undefined);
-
-        const payload = membershipId ? { membershipNumber_1: membershipId } : undefined;
+        let payload;
+        if (newAMLBody && newAMLBody.membershipId) {
+            payload = { membershipNumber_1: newAMLBody.membershipId };
+        } else if (updateBodyIndex !== undefined) {
+            payload = { membershipNumber_1: acspUpdatedFullProfile.amlDetails[updateBodyIndex].membershipDetails };
+        }
 
         res.render(config.AML_MEMBERSHIP_NUMBER, {
             ...getLocaleInfo(locales, lang),
@@ -49,11 +50,14 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const locales = getLocalesService();
         const session: Session = req.session as any as Session;
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + AML_MEMBERSHIP_NUMBER;
-        const newAMLBody: AmlSupervisoryBody = session.getExtraData(NEW_AML_BODY)!;
+        const newAMLBody: AmlSupervisoryBody = session.getExtraData(NEW_AML_BODY) || {};
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
         const AmlMembershipNumberServiceInstance = new AmlMembershipNumberService();
         const updateBodyIndex: number | undefined = session.getExtraData(ADD_AML_BODY_UPDATE);
-
+        if (!newAMLBody.amlSupervisoryBody && updateBodyIndex && updateBodyIndex > -1) {
+            newAMLBody.amlSupervisoryBody = acspUpdatedFullProfile.amlDetails[updateBodyIndex].supervisoryBody;
+            newAMLBody.membershipId = acspUpdatedFullProfile.amlDetails[updateBodyIndex].membershipDetails;
+        }
         const errorList = validationResult(req);
         if (!errorList.isEmpty()) {
             const amlSupervisoryBodyString = newAMLBody.amlSupervisoryBody!;

--- a/src/controllers/features/update-acsp/dateOfTheChangeController.ts
+++ b/src/controllers/features/update-acsp/dateOfTheChangeController.ts
@@ -17,10 +17,15 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const session: Session = req.session as any as Session;
         const cancelTheUpdateUrl = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang);
         const previousPage: string = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + getPreviousPageUrlDateOfChange(req), lang);
+
         if (!session.getExtraData(NEW_AML_BODY) && previousPage.includes(AML_MEMBERSHIP_NUMBER)) {
             const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
-            session.setExtraData(ADD_AML_BODY_UPDATE, acspUpdatedFullProfile.amlDetails.length - 1);
+            const updateBodyIndex: number | undefined = session.getExtraData(ADD_AML_BODY_UPDATE);
+            if (updateBodyIndex === undefined) {
+                session.setExtraData(ADD_AML_BODY_UPDATE, acspUpdatedFullProfile.amlDetails.length - 1);
+            }
         }
+
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE;
 
         // Save the AML removal index and body to the session to send to remove aml url

--- a/src/controllers/features/update-acsp/dateOfTheChangeController.ts
+++ b/src/controllers/features/update-acsp/dateOfTheChangeController.ts
@@ -7,7 +7,8 @@ import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../.
 import { getPreviousPageUrlDateOfChange, updateWithTheEffectiveDateAmendment } from "../../../services/update-acsp/dateOfTheChangeService";
 import { Session } from "@companieshouse/node-session-handler";
 import { AmlSupervisoryBody } from "@companieshouse/api-sdk-node/dist/services/acsp";
-import { AML_REMOVAL_BODY, AML_REMOVAL_INDEX, AML_REMOVED_BODY_DETAILS } from "../../../common/__utils/constants";
+import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
+import { ACSP_DETAILS_UPDATED, NEW_AML_BODY, ADD_AML_BODY_UPDATE, AML_REMOVAL_BODY, AML_REMOVAL_INDEX, AML_REMOVED_BODY_DETAILS } from "../../../common/__utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -16,6 +17,10 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const session: Session = req.session as any as Session;
         const cancelTheUpdateUrl = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang);
         const previousPage: string = addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + getPreviousPageUrlDateOfChange(req), lang);
+        if (!session.getExtraData(NEW_AML_BODY) && previousPage.includes(AML_MEMBERSHIP_NUMBER)) {
+            const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+            session.setExtraData(ADD_AML_BODY_UPDATE, acspUpdatedFullProfile.amlDetails.length - 1);
+        }
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_DATE_OF_THE_CHANGE;
 
         // Save the AML removal index and body to the session to send to remove aml url

--- a/src/services/update-acsp/dateOfTheChangeService.ts
+++ b/src/services/update-acsp/dateOfTheChangeService.ts
@@ -59,7 +59,7 @@ export const updateWithTheEffectiveDateAmendment = (req: Request, dateOfChange: 
 
         // Validate and clean up session data
         AmlMembershipNumberServiceInstance.validateUpdateBodyIndex(updateBodyIndex, acspUpdatedFullProfile, newAMLBody);
-        session.deleteExtraData(ADD_AML_BODY_UPDATE);
+
         session.deleteExtraData(NEW_AML_BODY);
     }
     session.deleteExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS);

--- a/test/src/controllers/updateAcspDetails/addAmlSupervisorController.test.ts
+++ b/test/src/controllers/updateAcspDetails/addAmlSupervisorController.test.ts
@@ -68,7 +68,69 @@ describe("GET" + UPDATE_ADD_AML_SUPERVISOR, () => {
         expect(res.text).toContain("Sorry we are experiencing technical difficulties");
     });
 });
+describe("addAmlSupervisorController - get", () => {
+    let req: Partial<Request>;
+    let res: Partial<Response>;
+    let next: NextFunction;
+    let sessionMock: Partial<Session>;
 
+    beforeEach(() => {
+        sessionMock = {
+            getExtraData: jest.fn(),
+            setExtraData: jest.fn()
+        };
+
+        req = {
+            session: sessionMock as Session,
+            query: {}
+        } as Partial<Request>;
+
+        res = {
+            render: jest.fn()
+        } as Partial<Response>;
+
+        next = jest.fn();
+    });
+
+    it("should set amlBody to the supervisoryBody at updateBodyIndex when updateBodyIndex is defined", async () => {
+        const acspUpdatedFullProfile = {
+            amlDetails: [
+                { membershipDetails: "123456", supervisoryBody: "Body A" },
+                { membershipDetails: "654321", supervisoryBody: "Body B" }
+            ]
+        };
+        const updateBodyIndex = 1;
+
+        sessionMock.getExtraData = jest.fn()
+            .mockImplementation((key: string) => {
+                if (key === ACSP_DETAILS_UPDATED) return acspUpdatedFullProfile;
+                if (key === ADD_AML_BODY_UPDATE) return updateBodyIndex;
+            });
+        await get(req as Request, res as Response, next);
+        expect(res.render).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+            amlBody: "Body B"
+        }));
+    });
+
+    it("should not set amlBody if updateBodyIndex is undefined", async () => {
+        const acspUpdatedFullProfile = {
+            amlDetails: [
+                { membershipDetails: "123456", supervisoryBody: "Body A" },
+                { membershipDetails: "654321", supervisoryBody: "Body B" }
+            ]
+        };
+        const updateBodyIndex = undefined;
+        sessionMock.getExtraData = jest.fn()
+            .mockImplementation((key: string) => {
+                if (key === ACSP_DETAILS_UPDATED) return acspUpdatedFullProfile;
+                if (key === ADD_AML_BODY_UPDATE) return updateBodyIndex;
+            });
+        await get(req as Request, res as Response, next);
+        expect(res.render).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+            amlBody: ""
+        }));
+    });
+});
 describe("amlSupervisor", () => {
     let req: Partial<Request>;
     let res: Partial<Response>;

--- a/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
+++ b/test/src/controllers/updateAcspDetails/amlMembershipNumberController.test.ts
@@ -46,23 +46,6 @@ describe("GET " + AML_MEMBERSHIP_NUMBER, () => {
         expect(res.status).toBe(200);
         expect(res.text).toContain("What is the Anti-Money Laundering (AML) membership number?");
     });
-    it("should set payload with membershipNumber_1 from acspUpdatedFullProfile when updateBodyIndex is defined", async () => {
-        const updateBodyIndex = 0;
-        const acspUpdatedFullProfile = {
-            amlDetails: [
-                { membershipDetails: "123456", supervisoryBody: "Some Body" }
-            ]
-        };
-
-        sessionMock.getExtraData = jest.fn()
-            .mockReturnValueOnce({})
-            .mockReturnValueOnce(updateBodyIndex)
-            .mockReturnValueOnce(acspUpdatedFullProfile);
-        await get(req as Request, res as Response, next);
-        expect(res.render).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
-            payload: { membershipNumber_1: "123456" }
-        }));
-    });
 
     it("should not set payload if updateBodyIndex is undefined", async () => {
         const updateBodyIndex = undefined;
@@ -82,24 +65,6 @@ describe("GET " + AML_MEMBERSHIP_NUMBER, () => {
         }));
     });
 
-    it("should not set payload if updateBodyIndex is out of bounds", async () => {
-        const updateBodyIndex = 5;
-        const acspUpdatedFullProfile = {
-            amlDetails: [
-                { membershipDetails: "123456", supervisoryBody: "Some Body" }
-            ]
-        };
-
-        sessionMock.getExtraData = jest.fn()
-            .mockReturnValueOnce({})
-            .mockReturnValueOnce(updateBodyIndex)
-            .mockReturnValueOnce(acspUpdatedFullProfile);
-
-        await get(req as Request, res as Response, next);
-        expect(res.render).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
-            payload: undefined
-        }));
-    });
     it("should render the AML membership number page with pre-filled membership number when updateBodyIndex is set", async () => {
         const session = getSessionRequestWithPermission();
         session.setExtraData(NEW_AML_BODY, { amlSupervisoryBody: "Some Body" });

--- a/test/src/services/update_acsp/dateOfTheChangeService.test.ts
+++ b/test/src/services/update_acsp/dateOfTheChangeService.test.ts
@@ -185,7 +185,6 @@ describe("updateWithTheEffectiveDateAmendment", () => {
         expect(acspUpdatedFullProfile.amlDetails[0].dateOfChange).toBe(newAMLBody.dateOfChange);
 
         expect(session.setExtraData).toHaveBeenCalledWith(NEW_AML_BODY, newAMLBody);
-        expect(session.deleteExtraData).toHaveBeenCalledWith(ADD_AML_BODY_UPDATE);
         expect(session.deleteExtraData).toHaveBeenCalledWith(NEW_AML_BODY);
         expect(session.deleteExtraData).toHaveBeenCalledWith(ACSP_DETAILS_UPDATE_IN_PROGRESS);
     });


### PR DESCRIPTION
Fixing the test returned issue of clicking back button from the update summary page.
Once reached to the cumulative update summary page after entering the date, the session values are deleted. Which was causing the back button not retaining the AML number and AML body details.

Fix implemented:
- Treating the back button click as an update event for the lastly added AML
- ADD_AML_BODY_UPDATE value is restored with the last index of the aml
- Necessary If else checks performed in the controllers of AML body and number, for get and post methods.