### PR TITLE
Navbar styling changes

### DIFF
--- a/assets/src/scss/__global.scss
+++ b/assets/src/scss/__global.scss
@@ -105,16 +105,21 @@ $govuk-global-styles: true;
   border-bottom: 10px solid #005ea5;
 }
 
+@media (min-width: 769px) {
+  #global-nav nav #navigation {
+      border-bottom: 1px solid #b1b4b6;
+      padding-bottom: 10px !important;
+  }
+}
+
 ul#navigation {
   font-size: 0.9em;
   margin-top: 15px;
   margin-bottom: 15px;
   text-align: right;
-  display: inline-block;
-  float: right;
 }
 ul#navigation li {
-  display: inline;
+  display: contents !important;
   font-size: 16px;
   overflow-wrap: break-word;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/88cef5b5-bc2d-4974-8f6c-480f575bf72d)

https://companieshouse.atlassian.net/browse/IDVA5-2179

Added these stylings to align all items on navbar into a single line and ensure the bottom is still visible. Already merged into CDN and tested in cidev.