### PR TITLE
Fixing Auth redirection for Close ACSP login

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -33,6 +33,9 @@ import { registrationVariablesMiddleware } from "./middleware/registration_varia
 import { updateVariablesMiddleware } from "./middleware/update-acsp/update_variables_middleware";
 import { isActiveFeature } from "./utils/feature.flag";
 import { closeVariablesMiddleware } from "./middleware/close-acsp/close_variables_middleware";
+import { closeAcspBaseAuthenticationMiddleware } from "./middleware/close-acsp/close_acsp_base_authentication_middleware";
+import { closeAcspAuthMiddleware } from "./middleware/close-acsp/close_acsp_authentication_middleware";
+import { closeAcspIsOwnerMiddleware } from "./middleware/close-acsp/close_acsp_is_owner_middleware";
 
 const app = express();
 const nonce: string = uuidv4();
@@ -82,16 +85,24 @@ if (isActiveFeature(FEATURE_FLAG_VERIFY_SOLE_TRADER_ONLY)) {
 }
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}|${BASE_URL}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, sessionMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}|${BASE_URL}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, csrfProtectionMiddleware);
-app.use(`^(?!(${BASE_URL}${HEALTHCHECK}|${BASE_URL}$|${BASE_URL}${ACCESSIBILITY_STATEMENT})|(${BASE_URL}${SOLE_TRADER})|(${UPDATE_ACSP_DETAILS_BASE_URL}))*`, authenticationMiddleware);
+app.use(`^(?!(${BASE_URL}${HEALTHCHECK}|${BASE_URL}$|${BASE_URL}${ACCESSIBILITY_STATEMENT})|(${BASE_URL}${SOLE_TRADER})|(${UPDATE_ACSP_DETAILS_BASE_URL})|(${CLOSE_ACSP_BASE_URL}))*`, authenticationMiddleware);
 app.use(`^(${BASE_URL}${SOLE_TRADER})*`, authenticationMiddlewareForSoleTrader);
+
+// Common Variable middleware for each service
 app.use(commonTemplateVariablesMiddleware);
 app.use(BASE_URL, registrationVariablesMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateVariablesMiddleware);
 app.use(CLOSE_ACSP_BASE_URL, closeVariablesMiddleware);
 
+// Update ACSP details middleware
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspBaseAuthenticationMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspAuthMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspIsOwnerMiddleware);
+
+// Close ACSP middleware
+app.use(CLOSE_ACSP_BASE_URL, closeAcspBaseAuthenticationMiddleware);
+app.use(CLOSE_ACSP_BASE_URL, closeAcspAuthMiddleware);
+app.use(CLOSE_ACSP_BASE_URL, closeAcspIsOwnerMiddleware);
 
 app.use((req: Request, res: Response, next: NextFunction) => {
     res.locals.nonce = nonce;

--- a/src/app.ts
+++ b/src/app.ts
@@ -87,8 +87,6 @@ app.use(`^(?!(${BASE_URL}${HEALTHCHECK}|${BASE_URL}$|${BASE_URL}${ACCESSIBILITY_
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}|${BASE_URL}$|${BASE_URL}${ACCESSIBILITY_STATEMENT}))*`, csrfProtectionMiddleware);
 app.use(`^(?!(${BASE_URL}${HEALTHCHECK}|${BASE_URL}$|${BASE_URL}${ACCESSIBILITY_STATEMENT})|(${BASE_URL}${SOLE_TRADER})|(${UPDATE_ACSP_DETAILS_BASE_URL})|(${CLOSE_ACSP_BASE_URL}))*`, authenticationMiddleware);
 app.use(`^(${BASE_URL}${SOLE_TRADER})*`, authenticationMiddlewareForSoleTrader);
-
-// Common Variable middleware for each service
 app.use(commonTemplateVariablesMiddleware);
 app.use(BASE_URL, registrationVariablesMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateVariablesMiddleware);

--- a/src/middleware/close-acsp/close_acsp_authentication_middleware.ts
+++ b/src/middleware/close-acsp/close_acsp_authentication_middleware.ts
@@ -1,0 +1,17 @@
+import { NextFunction, Request, Response } from "express";
+import { acspManageUsersAuthMiddleware, AuthOptions } from "@companieshouse/web-security-node";
+import { CHS_URL } from "../../utils/properties";
+import { getLoggedInAcspNumber } from "../../common/__utils/session";
+import { CLOSE_ACSP_BASE_URL } from "../../types/pageURL";
+
+export const closeAcspAuthMiddleware = (req: Request, res: Response, next: NextFunction): unknown => {
+    const acspNumber: string = getLoggedInAcspNumber(req.session);
+
+    const authMiddlewareConfig: AuthOptions = {
+        chsWebUrl: CHS_URL,
+        returnUrl: CLOSE_ACSP_BASE_URL,
+        acspNumber
+    };
+
+    return acspManageUsersAuthMiddleware(authMiddlewareConfig)(req, res, next);
+};

--- a/src/middleware/close-acsp/close_acsp_base_authentication_middleware.ts
+++ b/src/middleware/close-acsp/close_acsp_base_authentication_middleware.ts
@@ -1,0 +1,13 @@
+import { NextFunction, Request, Response } from "express";
+import { authMiddleware, AuthOptions } from "@companieshouse/web-security-node";
+import { CHS_URL } from "../../utils/properties";
+import { CLOSE_ACSP_BASE_URL } from "../../types/pageURL";
+
+export const closeAcspBaseAuthenticationMiddleware = (req: Request, res: Response, next: NextFunction) => {
+
+    const authMiddlewareConfig: AuthOptions = {
+        chsWebUrl: CHS_URL,
+        returnUrl: CLOSE_ACSP_BASE_URL
+    };
+    return authMiddleware(authMiddlewareConfig)(req, res, next);
+};

--- a/src/middleware/close-acsp/close_acsp_is_owner_middleware.ts
+++ b/src/middleware/close-acsp/close_acsp_is_owner_middleware.ts
@@ -1,0 +1,13 @@
+import { NextFunction, Request, Response } from "express";
+import { getLoggedInAcspRole } from "../../common/__utils/session";
+import logger from "../../utils/logger";
+
+export const closeAcspIsOwnerMiddleware = (req: Request, res: Response, next: NextFunction) => {
+    const acspRole: string = getLoggedInAcspRole(req.session);
+
+    if (!acspRole || acspRole.toUpperCase() !== "OWNER") {
+        logger.error("User does not have the correct role");
+        throw new Error(`Invalid ACSP role - ${acspRole}`);
+    }
+    next();
+};

--- a/test/mocks/all_middleware_mock.ts
+++ b/test/mocks/all_middleware_mock.ts
@@ -4,6 +4,7 @@ import mockSessionMiddleware from "./session_middleware_mock";
 import mockCompanyAuthenticationMiddleware from "./company_authentication_middleware_mock";
 import mockUKAddressesFromPostcode from "./postcode_lookup_service_mock";
 import updateAcsp from "./update_acsp_authentication_middleware_mock";
+import closeAcsp from "./close_acsp_authentication_middleware_mock";
 import mockCsrfProtectionMiddleware from "./csrf_protection_middleware_mock";
 
 export default {
@@ -13,5 +14,6 @@ export default {
     mockCompanyAuthenticationMiddleware,
     mockUKAddressesFromPostcode,
     mockCsrfProtectionMiddleware,
-    ...updateAcsp
+    ...updateAcsp,
+    ...closeAcsp
 };

--- a/test/mocks/close_acsp_authentication_middleware_mock.ts
+++ b/test/mocks/close_acsp_authentication_middleware_mock.ts
@@ -1,0 +1,24 @@
+import { NextFunction, Request, Response } from "express";
+import { closeAcspAuthMiddleware } from "../../src/middleware/close-acsp/close_acsp_authentication_middleware";
+import { closeAcspBaseAuthenticationMiddleware } from "../../src/middleware/close-acsp/close_acsp_base_authentication_middleware";
+import { closeAcspIsOwnerMiddleware } from "../../src/middleware/close-acsp/close_acsp_is_owner_middleware";
+
+jest.mock("../../src/middleware/close-acsp/close_acsp_authentication_middleware");
+jest.mock("../../src/middleware/close-acsp/close_acsp_base_authentication_middleware");
+jest.mock("../../src/middleware/close-acsp/close_acsp_is_owner_middleware");
+
+// get handle on mocked function
+const mockCloseAcspAuthenticationMiddleware = closeAcspAuthMiddleware as jest.Mock;
+const mockCloseAcspBaseAuthenticationMiddleware = closeAcspBaseAuthenticationMiddleware as jest.Mock;
+const mockCloseAcspIsOwnerMiddleware = closeAcspIsOwnerMiddleware as jest.Mock;
+
+// tell the mock what to return
+mockCloseAcspAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+mockCloseAcspBaseAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+mockCloseAcspIsOwnerMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+
+export default {
+    mockCloseAcspAuthenticationMiddleware,
+    mockCloseAcspBaseAuthenticationMiddleware,
+    mockCloseAcspIsOwnerMiddleware
+};

--- a/test/src/middleware/close-acsp/close_acsp_authentication_middleware.test.ts
+++ b/test/src/middleware/close-acsp/close_acsp_authentication_middleware.test.ts
@@ -1,0 +1,37 @@
+/* eslint-disable import/first */
+
+jest.mock("@companieshouse/web-security-node");
+
+import { acspManageUsersAuthMiddleware, AuthOptions } from "@companieshouse/web-security-node";
+import { Request, Response } from "express";
+import * as sessionUtils from "../../../../src/common/__utils/session";
+import { closeAcspAuthMiddleware } from "../../../../src/middleware/close-acsp/close_acsp_authentication_middleware";
+import { CLOSE_ACSP_BASE_URL } from "../../../../src/types/pageURL";
+
+// get handle on mocked function and create mock function to be returned from calling authMiddleware
+const mockAuthMiddleware = acspManageUsersAuthMiddleware as jest.Mock;
+const mockAuthReturnedFunction = jest.fn();
+
+// when the mocked authMiddleware is called, make it return a mocked function so we can verify it gets called
+mockAuthMiddleware.mockReturnValue(mockAuthReturnedFunction);
+
+const getLoggedInAcspNumberSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getLoggedInAcspNumber");
+
+const req: Request = {} as Request;
+const res: Response = {} as Response;
+const next = jest.fn();
+
+const expectedAuthMiddlewareConfig: AuthOptions = {
+    chsWebUrl: "http://chs.local",
+    returnUrl: CLOSE_ACSP_BASE_URL,
+    acspNumber: "ABC123"
+};
+
+describe("acsp authentication middleware tests", () => {
+    it("should call CH authentication library", () => {
+        getLoggedInAcspNumberSpy.mockReturnValue("ABC123");
+        closeAcspAuthMiddleware(req, res, next);
+        expect(mockAuthMiddleware).toHaveBeenCalledWith(expectedAuthMiddlewareConfig);
+        expect(mockAuthReturnedFunction).toHaveBeenCalledWith(req, res, next);
+    });
+});

--- a/test/src/middleware/close-acsp/close_acsp_base_authentication_middleware.test.ts
+++ b/test/src/middleware/close-acsp/close_acsp_base_authentication_middleware.test.ts
@@ -1,0 +1,32 @@
+/* eslint-disable import/first */
+
+jest.mock("@companieshouse/web-security-node");
+
+import { authMiddleware, AuthOptions } from "@companieshouse/web-security-node";
+import { Request, Response } from "express";
+import { closeAcspBaseAuthenticationMiddleware } from "../../../../src/middleware/close-acsp/close_acsp_base_authentication_middleware";
+import { CLOSE_ACSP_BASE_URL, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../../src/types/pageURL";
+
+// get handle on mocked function and create mock function to be returned from calling authMiddleware
+const mockAuthMiddleware = authMiddleware as jest.Mock;
+const mockAuthReturnedFunction = jest.fn();
+
+// when the mocked authMiddleware is called, make it return a mocked function so we can verify it gets called
+mockAuthMiddleware.mockReturnValue(mockAuthReturnedFunction);
+
+const req: Request = {} as Request;
+const res: Response = {} as Response;
+const next = jest.fn();
+
+const expectedAuthMiddlewareConfig: AuthOptions = {
+    chsWebUrl: "http://chs.local",
+    returnUrl: CLOSE_ACSP_BASE_URL
+};
+
+describe("authentication middleware tests", () => {
+    it("should call CH authentication library", () => {
+        closeAcspBaseAuthenticationMiddleware(req, res, next);
+        expect(mockAuthMiddleware).toHaveBeenCalledWith(expectedAuthMiddlewareConfig);
+        expect(mockAuthReturnedFunction).toHaveBeenCalledWith(req, res, next);
+    });
+});

--- a/test/src/middleware/close-acsp/close_acsp_is_owner_middleware.test.ts
+++ b/test/src/middleware/close-acsp/close_acsp_is_owner_middleware.test.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from "express";
+import * as sessionUtils from "../../../../src/common/__utils/session";
+import { closeAcspIsOwnerMiddleware } from "../../../../src/middleware/close-acsp/close_acsp_is_owner_middleware";
+
+const getLoggedInAcspRoleSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getLoggedInAcspRole");
+
+const req: Request = {} as Request;
+const res: Response = {} as Response;
+const next: NextFunction = jest.fn();
+
+describe("acsp is owner middleware tests", () => {
+    it("should throw an error when role is not 'owner'", () => {
+        getLoggedInAcspRoleSpy.mockReturnValue("admin");
+
+        expect(() => closeAcspIsOwnerMiddleware(req, res, next)).toThrow("Invalid ACSP role - admin");
+    });
+
+    it("should do nothing when role is owner", () => {
+        getLoggedInAcspRoleSpy.mockReturnValue("owner");
+
+        closeAcspIsOwnerMiddleware(req, res, next);
+
+        expect(next).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Ticket [IDVA5-2023](https://companieshouse.atlassian.net/browse/IDVA5-2023)

Adding auth middleware to redirect to the close ACSP service when the user logs in.

Previously when the user logged in from close ACSP they would be redirected to registration after they entered their login details. Now the user stays in the Close journey

[IDVA5-2023]: https://companieshouse.atlassian.net/browse/IDVA5-2023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ