### PR TITLE
Clearing session data after closing acsp

### DIFF
--- a/src/common/__utils/sessionHelper.ts
+++ b/src/common/__utils/sessionHelper.ts
@@ -12,7 +12,6 @@ import {
     AML_REMOVAL_INDEX,
     AML_REMOVED_BODY_DETAILS,
     APPLICATION_ID,
-    CLOSE_SUBMISSION_ID,
     COMPANY,
     COMPANY_DETAILS,
     COMPANY_NUMBER,
@@ -65,5 +64,4 @@ export const deleteAllSessionData = async (session: Session) => {
     session.deleteExtraData(ACSP_UPDATE_CHANGE_DATE.NAME_OF_BUSINESS);
     session.deleteExtraData(ACSP_UPDATE_CHANGE_DATE.REGISTERED_OFFICE_ADDRESS);
     session.deleteExtraData(ACSP_UPDATE_CHANGE_DATE.WHERE_DO_YOU_LIVE);
-    session.deleteExtraData(CLOSE_SUBMISSION_ID);
 };


### PR DESCRIPTION
Ticket [IDVA5-2312](https://companieshouse.atlassian.net/browse/IDVA5-2312)

Clearing the session data after closing the ACSP. This will mean that when the user tries enter update ACSP they will be kicked out.

[IDVA5-2312]: https://companieshouse.atlassian.net/browse/IDVA5-2312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ