### PR TITLE
Remove duplicate pageUrl and update to use correct one for AML body page

### DIFF
--- a/src/controllers/features/update-acsp/amlMembershipNumberController.ts
+++ b/src/controllers/features/update-acsp/amlMembershipNumberController.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import { AML_MEMBERSHIP_NUMBER, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_AML_MEMBERSHIP_NUMBER, UPDATE_DATE_OF_THE_CHANGE, UPDATE_SELECT_AML_SUPERVISOR, UPDATE_YOUR_ANSWERS } from "../../../types/pageURL";
+import { AML_MEMBERSHIP_NUMBER, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_ADD_AML_SUPERVISOR, UPDATE_AML_MEMBERSHIP_NUMBER, UPDATE_DATE_OF_THE_CHANGE, UPDATE_YOUR_ANSWERS } from "../../../types/pageURL";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import * as config from "../../../config";
 import { Session } from "@companieshouse/node-session-handler";
@@ -32,7 +32,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
         res.render(config.AML_MEMBERSHIP_NUMBER, {
             ...getLocaleInfo(locales, lang),
-            previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_SELECT_AML_SUPERVISOR, lang),
+            previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_ADD_AML_SUPERVISOR, lang),
             currentUrl,
             payload,
             amlSupervisoryBodies: [newAMLBody],

--- a/src/services/update-acsp/amlMembershipNumberService.ts
+++ b/src/services/update-acsp/amlMembershipNumberService.ts
@@ -2,7 +2,7 @@ import { formatValidationError, getPageProperties } from "../../validation/valid
 import { addLangToUrl, getLocaleInfo } from "../../utils/localise";
 import { Request, Response } from "express";
 import * as config from "../../config";
-import { UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_SELECT_AML_SUPERVISOR, UPDATE_YOUR_ANSWERS } from "../../types/pageURL";
+import { UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_ADD_AML_SUPERVISOR, UPDATE_YOUR_ANSWERS } from "../../types/pageURL";
 import { ValidationError } from "express-validator";
 import { AmlSupervisoryBody } from "@companieshouse/api-sdk-node/dist/services/acsp";
 import { AcspFullProfile } from "../../model/AcspFullProfile";
@@ -25,7 +25,7 @@ export class AmlMembershipNumberService {
         return new Promise((resolve) => {
             const pageProperties = getPageProperties(formatValidationError(validationError, lang));
             res.status(400).render(config.AML_MEMBERSHIP_NUMBER, {
-                previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_SELECT_AML_SUPERVISOR, lang),
+                previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_ADD_AML_SUPERVISOR, lang),
                 ...getLocaleInfo(locales, lang),
                 currentUrl,
                 pageProperties: pageProperties,

--- a/src/types/pageURL.ts
+++ b/src/types/pageURL.ts
@@ -218,8 +218,6 @@ export const UPDATE_AML_MEMBERSHIP_NUMBER = "/aml-membership-number";
 
 export const REMOVE_AML_SUPERVISOR = "/remove-an-aml";
 
-export const UPDATE_SELECT_AML_SUPERVISOR = "/select-aml-supervisor";
-
 export const UPDATE_CANCEL_ALL_UPDATES = "/cancel-all-updates";
 
 export const UPDATE_DATE_OF_THE_CHANGE = "/when-did-this-change";


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2244

**Bug:** back link on AML Membership Number page was redirecting to "/select-aml-supervisor" as there was a duplicate pageUrl which was used for the previousPage value. After we updated this url it was displaying 'Page not found'.

**Fix:** I've removed the duplicate pageUrl and replaced it with "/which-aml-supervisory-body-are-you-registered-with" which was updated to the correct url in both the controller (get method) and service (post method to render if errors are displayed).