### PR TITLE
Updating confirmation page to display users logged in email

### DIFF
--- a/src/controllers/features/update-acsp/applicationConfirmationController.ts
+++ b/src/controllers/features/update-acsp/applicationConfirmationController.ts
@@ -3,9 +3,9 @@ import { selectLang, getLocalesService, getLocaleInfo } from "../../../utils/loc
 import * as config from "../../../config";
 import { AUTHORISED_AGENT, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_APPLICATION_CONFIRMATION } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { ACSP_DETAILS, UPDATE_SUBMISSION_ID } from "../../../common/__utils/constants";
+import { UPDATE_SUBMISSION_ID } from "../../../common/__utils/constants";
 import { deleteAllSessionData } from "../../../common/__utils/sessionHelper";
-import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
+import { trimAndLowercaseString } from "../../../services/common";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -13,8 +13,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
         const currentUrl = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_APPLICATION_CONFIRMATION;
-        const acspFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
-        const email: string = acspFullProfile.email;
+        const loginEmail = trimAndLowercaseString(res.locals.userEmail);
         const transactionId: string = session.getExtraData(UPDATE_SUBMISSION_ID)!;
 
         await deleteAllSessionData(session);
@@ -23,7 +22,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             ...getLocaleInfo(locales, lang),
             currentUrl,
             authorisedAgentAccountLink: AUTHORISED_AGENT,
-            email,
+            loginEmail,
             transactionId
         });
     } catch (err) {

--- a/src/views/features/update-acsp-details/application-confirmation/application-confirmation.njk
+++ b/src/views/features/update-acsp-details/application-confirmation/application-confirmation.njk
@@ -19,7 +19,7 @@
     classes: "govuk-!-margin-top-7"
   }) }}
 
-    <p class="govuk-body"> {{ i18n.weHaveSentAConfirmationEmailTo }} <strong>{{ email }}</strong> {{ i18n.withYourReferenceNumber }}</p>
+    <p class="govuk-body"> {{ i18n.weHaveSentAConfirmationEmailTo }} <strong>{{ loginEmail }}</strong> {{ i18n.withYourReferenceNumber }}</p>
     
     <h2 class="govuk-heading-m">{{ i18n.whatHappensNextHeading }}</h2>
     <p class="govuk-body">{{ i18n.wellEmailToLetYouKnow}}</p>

--- a/src/views/partials/phase_banner.njk
+++ b/src/views/partials/phase_banner.njk
@@ -9,13 +9,9 @@
         {% if currentUrl !== "/register-as-companies-house-authorised-agent" and currentUrl !== "/register-as-companies-house-authorised-agent/cannot-use-service" %}
           target="_blank"
         {% endif %}
-        rel="noopener noreferrer">
-        feedback
+        rel="noopener noreferrer">feedback
         {% if currentUrl !== "/register-as-companies-house-authorised-agent" and currentUrl !== "/register-as-companies-house-authorised-agent/cannot-use-service" %}
-          (opens in a new tab)
-        {% endif %}
-      </a>
-      will help us to improve it.
+        (opens in a new tab){% endif %}</a> will help us to improve it.
     </span>
   </p>
 </div>


### PR DESCRIPTION
Change for ticket:
[IDVA5-2218](https://companieshouse.atlassian.net/browse/IDVA5-2218)

- Updating confirmation page on Update ACSP Details service to display the logged in user email address rather than the correspondence email address.
- Fixing a visual bug on the href text of the feedback banner

[IDVA5-2218]: https://companieshouse.atlassian.net/browse/IDVA5-2218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ