### PR TITLE
Updating missing Welsh translation

### DIFF
--- a/locales/cy/aml-body-number.json
+++ b/locales/cy/aml-body-number.json
@@ -5,7 +5,7 @@
   "amlMembershipLisit2": "ID rheoliad",
   "amlMembershipLisit3": "ID AML",
   "amlcontactinfo": "Cysylltwch â'r corff goruchwylio AML os oes angen i chi wirio eich manylion.",
-  "amlMembershipDescriptionUpdate": "Byddwn yn cadarnhau bod y corff goruchwylio AML yn dal yr un manylion ar gyfer eich asiant awdurdodedig. Gall hyn gymryd mwy o amser os ydych wedi cofrestru'n ddiweddar",
+  "amlMembershipDescriptionUpdate": "Byddwn yn cadarnhau bod y corff goruchwylio AML yn dal yr un manylion ar gyfer eich asiant awdurdodedig. Gall hyn gymryd mwy o amser os ydych wedi cofrestru'n ddiweddar.",
 
   "error-amlIDNumberInput": "Cofnodwch y manylion ar gyfer ",
   "error-amlIdLength": "Rhaid i'r rhif aelodaeth Gwrth-Gwyngalchu Arian (AML) fod yn 256 nod neu lai ar gyfer ",

--- a/locales/cy/common.json
+++ b/locales/cy/common.json
@@ -17,5 +17,6 @@
     "openInNewTab": "yn agor mewn tab newydd",
     "whatHappensNextHeading": "Beth sy'n digwydd nesaf",
     "thereIsAProblemError": "Mae yna broblem",
-    "error": "Gwall"
+    "error": "Gwall",
+    "Warning": "Rhybudd"
 }

--- a/locales/en/address-look-up.json
+++ b/locales/en/address-look-up.json
@@ -7,7 +7,7 @@
     "correspondenceLookUpAddressPostCodeInput": "UK postcode",
     "correspondenceLookUpAddressInputHint1": "Property name or number",
     "correspondenceLookUpAddressInputHint2": "You'll need to enter the address manually if it's not in the UK.",
-    "businessLookUpAddressPostcodeHint": "For example, The Mill', '116' or 'Flat 37a'",
+    "businessLookUpAddressPostcodeHint": "For example, 'The Mill', '116' or 'Flat 37a'",
     "correspondenceLookUpAddressFindAddressBtn": "Find address",
     "correspondenceLookUpAddressManuallyBtn": "Enter address manually",
     "correspondenceLookUpAddressListTitle": "Select the correspondence address",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -17,5 +17,6 @@
     "openInNewTab": "opens in a new tab",
     "whatHappensNextHeading": "What happens next",
     "thereIsAProblemError": "There is a problem",
-    "error": "Error"
+    "error": "Error",
+    "Warning": "Warning"
 }

--- a/src/views/common/correspondence-auto-lookup-address/auto-lookup-address.njk
+++ b/src/views/common/correspondence-auto-lookup-address/auto-lookup-address.njk
@@ -43,7 +43,11 @@
       id: "premise",
       name: "premise",
       autocomplete: "street-address",
-      value: payload.premise
+      value: payload.premise,
+      hint: {
+        text: i18n.addressPropertyDetailsHint,
+        classes: "govuk-hint"
+      }
     }) }}
     {% if reqType === "updateAcsp" %}
       <div class="govuk-button-group">

--- a/src/views/common/your-responsibilities/your-responsibilities.njk
+++ b/src/views/common/your-responsibilities/your-responsibilities.njk
@@ -31,7 +31,7 @@
     <div class="govuk-warning-text">
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
       <strong class="govuk-warning-text__text">
-        <span class="govuk-visually-hidden">Warning</span>
+        <span class="govuk-visually-hidden">{{ i18n.Warning }}</span>
         {{ i18n.yourResponsibilitiesWarningText }}
       </strong>
     </div>

--- a/src/views/features/close-acsp/confirm-you-want-to-close/confirm-you-want-to-close.njk
+++ b/src/views/features/close-acsp/confirm-you-want-to-close/confirm-you-want-to-close.njk
@@ -14,7 +14,7 @@
         <div class="govuk-warning-text">
             <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
             <strong class="govuk-warning-text__text">
-                <span class="govuk-visually-hidden">Warning</span>
+                <span class="govuk-visually-hidden">{{ i18n.Warning }}</span>
                 {{ i18n.ifYouConfirmWarningText | replace('{BUSINESS_NAME}', businessName) }}
             </strong>
         </div>

--- a/src/views/features/update-acsp-details/index/home.njk
+++ b/src/views/features/update-acsp-details/index/home.njk
@@ -17,7 +17,7 @@
     <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
-          <span class="govuk-visually-hidden">Warning</span>
+          <span class="govuk-visually-hidden">{{ i18n.Warning }}</span>
           {{ i18n.ifDetailsChangeWarningText }}
         </strong>
     </div>


### PR DESCRIPTION
Changes for bug ticket:
[IDVA5-2204](https://companieshouse.atlassian.net/browse/IDVA5-2204?atlOrigin=eyJpIjoiMmQ5NTQxZTJiOTkwNDM0NmJjYjNmZTViMTY4YjFkZTAiLCJwIjoiaiJ9)

- Updated missing Welsh translations
- Added missing hint text on address auto lookup screens
- Added translation for visually hidden 'Warning' text across Update ACSP and Registration services, as this is required for screen readers

[IDVA5-2204]: https://companieshouse.atlassian.net/browse/IDVA5-2204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ