### PR TITLE
normalising email addresses before comparrison on confirmation page

### DIFF
--- a/src/controllers/features/close-acsp/confirmationAuthorisedAgentClosedController.ts
+++ b/src/controllers/features/close-acsp/confirmationAuthorisedAgentClosedController.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { selectLang, getLocalesService, getLocaleInfo } from "../../../utils/localise";
+import { trimAndLowercaseString } from "../../../services/common";
 import * as config from "../../../config";
 import { CLOSE_ACSP_BASE_URL, CLOSE_CONFIRMATION_ACSP_CLOSED, STRIKE_OFF_YOUR_COMPANY, TELL_HMRC_YOUVE_STOPPED_TRADING } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
@@ -12,12 +13,16 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const locales = getLocalesService();
         const session: Session = req.session as any as Session;
         const acspDetails: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
+        const loginEmail = trimAndLowercaseString(res.locals.userEmail);
+        const correspondenceEmail = trimAndLowercaseString(acspDetails.email);
+        const showBothEmails = loginEmail !== correspondenceEmail;
 
         res.render(config.CLOSE_CONFIRMATION_ACSP_CLOSED, {
             ...getLocaleInfo(locales, lang),
             currentUrl: CLOSE_ACSP_BASE_URL + CLOSE_CONFIRMATION_ACSP_CLOSED,
-            loginEmail: res.locals.userEmail,
-            correspondenceEmail: acspDetails.email,
+            loginEmail,
+            correspondenceEmail,
+            showBothEmails,
             businessName: acspDetails.name,
             transactionId: "TRANSACTION_ID",
             strikeOffYourLtdCompanyLink: STRIKE_OFF_YOUR_COMPANY,

--- a/src/views/features/close-acsp/confirmation-authorised-agent-closed/confirmation-authorised-agent-closed.njk
+++ b/src/views/features/close-acsp/confirmation-authorised-agent-closed/confirmation-authorised-agent-closed.njk
@@ -10,7 +10,7 @@
   {# Remove back button on this page by replacing it with nothing #}
 {% endblock %}
 
-{% if loginEmail !== correspondenceEmail %}
+{% if showBothEmails %}
   {% set sentEmailToBodyText =
     "<p class='govuk-body'>"+i18n.weHaveSentAConfirmationEmail+"<strong>"+loginEmail+"</strong>"+i18n.and+"<strong>"+correspondenceEmail+"</strong>.</p>"
   %}


### PR DESCRIPTION
Fixing issue for ticket returned from testing:
[IDVA5-1759](https://companieshouse.atlassian.net/browse/IDVA5-1759)

- Normalising both login email and correspondence email address before comparison to prevent both displaying on front end screen if there is a difference in letter case (i.e; login email = test@test.com, correspondence email = TEST@TEST.COM)

[IDVA5-1759]: https://companieshouse.atlassian.net/browse/IDVA5-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ