### PR TITLE
Updating content for correspondence email update acsp details

### DIFF
--- a/locales/cy/update-acsp-what-is-your-email.json
+++ b/locales/cy/update-acsp-what-is-your-email.json
@@ -1,5 +1,5 @@
 {
-    "wellUseThisToSendInformationHint": "Byddwn yn defnyddio hyn i anfon gwybodaeth am y cyfrif asiant awdurdodedig unwaith y bydd y busnes wedi'i gofrestru.",
+    "wellUseThisToSendInformationHint": "Byddwn yn defnyddio hyn i anfon gwybodaeth am y cyfrif asiant awdurdodedig.",
     "whatCorrespondenceWellSend": "Pa ohebiaeth y byddwn yn ei hanfon i'r cyfeiriad e-bost",
     "wellUseThisToSendEssentialEmails": "Byddwn yn defnyddio hyn i anfon negeseuon e-bost hanfodol am gyfrif yr asiant. Er enghraifft, os oes angen:"
 }

--- a/locales/en/update-acsp-what-is-your-email.json
+++ b/locales/en/update-acsp-what-is-your-email.json
@@ -1,5 +1,5 @@
 {
-    "wellUseThisToSendInformationHint": "We'll use this to send information about the authorised agent account once the business is registered.",
+    "wellUseThisToSendInformationHint": "We'll use this to send information about the authorised agent account.",
     "whatCorrespondenceWellSend": "What correspondence we'll send to the email address",
     "wellUseThisToSendEssentialEmails": "We'll use this to send essential emails about the agent account. For example, if we need to:"
 }

--- a/src/views/features/update-acsp-details/what-is-your-email/what-is-your-email.njk
+++ b/src/views/features/update-acsp-details/what-is-your-email/what-is-your-email.njk
@@ -67,7 +67,6 @@
                 <li>{{ i18n.checkTheAgentIsComplying }}</li>
                 <li>{{ i18n.suspendTheAgentAccount }}</li>
             </ul>
-            <p>{{ i18n.updateEmailAddressAfter }}</p>
         </div>
     </details>
 


### PR DESCRIPTION
Changes for ticket:
[IDVA5-2176](https://companieshouse.atlassian.net/browse/IDVA5-2176?atlOrigin=eyJpIjoiOTU5ZWYzZmI0OGY5NDVkZGI2NGEzNDk1YTYyNzMyNTMiLCJwIjoiaiJ9)

Updating content for 'What email address should we use for correspondence?' screen for Update ACSP Details service

[IDVA5-2176]: https://companieshouse.atlassian.net/browse/IDVA5-2176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ