### PR TITLE
updating service name in footer to dynamically match service

### DIFF
--- a/src/views/partials/__footer.njk
+++ b/src/views/partials/__footer.njk
@@ -27,7 +27,7 @@
 }) }}
 <div id="templateName" data-id="{{title}}" hidden></div>
 <script type="application/javascript" nonce={{ nonce | dump | safe }}>
-  window.SERVICE_NAME = "Register as a companies house authorised agent";
+  window.SERVICE_NAME = '{{ serviceName }}' + ' - '
   window.PIWIK_URL = '{{ PIWIK_URL }}'
   window.PIWIK_SITE_ID = '{{ PIWIK_SITE_ID }}'
 </script>


### PR DESCRIPTION
Fix for ticket:
[IDVA5-2234](https://companieshouse.atlassian.net/browse/IDVA5-2234?atlOrigin=eyJpIjoiYTI0YzczZTFlYmFhNGIxYjk3NDU2ZDE2ODRmYmIyMDUiLCJwIjoiaiJ9)

- When a validation error is faced within our services, Matomo records the service name/current page/error message as an event action.
- When a validation error was encountered while using the update acsp service, then Matomo was picking up the hard coded registration service name and prepending this to the event action.
- This bug fix now dynamically obtains the current service in use, using the service name variable from the variables middleware when a validation error is encountered.

Before fix:
![Screenshot 2025-05-28 at 16 07 45](https://github.com/user-attachments/assets/2e6d3276-d95f-4970-8c70-a22e2fa88760)

After fix:
![Screenshot 2025-05-29 at 09 32 21](https://github.com/user-attachments/assets/9e145ff7-a59d-4969-9226-5188c751cd8b)


[IDVA5-2234]: https://companieshouse.atlassian.net/browse/IDVA5-2234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ