### PR TITLE
Adding feedback link for update acsp service

### DIFF
--- a/src/controllers/features/update-acsp/applicationConfirmationController.ts
+++ b/src/controllers/features/update-acsp/applicationConfirmationController.ts
@@ -23,7 +23,6 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             ...getLocaleInfo(locales, lang),
             currentUrl,
             authorisedAgentAccountLink: AUTHORISED_AGENT,
-            surveyLink: "#",
             email,
             transactionId
         });

--- a/src/controllers/indexController.ts
+++ b/src/controllers/indexController.ts
@@ -14,14 +14,12 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     const locales = getLocalesService();
 
     const verifyIdentityGovOneLoginLink = addLangToUrl(VERIFY_IDENTITY_WITH_GOV_UK_ONE_LOGIN, lang);
-    const feedbackLink = "https://www.smartsurvey.co.uk/s/reg-as-acsp-fdbk/";
     const abilityNetAccessibilityLink = "https://mcmw.abilitynet.org.uk/";
 
     res.render(config.HOME, {
         ...getLocaleInfo(locales, lang),
         currentUrl: BASE_URL,
         PIWIK_REGISTRATION_START_GOAL_ID,
-        feedbackLink,
         abilityNetAccessibilityLink,
         ACSP01_COST,
         verifyIdentityGovOneLoginLink

--- a/src/middleware/registration_variables_middleware.ts
+++ b/src/middleware/registration_variables_middleware.ts
@@ -1,6 +1,6 @@
 import { Handler } from "express";
 import { AcspType } from "../model/AcspType";
-import { BASE_URL } from "../types/pageURL";
+import { BASE_URL, REGISTRATION_FEEDBACK_LINK } from "../types/pageURL";
 
 /**
  * Populates variables for use in templates that are used on multiple pages.
@@ -17,6 +17,7 @@ export const registrationVariablesMiddleware: Handler = (req, res, next) => {
     res.locals.serviceUrl = BASE_URL;
     res.locals.journeyType = AcspType.REGISTER_ACSP;
     res.locals.tabTitleKey = "CommonTabTitle";
+    res.locals.feedbackLink = REGISTRATION_FEEDBACK_LINK;
 
     next();
 };

--- a/src/middleware/update-acsp/update_variables_middleware.ts
+++ b/src/middleware/update-acsp/update_variables_middleware.ts
@@ -1,4 +1,4 @@
-import { UPDATE_ACSP_DETAILS_BASE_URL } from "../../types/pageURL";
+import { UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_FEEDBACK_LINK } from "../../types/pageURL";
 import { REQ_TYPE_UPDATE_ACSP } from "../../common/__utils/constants";
 import { Handler } from "express";
 
@@ -17,6 +17,7 @@ export const updateVariablesMiddleware: Handler = (req, res, next) => {
     res.locals.serviceUrl = UPDATE_ACSP_DETAILS_BASE_URL;
     res.locals.reqType = REQ_TYPE_UPDATE_ACSP;
     res.locals.tabTitleKey = "CommonTabTitleUpdateAcsp";
+    res.locals.feedbackLink = UPDATE_FEEDBACK_LINK;
 
     next();
 };

--- a/src/types/pageURL.ts
+++ b/src/types/pageURL.ts
@@ -68,6 +68,8 @@ export const STRIKE_OFF_YOUR_COMPANY = "https://www.gov.uk/strike-off-your-compa
 
 export const TELL_HMRC_YOUVE_STOPPED_TRADING = "https://www.gov.uk/stop-being-self-employed";
 
+export const REGISTRATION_FEEDBACK_LINK = "https://www.smartsurvey.co.uk/s/reg-as-acsp-fdbk/";
+
 // sole trader journey urls
 export const SOLE_TRADER_WHAT_IS_YOUR_ROLE = SOLE_TRADER + "/what-is-your-role";
 
@@ -225,6 +227,8 @@ export const UPDATE_DATE_OF_THE_CHANGE = "/date-of-the-change";
 export const UPDATE_PROVIDE_AML_DETAILS = "/provide-aml-details";
 
 export const UPDATE_CHECK_YOUR_UPDATES = "/check-your-updates";
+
+export const UPDATE_FEEDBACK_LINK = "https://www.smartsurvey.co.uk/s/updateacsp-fdbk/";
 
 // close acsp urls
 

--- a/src/views/features/update-acsp-details/application-confirmation/application-confirmation.njk
+++ b/src/views/features/update-acsp-details/application-confirmation/application-confirmation.njk
@@ -29,7 +29,7 @@
 
     <h2 class="govuk-heading-m">{{ i18n.helpUsToImproveThisServiceHeading }}</h2>
     <p class="govuk-body">
-      {{ i18n.thisIsANewService }} <a href={{ surveyLink }} class="govuk-link govuk-link--no-visited-state" target="_blank">{{ i18n.completeOurQuickSurveyLink }}</a> {{ i18n.toHelpUsImproveIt }}
+      {{ i18n.thisIsANewService }} <a href={{ feedbackLink }} class="govuk-link govuk-link--no-visited-state" target="_blank">{{ i18n.completeOurQuickSurveyLink }}</a> {{ i18n.toHelpUsImproveIt }}
     </p>
 
 {% endblock main_content %}

--- a/src/views/partials/phase_banner.njk
+++ b/src/views/partials/phase_banner.njk
@@ -5,7 +5,16 @@
     </strong>
     <span class="govuk-phase-banner__text">
       This is a new service – your 
-      <a class="govuk-link" href="{{ feedbackLink | default('https://www.smartsurvey.co.uk/s/reg-as-acsp-fdbk/') }}" {% if currentUrl !== "/register-as-companies-house-authorised-agent" and currentUrl !== "/register-as-companies-house-authorised-agent/cannot-use-service" %} target="_blank" {% endif %} rel="noopener noreferrer">feedback{% if currentUrl !== "/register-as-companies-house-authorised-agent" and currentUrl !== "/register-as-companies-house-authorised-agent/cannot-use-service" %}(opens in a new tab){% endif %}</a>
+      <a class="govuk-link" href="{{ feedbackLink }}"
+        {% if currentUrl !== "/register-as-companies-house-authorised-agent" and currentUrl !== "/register-as-companies-house-authorised-agent/cannot-use-service" %}
+          target="_blank"
+        {% endif %}
+        rel="noopener noreferrer">
+        feedback
+        {% if currentUrl !== "/register-as-companies-house-authorised-agent" and currentUrl !== "/register-as-companies-house-authorised-agent/cannot-use-service" %}
+          (opens in a new tab)
+        {% endif %}
+      </a>
       will help us to improve it.
     </span>
   </p>


### PR DESCRIPTION
Changes for ticket:
[IDVA5-2207](https://companieshouse.atlassian.net/browse/IDVA5-2207)

- Adding constants for feedback links for both update acsp and registration services
- Assigning above constants to feedbackLink variables in middlewares to be accessible across services (we no longer need the default value as the feedbackLink will not be undefined/null)
- Updating phase_banner.njk to use feedbackLink from middleware
- Adding feedbackLink to confirmation page on update acsp details service

[IDVA5-2207]: https://companieshouse.atlassian.net/browse/IDVA5-2207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ