### PR TITLE
Moving aml index and body session variables being cleared

### DIFF
--- a/src/controllers/features/update-acsp/updateYourDetailsController.ts
+++ b/src/controllers/features/update-acsp/updateYourDetailsController.ts
@@ -31,7 +31,9 @@ import {
     ACSP_UPDATE_CHANGE_DATE,
     ADD_AML_BODY_UPDATE,
     AML_REMOVED_BODY_DETAILS,
-    NEW_AML_BODY
+    NEW_AML_BODY,
+    AML_REMOVAL_INDEX,
+    AML_REMOVAL_BODY
 }
     from "../../../common/__utils/constants";
 import { AMLSupervioryBodiesFormatted } from "../../../model/AMLSupervisoryBodiesFormatted";
@@ -69,6 +71,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         session.deleteExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL);
         session.deleteExtraData(ADD_AML_BODY_UPDATE);
         session.deleteExtraData(NEW_AML_BODY);
+        session.deleteExtraData(AML_REMOVAL_INDEX);
+        session.deleteExtraData(AML_REMOVAL_BODY);
 
         // Before passing to view, convert dateOfChange to Date object from ISO string (to allow pre-1960 dates)
         acspUpdatedFullProfile.amlDetails = acspUpdatedFullProfile.amlDetails.map(amlDetail => ({

--- a/src/controllers/features/update-acsp/yourUpdatesController.ts
+++ b/src/controllers/features/update-acsp/yourUpdatesController.ts
@@ -114,8 +114,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_APPLICATION_CONFIRMATION, lang));
             } else {
                 session.deleteExtraData(ACSP_UPDATE_PREVIOUS_PAGE_URL);
-                session.deleteExtraData(AML_REMOVAL_INDEX);
-                session.deleteExtraData(AML_REMOVAL_BODY);
                 res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang));
             }
         }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2250

**Bug:** after removing AML body and entering date of change, if user clicks 'back' to go from Your Updates to Update Your Details, the next update they make has the previous date of change pre-populated and when they continue to Your Updates, no updates were showing. A technical error screen would show if user clicked 'back' at that point.

**Fix:** Instead of clearing session variables for AML_REMOVAL_INDEX and AML_REMOVAL_BODY in post method of Your Updates, I clear them in get method of Update Your Details so if users uses back navigation they are still cleared.

