### PR TITLE
Adding ACSP status check before submitting

### DIFF
--- a/src/common/__utils/constants.ts
+++ b/src/common/__utils/constants.ts
@@ -17,6 +17,7 @@ export const PAYEMNT_REFERENCE: string = "Register_ACSP_";
 export const CLOSED:string = "closed";
 export const REJECTED:string = "rejected";
 export const ACCEPTED:string = "accepted";
+export const CEASED:string = "ceased";
 export const IN_PROGRESS:string = "in progress";
 export const APPLICATION_ID:string = "application id";
 export const RESUME_APPLICATION_ID:string = "resume application id";

--- a/src/controllers/features/close-acsp/confirmYouWantToCloseController.ts
+++ b/src/controllers/features/close-acsp/confirmYouWantToCloseController.ts
@@ -2,10 +2,13 @@ import { Request, Response, NextFunction } from "express";
 import * as config from "../../../config";
 import { CLOSE_ACSP_BASE_URL, CLOSE_CONFIRMATION_ACSP_CLOSED, CLOSE_CONFIRM_YOU_WANT_TO_CLOSE, CLOSE_WHAT_WILL_HAPPEN } from "../../../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
-import { ACSP_DETAILS, CLOSE_DESCRIPTION, CLOSE_REFERENCE, CLOSE_SUBMISSION_ID } from "../../../common/__utils/constants";
+import { ACSP_DETAILS, CEASED, CLOSE_DESCRIPTION, CLOSE_REFERENCE, CLOSE_SUBMISSION_ID } from "../../../common/__utils/constants";
 import { closeTransaction } from "../../../services/transactions/transaction_service";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspCloseService } from "../../../services/close-acsp/acspCloseService";
+import { getLoggedInAcspNumber } from "../../../common/__utils/session";
+import { getAcspFullProfile } from "../../../services/acspProfileService";
+import { AcspCeasedError } from "../../../errors/acspCeasedError";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -27,6 +30,16 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const lang = selectLang(req.query.lang);
         const session: Session = req.session as any as Session;
+
+        // Check the ACSP's status and if they are ceased throw an error
+        const acspNumber: string = getLoggedInAcspNumber(req.session);
+        const acspDetails = await getAcspFullProfile(acspNumber);
+        session.setExtraData(ACSP_DETAILS, acspDetails);
+
+        if (acspDetails.status === CEASED) {
+            throw new AcspCeasedError("ACSP is ceased. Cannot proceed with account closure.");
+        }
+
         const acspCloseService = new AcspCloseService();
         await acspCloseService.createTransaction(session);
         await acspCloseService.saveCloseDetails(session, session.getExtraData(ACSP_DETAILS)!);

--- a/src/errors/acspCeasedError.ts
+++ b/src/errors/acspCeasedError.ts
@@ -1,0 +1,1 @@
+export class AcspCeasedError extends Error {}

--- a/src/middleware/close-acsp/close_acsp_get_acsp_profile_middleware.ts
+++ b/src/middleware/close-acsp/close_acsp_get_acsp_profile_middleware.ts
@@ -2,8 +2,9 @@ import { NextFunction, Request, Response } from "express";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { getLoggedInAcspNumber } from "../../common/__utils/session";
 import { getAcspFullProfile } from "../../services/acspProfileService";
-import { ACSP_DETAILS } from "../../common/__utils/constants";
+import { ACSP_DETAILS, CEASED } from "../../common/__utils/constants";
 import { Session } from "@companieshouse/node-session-handler";
+import { AcspCeasedError } from "../../errors/acspCeasedError";
 
 export const getAcspProfileMiddleware = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -14,6 +15,9 @@ export const getAcspProfileMiddleware = async (req: Request, res: Response, next
         if (!acspDetails) {
             acspDetails = await getAcspFullProfile(acspNumber);
             session.setExtraData(ACSP_DETAILS, acspDetails);
+            if (acspDetails.status === CEASED) {
+                throw new AcspCeasedError("ACSP is ceased. Cannot proceed with account closure.");
+            }
         }
         next();
     } catch (error) {

--- a/src/middleware/update-acsp/update_acsp_get_acsp_profile_middleware.ts
+++ b/src/middleware/update-acsp/update_acsp_get_acsp_profile_middleware.ts
@@ -2,8 +2,9 @@ import { NextFunction, Request, Response } from "express";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { getLoggedInAcspNumber } from "../../common/__utils/session";
 import { getAcspFullProfile } from "../../services/acspProfileService";
-import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../common/__utils/constants";
+import { ACSP_DETAILS, ACSP_DETAILS_UPDATED, CEASED } from "../../common/__utils/constants";
 import { Session } from "@companieshouse/node-session-handler";
+import { AcspCeasedError } from "../../errors/acspCeasedError";
 
 export const getUpdateAcspProfileMiddleware = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -14,6 +15,9 @@ export const getUpdateAcspProfileMiddleware = async (req: Request, res: Response
         if (!acspDetails) {
             acspDetails = await getAcspFullProfile(acspNumber);
             session.setExtraData(ACSP_DETAILS, acspDetails);
+            if (acspDetails.status === CEASED) {
+                throw new AcspCeasedError("ACSP is ceased. Cannot proceed with updates.");
+            }
         }
 
         const acspDetailsUpdated: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;

--- a/test/src/controllers/closeAcsp/confirmYouWantToCloseController.test.ts
+++ b/test/src/controllers/closeAcsp/confirmYouWantToCloseController.test.ts
@@ -8,15 +8,18 @@ import { CLOSE_ACSP_BASE_URL, CLOSE_CONFIRM_YOU_WANT_TO_CLOSE, CLOSE_CONFIRMATIO
 import * as localise from "../../../../src/utils/localise";
 import { postTransaction } from "../../../../src/services/transactions/transaction_service";
 import { postAcspRegistration } from "../../../../src/services/acspRegistrationService";
+import { getAcspFullProfile } from "../../../../src/services/acspProfileService";
 
 const router = supertest(app);
 
 jest.mock("@companieshouse/api-sdk-node");
 jest.mock("../../../../src/services/transactions/transaction_service");
 jest.mock("../../../../src/services/acspRegistrationService");
+jest.mock("../../../../src/services/acspProfileService");
 
 const mockPostTransaction = postTransaction as jest.Mock;
 const mockPostRegistration = postAcspRegistration as jest.Mock;
+const mockGetAcspFullProfile = getAcspFullProfile as jest.Mock;
 
 describe("GET " + CLOSE_ACSP_BASE_URL + CLOSE_CONFIRM_YOU_WANT_TO_CLOSE, () => {
     it("should return status 200 and render the page", async () => {
@@ -40,10 +43,20 @@ describe("POST " + CLOSE_ACSP_BASE_URL + CLOSE_CONFIRM_YOU_WANT_TO_CLOSE, () => 
     it("should return status 302 after redirect", async () => {
         await mockPostTransaction.mockResolvedValueOnce({});
         await mockPostRegistration.mockResolvedValueOnce({});
+        await mockGetAcspFullProfile.mockResolvedValueOnce({ status: "active" });
         const res = await router.post(CLOSE_ACSP_BASE_URL + CLOSE_CONFIRM_YOU_WANT_TO_CLOSE);
         expect(res.status).toBe(302);
         expect(res.header.location).toBe(CLOSE_ACSP_BASE_URL + CLOSE_CONFIRMATION_ACSP_CLOSED + "?lang=en");
         expect(mocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
+    });
+
+    it("should return status 500 when an status is CEASED", async () => {
+        await mockPostTransaction.mockResolvedValueOnce({});
+        await mockPostRegistration.mockResolvedValueOnce({});
+        await mockGetAcspFullProfile.mockResolvedValueOnce({ status: "ceased" });
+        const res = await router.post(CLOSE_ACSP_BASE_URL + CLOSE_CONFIRM_YOU_WANT_TO_CLOSE);
+        expect(res.status).toBe(500);
+        expect(res.text).toContain("Sorry we are experiencing technical difficulties");
     });
 
     it("should return status 500 when an error occurs", async () => {

--- a/test/src/middleware/update-acsp/update_acsp_get_acsp_profile_middleware.test.ts
+++ b/test/src/middleware/update-acsp/update_acsp_get_acsp_profile_middleware.test.ts
@@ -5,6 +5,7 @@ import { ACSP_DETAILS } from "../../../../src/common/__utils/constants";
 import { getAcspFullProfile } from "../../../../src/services/acspProfileService";
 import { createRequest, MockRequest } from "node-mocks-http";
 import { Session } from "@companieshouse/node-session-handler";
+import { AcspCeasedError } from "../../../../src/errors/acspCeasedError";
 
 jest.mock("../../../../src/services/acspProfileService");
 
@@ -33,11 +34,20 @@ describe("getUpdateAcspProfileMiddleware", () => {
     });
 
     it("should fetch ACSP details when not in session", async () => {
-        const session = req.session as any as Session;
         await getUpdateAcspProfileMiddleware(req, res, next);
 
         expect(getAcspFullProfile).toHaveBeenCalledWith(acspNumber);
         expect(next).toHaveBeenCalled();
+    });
+
+    it("should fetch ACSP details when not in session and throw an error if status is ceased", async () => {
+
+        (getAcspFullProfile as jest.Mock).mockResolvedValue({ status: "ceased" });
+
+        await getUpdateAcspProfileMiddleware(req, res, next);
+
+        expect(getAcspFullProfile).toHaveBeenCalledWith(acspNumber);
+        expect(next).toHaveBeenCalledWith(expect.any(AcspCeasedError));
     });
 
     it("should pass through to next when an error has been caught", async () => {


### PR DESCRIPTION
Ticket [IDAV5-2312](https://companieshouse.atlassian.net/browse/IDVA5-2312)

Adding ACSP status check before submitting on close and update journeys. This prevents users of ACSPs who are still logged in after the ACSP is close submitting changes