### PR TITLE
IDVA5-2184 Update ACSP - Welsh toggle is not holding up to Authorised agent dashboard when clicking on Cancel All Updates button 

### DIFF
--- a/src/controllers/features/update-acsp/applicationConfirmationController.ts
+++ b/src/controllers/features/update-acsp/applicationConfirmationController.ts
@@ -19,7 +19,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         res.render(config.UPDATE_ACSP_DETAILS_APPLICATION_CONFIRMATION, {
             ...getLocaleInfo(locales, lang),
             currentUrl,
-            authorisedAgentAccountLink: AUTHORISED_AGENT,
+            authorisedAgentAccountLink: AUTHORISED_AGENT + selectLang(req.query.lang),
             transactionId
         });
     } catch (err) {

--- a/src/controllers/features/update-acsp/cancelAllUpdatesController.ts
+++ b/src/controllers/features/update-acsp/cancelAllUpdatesController.ts
@@ -36,7 +36,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         session.deleteExtraData(ACSP_UPDATE_CHANGE_DATE.REGISTERED_OFFICE_ADDRESS);
         session.deleteExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS);
 
-        res.redirect(AUTHORISED_AGENT);
+        res.redirect(addLangToUrl(AUTHORISED_AGENT, selectLang(req.query.lang)));
     } catch (err) {
         next(err);
     }

--- a/test/src/controllers/updateAcspDetails/cancelAllUpdatesController.test.ts
+++ b/test/src/controllers/updateAcspDetails/cancelAllUpdatesController.test.ts
@@ -76,7 +76,7 @@ describe("POST " + UPDATE_ACSP_DETAILS_BASE_URL, () => {
         const res = await router.post(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CANCEL_ALL_UPDATES);
         expect(mocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
         expect(res.status).toBe(302);
-        expect(res.header.location).toBe(AUTHORISED_AGENT);
+        expect(res.header.location).toBe(AUTHORISED_AGENT + "?lang=en");
     });
 });
 


### PR DESCRIPTION
There were a redirect and link without the lang parameter, which was causing the issue
-- Added the lang parameter in the controller.
-- Added the lang parameter in the njk through the respective variable.
-- Modified the test cases.