### PR TITLE
Adding matomo goal to start page of close acsp service

### DIFF
--- a/src/controllers/features/close-acsp/indexController.ts
+++ b/src/controllers/features/close-acsp/indexController.ts
@@ -12,6 +12,7 @@ import { getLoggedInAcspNumber } from "../../../common/__utils/session";
 import { Session } from "@companieshouse/node-session-handler";
 import { ACSP_DETAILS } from "../../../common/__utils/constants";
 import { getBusinessName } from "../../../services/common";
+import { PIWIK_CLOSE_ACSP_START_GOAL_ID } from "../../../utils/properties";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -25,6 +26,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         res.render(config.CLOSE_ACSP_HOME, {
             ...getLocaleInfo(locales, lang),
             currentUrl,
+            PIWIK_CLOSE_ACSP_START_GOAL_ID,
             businessName: getBusinessName(acspDetails.name),
             manageUsersLink: addLangToUrl(MANAGE_USERS, lang)
         });

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -88,6 +88,10 @@ export const PIWIK_REGISTRATION_CHECK_YOUR_ANSWERS_ID = getEnvironmentValue("PIW
 
 export const PIWIK_UPDATE_ACSP_START_GOAL_ID = getEnvironmentValue("PIWIK_UPDATE_ACSP_START_GOAL_ID", "10");
 
+// Matomo event goals - Close ACSP service
+
+export const PIWIK_CLOSE_ACSP_START_GOAL_ID = getEnvironmentValue("PIWIK_CLOSE_ACSP_START_GOAL_ID", "11");
+
 // Feature Flags
 
 export const FEATURE_FLAG_VERIFY_SOLE_TRADER_ONLY = getEnvironmentValue("FEATURE_FLAG_VERIFY_SOLE_TRADER_ONLY", "false");

--- a/src/views/features/close-acsp/index/home.njk
+++ b/src/views/features/close-acsp/index/home.njk
@@ -13,20 +13,37 @@
       <h1 class="govuk-heading-l">
         {{ i18n.startPageTitleCloseAcsp }}
       </h1>
-      <p> {{i18n.ifYouCloseAcsp  | replace("{BUSINESS_NAME}", businessName) }}
-      </p>
+      <p class="govuk-body">{{i18n.ifYouCloseAcsp  | replace("{BUSINESS_NAME}", businessName) }}</p>
       <h2 class="govuk-heading-m">{{ i18n.beforeYouContinueHeading}}</h2>
-      <p>{{ i18n.beforeYouContinueText1 }}
-        <a href="{{ manageUsersLink }}">{{ i18n.beforeYouContinueManageUsersLink }}</a>.
+      <p class="govuk-body">{{ i18n.beforeYouContinueText1 }}
+        <a class="govuk-link" href="{{ manageUsersLink }}">{{ i18n.beforeYouContinueManageUsersLink }}</a>.
       </p>
-      <p>{{ i18n.beforeYouContinueText2}} </p>
+      <p class="govuk-body">{{ i18n.beforeYouContinueText2}}</p>
 
       <div class="govuk-button-group">
         {{ govukButton({
-          text: i18n.Continue
+          text: i18n.Continue,
+          id: "continue-button",
+          isStartButton: true
         }) }}
-
         <a class="govuk-link" href="{{ authorisedAgentDashboardUrl }}">{{ i18n.Cancel}}</a>
-</div>
+      </div>
   </form>
+
+  <script nonce={{ nonce | dump | safe }}>
+    function closeAcspStartGoalEventListener () {
+      document.getElementById("continue-button").addEventListener("click", () => {
+      _paq.push(['trackGoal', "{{ PIWIK_CLOSE_ACSP_START_GOAL_ID }}"]);
+    });
+    }
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", function (e) {
+       closeAcspStartGoalEventListener()
+      });
+    } else {
+      closeAcspStartGoalEventListener()
+    }
+  </script>
+
 {% endblock %}


### PR DESCRIPTION
Changes for ticket:
[IDVA5-2217](https://companieshouse.atlassian.net/browse/IDVA5-2217)

- Adding matomo goal for close acsp service, triggers when user clicks the continue button on the index page

[IDVA5-2217]: https://companieshouse.atlassian.net/browse/IDVA5-2217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ