### PR TITLE
Adding company name to close acsp transaction

### DIFF
--- a/src/services/close-acsp/acspCloseService.ts
+++ b/src/services/close-acsp/acspCloseService.ts
@@ -1,5 +1,5 @@
 import { Session } from "@companieshouse/node-session-handler";
-import { CLOSE_DESCRIPTION, CLOSE_REFERENCE, CLOSE_SUBMISSION_ID } from "../../common/__utils/constants";
+import { ACSP_DETAILS, CLOSE_DESCRIPTION, CLOSE_REFERENCE, CLOSE_SUBMISSION_ID } from "../../common/__utils/constants";
 import { postTransaction } from "../transactions/transaction_service";
 import logger from "../../utils/logger";
 import { postAcspRegistration } from "../../services/acspRegistrationService";
@@ -11,7 +11,8 @@ export class AcspCloseService {
         const existingTransactionId = session.getExtraData(CLOSE_SUBMISSION_ID);
         if (existingTransactionId === undefined || JSON.stringify(existingTransactionId) === "{}") {
             try {
-                const transaction = await postTransaction(session, CLOSE_DESCRIPTION, CLOSE_REFERENCE);
+                const acspDetails: AcspFullProfile = session.getExtraData(ACSP_DETAILS)!;
+                const transaction = await postTransaction(session, CLOSE_DESCRIPTION, CLOSE_REFERENCE, acspDetails.name);
                 session.setExtraData(CLOSE_SUBMISSION_ID, transaction.id);
                 return Promise.resolve();
             } catch (error) {

--- a/test/src/services/close-acsp/acspCloseService.test.ts
+++ b/test/src/services/close-acsp/acspCloseService.test.ts
@@ -5,10 +5,11 @@ import { getSessionRequestWithPermission } from "../../../mocks/session.mock";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspCloseService } from "../../../../src/services/close-acsp/acspCloseService";
 import { postTransaction } from "../../../../src/services/transactions/transaction_service";
-import { CLOSE_SUBMISSION_ID } from "../../../../src/common/__utils/constants";
+import { ACSP_DETAILS, CLOSE_SUBMISSION_ID } from "../../../../src/common/__utils/constants";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { AcspData } from "@companieshouse/api-sdk-node/dist/services/acsp";
 import { postAcspRegistration } from "../../../../src/services/acspRegistrationService";
+import { dummyFullProfile } from "../../../mocks/acsp_profile.mock";
 
 jest.mock("@companieshouse/api-sdk-node");
 jest.mock("../../../../src/services/transactions/transaction_service");
@@ -34,6 +35,8 @@ describe("AcspCloseService tests", () => {
         it("should return start a new transaction and save the transaction ID to session", async () => {
             mockPostTransaction.mockResolvedValueOnce(validTransaction);
             const session: Session = req.session as any as Session;
+            session.setExtraData(ACSP_DETAILS, dummyFullProfile);
+
             await acspCloseService.createTransaction(session);
 
             expect(session.getExtraData(CLOSE_SUBMISSION_ID)).toEqual(transactionId);


### PR DESCRIPTION
Fix for ticket:
[IDVA5-1507](https://companieshouse.atlassian.net/browse/IDVA5-1507)

- Saving business name to Close ACSP transaction to allow close acsp email template to populate the company name field

[IDVA5-1507]: https://companieshouse.atlassian.net/browse/IDVA5-1507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ