### PR TITLE
Saving data to mongo for close acsp

### DIFF
--- a/src/controllers/features/close-acsp/confirmYouWantToCloseController.ts
+++ b/src/controllers/features/close-acsp/confirmYouWantToCloseController.ts
@@ -4,6 +4,7 @@ import { CLOSE_ACSP_BASE_URL, CLOSE_CONFIRMATION_ACSP_CLOSED, CLOSE_CONFIRM_YOU_
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspCloseService } from "../../../services/close-acsp/acspCloseService";
+import { ACSP_DETAILS } from "../../../common/__utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -27,6 +28,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         const session: Session = req.session as any as Session;
         const acspCloseService = new AcspCloseService();
         await acspCloseService.createTransaction(session);
+        await acspCloseService.saveCloseDetails(session, session.getExtraData(ACSP_DETAILS)!);
         res.redirect(addLangToUrl(CLOSE_ACSP_BASE_URL + CLOSE_CONFIRMATION_ACSP_CLOSED, lang));
     } catch (error) {
         next(error);

--- a/src/controllers/features/close-acsp/confirmationAuthorisedAgentClosedController.ts
+++ b/src/controllers/features/close-acsp/confirmationAuthorisedAgentClosedController.ts
@@ -4,7 +4,7 @@ import { trimAndLowercaseString } from "../../../services/common";
 import * as config from "../../../config";
 import { CLOSE_ACSP_BASE_URL, CLOSE_CONFIRMATION_ACSP_CLOSED, STRIKE_OFF_YOUR_COMPANY, TELL_HMRC_YOUVE_STOPPED_TRADING } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { ACSP_DETAILS } from "../../../common/__utils/constants";
+import { ACSP_DETAILS, CLOSE_SUBMISSION_ID } from "../../../common/__utils/constants";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -23,7 +23,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             loginEmail,
             correspondenceEmail,
             showBothEmails,
-            transactionId: "TRANSACTION_ID",
+            transactionId: session.getExtraData(CLOSE_SUBMISSION_ID)!,
             strikeOffYourLtdCompanyLink: STRIKE_OFF_YOUR_COMPANY,
             tellHmrcIfYouveStoppedTradingLink: TELL_HMRC_YOUVE_STOPPED_TRADING
         });

--- a/src/services/close-acsp/acspCloseService.ts
+++ b/src/services/close-acsp/acspCloseService.ts
@@ -2,6 +2,9 @@ import { Session } from "@companieshouse/node-session-handler";
 import { CLOSE_DESCRIPTION, CLOSE_REFERENCE, CLOSE_SUBMISSION_ID } from "../../common/__utils/constants";
 import { postTransaction } from "../transactions/transaction_service";
 import logger from "../../utils/logger";
+import { postAcspRegistration } from "../../services/acspRegistrationService";
+import { AcspData } from "@companieshouse/api-sdk-node/dist/services/acsp";
+import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 
 export class AcspCloseService {
     async createTransaction (session: Session): Promise<void> {
@@ -15,6 +18,22 @@ export class AcspCloseService {
                 logger.error(`Error while creating transaction for close ACSP`);
                 return Promise.reject(error);
             }
+        }
+    }
+
+    async saveCloseDetails (session: Session, acspDetails: AcspFullProfile): Promise<void> {
+        try {
+            const transactionId: string = session.getExtraData(CLOSE_SUBMISSION_ID)!;
+
+            const acspData: AcspData = {
+                acspType: "CLOSE_ACSP",
+                acspId: acspDetails.number
+            };
+
+            await postAcspRegistration(session, transactionId, acspData);
+        } catch (error) {
+            logger.error("Error while saving close details for ACSP");
+            return Promise.reject(error);
         }
     }
 }

--- a/test/src/controllers/closeAcsp/confirmYouWantToCloseController.test.ts
+++ b/test/src/controllers/closeAcsp/confirmYouWantToCloseController.test.ts
@@ -6,21 +6,17 @@ import supertest from "supertest";
 import app from "../../../../src/app";
 import { CLOSE_ACSP_BASE_URL, CLOSE_CONFIRM_YOU_WANT_TO_CLOSE, CLOSE_CONFIRMATION_ACSP_CLOSED } from "../../../../src/types/pageURL";
 import * as localise from "../../../../src/utils/localise";
-import * as controller from "../../../../src/controllers/features/close-acsp/confirmYouWantToCloseController";
 import { postTransaction } from "../../../../src/services/transactions/transaction_service";
-jest.mock("../../../../src/services/transactions/transaction_service");
+import { postAcspRegistration } from "../../../../src/services/acspRegistrationService";
 
 const router = supertest(app);
-const mockPostTransaction = postTransaction as jest.Mock;
-let req: any;
-let res: any;
-let next: jest.Mock;
 
-beforeEach(() => {
-    req = { query: {}, session: { getExtraData: jest.fn() } };
-    res = { render: jest.fn() };
-    next = jest.fn();
-});
+jest.mock("@companieshouse/api-sdk-node");
+jest.mock("../../../../src/services/transactions/transaction_service");
+jest.mock("../../../../src/services/acspRegistrationService");
+
+const mockPostTransaction = postTransaction as jest.Mock;
+const mockPostRegistration = postAcspRegistration as jest.Mock;
 
 describe("GET " + CLOSE_ACSP_BASE_URL + CLOSE_CONFIRM_YOU_WANT_TO_CLOSE, () => {
     it("should return status 200 and render the page", async () => {
@@ -38,19 +34,12 @@ describe("GET " + CLOSE_ACSP_BASE_URL + CLOSE_CONFIRM_YOU_WANT_TO_CLOSE, () => {
         expect(res.status).toBe(500);
         expect(res.text).toContain("Sorry we are experiencing technical difficulties");
     });
-
-    it("should call next with error if an exception is caught", async () => {
-        jest.spyOn(localise, "selectLang").mockImplementationOnce(() => {
-            throw new Error("Unit test error");
-        });
-        await controller.get(req, res, next);
-        expect(next).toHaveBeenCalledWith(expect.any(Error));
-    });
 });
 
 describe("POST " + CLOSE_ACSP_BASE_URL + CLOSE_CONFIRM_YOU_WANT_TO_CLOSE, () => {
     it("should return status 302 after redirect", async () => {
         await mockPostTransaction.mockResolvedValueOnce({});
+        await mockPostRegistration.mockResolvedValueOnce({});
         const res = await router.post(CLOSE_ACSP_BASE_URL + CLOSE_CONFIRM_YOU_WANT_TO_CLOSE);
         expect(res.status).toBe(302);
         expect(res.header.location).toBe(CLOSE_ACSP_BASE_URL + CLOSE_CONFIRMATION_ACSP_CLOSED + "?lang=en");
@@ -58,19 +47,9 @@ describe("POST " + CLOSE_ACSP_BASE_URL + CLOSE_CONFIRM_YOU_WANT_TO_CLOSE, () => 
     });
 
     it("should return status 500 when an error occurs", async () => {
-        jest.spyOn(localise, "selectLang").mockImplementationOnce(() => {
-            throw new Error("Test error");
-        });
-        const res = await router.post(CLOSE_ACSP_BASE_URL);
+        await mockPostRegistration.mockRejectedValueOnce(new Error("Test error"));
+        const res = await router.post(CLOSE_ACSP_BASE_URL + CLOSE_CONFIRM_YOU_WANT_TO_CLOSE);
         expect(res.status).toBe(500);
         expect(res.text).toContain("Sorry we are experiencing technical difficulties");
-    });
-
-    it("should call next with error if an exception is caught", async () => {
-        jest.spyOn(localise, "selectLang").mockImplementationOnce(() => {
-            throw new Error("test error");
-        });
-        await controller.post(req, res, next);
-        expect(next).toHaveBeenCalledWith(expect.any(Error));
     });
 });

--- a/test/src/services/close-acsp/acspCloseService.test.ts
+++ b/test/src/services/close-acsp/acspCloseService.test.ts
@@ -6,11 +6,16 @@ import { Session } from "@companieshouse/node-session-handler";
 import { AcspCloseService } from "../../../../src/services/close-acsp/acspCloseService";
 import { postTransaction } from "../../../../src/services/transactions/transaction_service";
 import { CLOSE_SUBMISSION_ID } from "../../../../src/common/__utils/constants";
+import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
+import { AcspData } from "@companieshouse/api-sdk-node/dist/services/acsp";
+import { postAcspRegistration } from "../../../../src/services/acspRegistrationService";
 
 jest.mock("@companieshouse/api-sdk-node");
 jest.mock("../../../../src/services/transactions/transaction_service");
+jest.mock("../../../../src/services/acspRegistrationService");
 
 const mockPostTransaction = postTransaction as jest.Mock;
+const mockPostAcspRegistration = postAcspRegistration as jest.Mock;
 let req: MockRequest<Request>;
 const acspCloseService = new AcspCloseService();
 
@@ -25,26 +30,67 @@ describe("AcspCloseService tests", () => {
         req.session = session;
     });
 
-    it("should return start a new transaction and save the transaction ID to session", async () => {
-        mockPostTransaction.mockResolvedValueOnce(validTransaction);
-        const session: Session = req.session as any as Session;
-        await acspCloseService.createTransaction(session);
+    describe("createTransaction tests", () => {
+        it("should return start a new transaction and save the transaction ID to session", async () => {
+            mockPostTransaction.mockResolvedValueOnce(validTransaction);
+            const session: Session = req.session as any as Session;
+            await acspCloseService.createTransaction(session);
 
-        expect(session.getExtraData(CLOSE_SUBMISSION_ID)).toEqual(transactionId);
+            expect(session.getExtraData(CLOSE_SUBMISSION_ID)).toEqual(transactionId);
+        });
+
+        it("should not start a new transaction if one already exists", async () => {
+            const session: Session = req.session as any as Session;
+            session.setExtraData(CLOSE_SUBMISSION_ID, transactionId);
+            await acspCloseService.createTransaction(session);
+
+            expect(mockPostTransaction).not.toHaveBeenCalled();
+        });
+
+        it("should throw an error if postTransaction fails", () => {
+            mockPostTransaction.mockRejectedValueOnce(new Error("Failed to post transaction"));
+            const session: Session = req.session as any as Session;
+
+            expect(acspCloseService.createTransaction(session)).rejects.toThrow();
+        });
     });
 
-    it("should not start a new transaction if one already exists", async () => {
-        const session: Session = req.session as any as Session;
-        session.setExtraData(CLOSE_SUBMISSION_ID, transactionId);
-        await acspCloseService.createTransaction(session);
+    describe("saveCloseDetails tests", () => {
+        let session: Session;
+        let acspDetails: AcspFullProfile;
 
-        expect(mockPostTransaction).not.toHaveBeenCalled();
-    });
+        beforeEach(() => {
+            session = req.session as any as Session;
+            acspDetails = {
+                number: "AP123456",
+                status: "",
+                type: "",
+                notifiedFrom: new Date(),
+                registeredOfficeAddress: { addressLine1: "Old Address" },
+                serviceAddress: { addressLine1: "Old Service Address" },
+                email: "old@example.com",
+                name: "Old Name",
+                amlDetails: [{ supervisoryBody: "association-of-chartered-certified-accountants-acca", membershipDetails: "123456" }]
+            } as AcspFullProfile;
+        });
 
-    it("should throw an error if postTransaction fails", () => {
-        mockPostTransaction.mockRejectedValueOnce(new Error("Failed to post transaction"));
-        const session: Session = req.session as any as Session;
+        it("should save the ACSP & acsp type then call postAcspRegistration", async () => {
+            session.setExtraData(CLOSE_SUBMISSION_ID, transactionId);
 
-        expect(acspCloseService.createTransaction(session)).rejects.toThrow();
+            await acspCloseService.saveCloseDetails(session, acspDetails);
+
+            const expectedAcspData: AcspData = {
+                acspType: "CLOSE_ACSP",
+                acspId: acspDetails.number
+            };
+
+            expect(mockPostAcspRegistration).toHaveBeenCalledWith(session, transactionId, expectedAcspData);
+        });
+
+        it("should handle errors and reject the promise", async () => {
+            session.setExtraData(CLOSE_SUBMISSION_ID, transactionId);
+            mockPostAcspRegistration.mockRejectedValueOnce(new Error("Failed to post registration"));
+            await expect(acspCloseService.saveCloseDetails(session, acspDetails)).rejects.toThrow("Failed to post registration");
+        });
     });
 });


### PR DESCRIPTION
Ticket [IDVA5-1816](https://companieshouse.atlassian.net/browse/IDVA5-1816)

Saving the ACSP request type and ACSP number to mongo for close ACSP
Also displaying the transaction id on the confirmation screen

[IDVA5-1816]: https://companieshouse.atlassian.net/browse/IDVA5-1816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ