### PR TITLE
IDVA5-2185 updateFlag value fixed to show/hide continue and cancel button

### DIFF
--- a/src/controllers/features/update-acsp/updateYourDetailsController.ts
+++ b/src/controllers/features/update-acsp/updateYourDetailsController.ts
@@ -40,6 +40,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const session: Session = req.session as any as Session;
         const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
+        const updateFlag = !deepEquals(acspFullProfile, acspUpdatedFullProfile);
 
         const changeDates = {
             name: formatDateIntoReadableString(new Date(session.getExtraData(ACSP_UPDATE_CHANGE_DATE.NAME) || "")),
@@ -78,7 +79,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             addAML: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_ADD_AML_SUPERVISOR, lang),
             profileDetails: getProfileDetails(acspFullProfile),
             profileDetailsUpdated: getProfileDetails(acspUpdatedFullProfile),
-            updateFlag: deepEquals(acspFullProfile, acspUpdatedFullProfile),
+            updateFlag,
             acspFullProfile,
             acspUpdatedFullProfile,
             cancelChangeUrl: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + CANCEL_AN_UPDATE, lang),


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2185

**Bug:** Continue/Cancel buttons at bottom of Update Your Details were not showing even after updating any values, Adding AML or Removing AML.

**Fix:** Moved the updateFlag value so it is set first in controller and also checking for !deepEquals