### PR TITLE
Kickout screen when user is not a part of an ACSP

### DIFF
--- a/locales/cy/must-be-authorised-agent.json
+++ b/locales/cy/must-be-authorised-agent.json
@@ -1,0 +1,6 @@
+{
+    "needToBeAddedToAuthorisedAgentAccountHeading": "Mae angen i chi gael eich ychwanegu at gyfrif asiant awdurdodedig i weld y dudalen hon",
+    "needToAskToBeAdded": "Bydd angen i chi ofyn am gael eich ychwanegu at gyfrif asiant awdurdodedig i weld ei ddefnyddwyr.",
+    "applyAsAnAuthorisedAgent": "Os nad oes cyfrif presennol ar gyfer eich busnes, gallwch ",
+    "applyAsAnAuthorisedAgentLink": "wneud cais i gofrestru fel asiant awdurdodedig gyda Thŷ'r Cwmnïau"
+}

--- a/locales/en/must-be-authorised-agent.json
+++ b/locales/en/must-be-authorised-agent.json
@@ -1,0 +1,6 @@
+{
+    "needToBeAddedToAuthorisedAgentAccountHeading": "You need to be added to an authorised agent account to view this page",
+    "needToAskToBeAdded": "You'll need to ask to be added to an authorised agent account to view its users.",
+    "applyAsAnAuthorisedAgent": "If there's not an existing account for your business, you can ",
+    "applyAsAnAuthorisedAgentLink": "apply to register as an authorised agent with Companies House"
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,7 +18,7 @@ import {
     CHS_MONITOR_GUI_URL,
     FEATURE_FLAG_VERIFY_SOLE_TRADER_ONLY
 } from "./utils/properties";
-import { BASE_URL, SOLE_TRADER, HEALTHCHECK, ACCESSIBILITY_STATEMENT, UPDATE_ACSP_DETAILS_BASE_URL, TYPE_OF_BUSINESS, SIGN_OUT_URL, CLOSE_ACSP_BASE_URL } from "./types/pageURL";
+import { BASE_URL, SOLE_TRADER, HEALTHCHECK, ACCESSIBILITY_STATEMENT, UPDATE_ACSP_DETAILS_BASE_URL, TYPE_OF_BUSINESS, SIGN_OUT_URL, CLOSE_ACSP_BASE_URL, MUST_BE_AUTHORISED_AGENT } from "./types/pageURL";
 import { commonTemplateVariablesMiddleware } from "./middleware/common_variables_middleware";
 import { updateAcspAuthMiddleware } from "./middleware/update-acsp/update_acsp_authentication_middleware";
 import { updateAcspBaseAuthenticationMiddleware } from "./middleware/update-acsp/update_acsp_base_authentication_middleware";
@@ -38,6 +38,8 @@ import { closeAcspAuthMiddleware } from "./middleware/close-acsp/close_acsp_auth
 import { closeAcspIsOwnerMiddleware } from "./middleware/close-acsp/close_acsp_is_owner_middleware";
 import { getAcspProfileMiddleware } from "./middleware/close-acsp/close_acsp_get_acsp_profile_middleware";
 import { getUpdateAcspProfileMiddleware } from "./middleware/update-acsp/update_acsp_get_acsp_profile_middleware";
+import { updateAcspUserIsPartOfAcspMiddleware } from "./middleware/update-acsp/update_acsp_user_is_part_of_acsp_middleware";
+import { closeAcspUserIsPartOfAcspMiddleware } from "./middleware/close-acsp/close_acsp_user_is_part_of_acsp_middleware";
 
 const app = express();
 const nonce: string = uuidv4();
@@ -99,27 +101,19 @@ app.use(BASE_URL, registrationVariablesMiddleware);
 
 // Update ACSP details middleware
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspBaseAuthenticationMiddleware);
-// app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspUserIsPartOfAcspMiddleware);
-app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspAuthMiddleware);
-// app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateAcspAuthMiddleware);
-app.use(UPDATE_ACSP_DETAILS_BASE_URL, getUpdateAcspProfileMiddleware);
-// app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, getUpdateAcspProfileMiddleware);
-app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateVariablesMiddleware);
-// app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateVariablesMiddleware);
-app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspIsOwnerMiddleware);
-// app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateAcspIsOwnerMiddleware);
+app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspUserIsPartOfAcspMiddleware);
+app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateAcspAuthMiddleware);
+app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, getUpdateAcspProfileMiddleware);
+app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateVariablesMiddleware);
+app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateAcspIsOwnerMiddleware);
 
 // Close ACSP middleware
 app.use(CLOSE_ACSP_BASE_URL, closeAcspBaseAuthenticationMiddleware);
-// app.use(CLOSE_ACSP_BASE_URL, closeAcspUserIsPartOfAcspMiddleware);
-app.use(CLOSE_ACSP_BASE_URL, closeAcspAuthMiddleware);
-// app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, closeAcspAuthMiddleware);
-app.use(CLOSE_ACSP_BASE_URL, getAcspProfileMiddleware);
-// app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, getAcspProfileMiddleware);
-app.use(CLOSE_ACSP_BASE_URL, closeVariablesMiddleware);
-// app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, closeVariablesMiddleware);
-app.use(CLOSE_ACSP_BASE_URL, closeAcspIsOwnerMiddleware);
-// app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, closeAcspIsOwnerMiddleware);
+app.use(CLOSE_ACSP_BASE_URL, closeAcspUserIsPartOfAcspMiddleware);
+app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, closeAcspAuthMiddleware);
+app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, getAcspProfileMiddleware);
+app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, closeVariablesMiddleware);
+app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, closeAcspIsOwnerMiddleware);
 
 // Company Auth redirect
 // const companyAuthRegex = new RegExp(`^${HOME_URL}/.+`);

--- a/src/app.ts
+++ b/src/app.ts
@@ -99,15 +99,15 @@ app.use(BASE_URL, registrationVariablesMiddleware);
 
 // Update ACSP details middleware
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspBaseAuthenticationMiddleware);
-//app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspUserIsPartOfAcspMiddleware);
+// app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspUserIsPartOfAcspMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspAuthMiddleware);
-//app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateAcspAuthMiddleware);
+// app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateAcspAuthMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, getUpdateAcspProfileMiddleware);
-//app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, getUpdateAcspProfileMiddleware);
+// app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, getUpdateAcspProfileMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateVariablesMiddleware);
 // app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateVariablesMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspIsOwnerMiddleware);
-//app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateAcspIsOwnerMiddleware);
+// app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateAcspIsOwnerMiddleware);
 
 // Close ACSP middleware
 app.use(CLOSE_ACSP_BASE_URL, closeAcspBaseAuthenticationMiddleware);

--- a/src/app.ts
+++ b/src/app.ts
@@ -99,17 +99,27 @@ app.use(BASE_URL, registrationVariablesMiddleware);
 
 // Update ACSP details middleware
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspBaseAuthenticationMiddleware);
+//app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspUserIsPartOfAcspMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspAuthMiddleware);
+//app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateAcspAuthMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, getUpdateAcspProfileMiddleware);
+//app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, getUpdateAcspProfileMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateVariablesMiddleware);
+// app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateVariablesMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspIsOwnerMiddleware);
+//app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateAcspIsOwnerMiddleware);
 
 // Close ACSP middleware
 app.use(CLOSE_ACSP_BASE_URL, closeAcspBaseAuthenticationMiddleware);
+// app.use(CLOSE_ACSP_BASE_URL, closeAcspUserIsPartOfAcspMiddleware);
 app.use(CLOSE_ACSP_BASE_URL, closeAcspAuthMiddleware);
+// app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, closeAcspAuthMiddleware);
 app.use(CLOSE_ACSP_BASE_URL, getAcspProfileMiddleware);
+// app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, getAcspProfileMiddleware);
 app.use(CLOSE_ACSP_BASE_URL, closeVariablesMiddleware);
+// app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, closeVariablesMiddleware);
 app.use(CLOSE_ACSP_BASE_URL, closeAcspIsOwnerMiddleware);
+// app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, closeAcspIsOwnerMiddleware);
 
 // Company Auth redirect
 // const companyAuthRegex = new RegExp(`^${HOME_URL}/.+`);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -42,6 +42,7 @@ export const AUTO_LOOKUP_ADDRESS = `${BASE_COMMON_URL}/correspondence-auto-looku
 export const CORRESPONDENCE_ADDRESS_LIST = `${BASE_COMMON_URL}/correspondence-auto-lookup-address/correspondence-address-list`;
 export const SIGN_OUT_PAGE = `${BASE_COMMON_URL}/sign-out-page/sign-out`;
 export const SAVED_APPLICATION = `${BASE_COMMON_URL}/saved-application/saved-application`;
+export const MUST_BE_AUTHORISED_AGENT = `${BASE_COMMON_URL}/must-be-authorised-agent/must-be-authorised-agent`;
 
 export const ERROR_400 = `${BASE_PARTIALS_URL}/error_400`;
 export const ERROR_404 = `${BASE_PARTIALS_URL}/error_404`;

--- a/src/controllers/features/common/mustBeAuthorisedAgentController.ts
+++ b/src/controllers/features/common/mustBeAuthorisedAgentController.ts
@@ -1,16 +1,23 @@
 import { NextFunction, Request, Response } from "express";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
 import * as config from "../../../config";
-import { BASE_URL, MUST_BE_AUTHORISED_AGENT } from "../../../types/pageURL";
+import { BASE_URL, CLOSE_ACSP_BASE_URL, MUST_BE_AUTHORISED_AGENT, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../types/pageURL";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
 
+        let baseUrl;
+        if (req.originalUrl.includes(UPDATE_ACSP_DETAILS_BASE_URL)) {
+            baseUrl = UPDATE_ACSP_DETAILS_BASE_URL;
+        } else if (req.originalUrl.includes(CLOSE_ACSP_BASE_URL)) {
+            baseUrl = CLOSE_ACSP_BASE_URL;
+        }
+
         res.render(config.MUST_BE_AUTHORISED_AGENT, {
             ...getLocaleInfo(locales, lang),
-            currentUrl: BASE_URL + MUST_BE_AUTHORISED_AGENT,
+            currentUrl: baseUrl + MUST_BE_AUTHORISED_AGENT,
             registerAsAcspLink: addLangToUrl(BASE_URL, lang)
         });
     } catch (error) {

--- a/src/controllers/features/common/mustBeAuthorisedAgentController.ts
+++ b/src/controllers/features/common/mustBeAuthorisedAgentController.ts
@@ -1,0 +1,19 @@
+import { NextFunction, Request, Response } from "express";
+import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
+import * as config from "../../../config";
+import { BASE_URL, MUST_BE_AUTHORISED_AGENT } from "../../../types/pageURL";
+
+export const get = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lang = selectLang(req.query.lang);
+        const locales = getLocalesService();
+
+        res.render(config.MUST_BE_AUTHORISED_AGENT, {
+            ...getLocaleInfo(locales, lang),
+            currentUrl: BASE_URL + MUST_BE_AUTHORISED_AGENT,
+            registerAsAcspLink: addLangToUrl(BASE_URL, lang)
+        });
+    } catch (error) {
+        next(error);
+    }
+};

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -16,6 +16,7 @@ export * as resumeJourneyController from "./features/common/resumeJourneyControl
 export * as cannotSubmitAnotherApplicationController from "./features/common/cannotSubmitAnotherApplicationController";
 export * as cannotRegisterAgainController from "./features/common/cannotRegisterAgainController";
 export * as paymentFailedController from "./features/common/paymentFailedController";
+export * as mustBeAuthorisedAgentController from "./features/common/mustBeAuthorisedAgentController";
 
 // Sole trader
 export * as soleTraderCorrespodanceAddressDetailsController from "./features/sole-trader/correspodanceAddressDetailsController";

--- a/src/middleware/close-acsp/close_acsp_user_is_part_of_acsp_middleware.ts
+++ b/src/middleware/close-acsp/close_acsp_user_is_part_of_acsp_middleware.ts
@@ -7,11 +7,9 @@ export const closeAcspUserIsPartOfAcspMiddleware = async (req: Request, res: Res
     try {
         const lang = selectLang(req.query.lang);
         const acspNumber: string = getLoggedInAcspNumber(req.session);
-        if (!acspNumber) {
-            if (!req.originalUrl.includes(MUST_BE_AUTHORISED_AGENT)) {
-                res.redirect(addLangToUrl(CLOSE_ACSP_BASE_URL + MUST_BE_AUTHORISED_AGENT, lang));
-                return;
-            }
+        if (!acspNumber && !req.originalUrl.includes(MUST_BE_AUTHORISED_AGENT)) {
+            res.redirect(addLangToUrl(CLOSE_ACSP_BASE_URL + MUST_BE_AUTHORISED_AGENT, lang));
+            return;
         }
 
         next();

--- a/src/middleware/close-acsp/close_acsp_user_is_part_of_acsp_middleware.ts
+++ b/src/middleware/close-acsp/close_acsp_user_is_part_of_acsp_middleware.ts
@@ -1,0 +1,21 @@
+import { NextFunction, Request, Response } from "express";
+import { addLangToUrl, selectLang } from "../../utils/localise";
+import { getLoggedInAcspNumber } from "../../common/__utils/session";
+import { CLOSE_ACSP_BASE_URL, MUST_BE_AUTHORISED_AGENT } from "../../types/pageURL";
+
+export const closeAcspUserIsPartOfAcspMiddleware = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lang = selectLang(req.query.lang);
+        const acspNumber: string = getLoggedInAcspNumber(req.session);
+        if (!acspNumber) {
+            if (!req.originalUrl.includes(MUST_BE_AUTHORISED_AGENT)) {
+                res.redirect(addLangToUrl(CLOSE_ACSP_BASE_URL + MUST_BE_AUTHORISED_AGENT, lang));
+                return;
+            }
+        }
+
+        next();
+    } catch (error) {
+        next(error);
+    }
+};

--- a/src/middleware/update-acsp/update_acsp_user_is_part_of_acsp_middleware.ts
+++ b/src/middleware/update-acsp/update_acsp_user_is_part_of_acsp_middleware.ts
@@ -1,0 +1,21 @@
+import { NextFunction, Request, Response } from "express";
+import { addLangToUrl, selectLang } from "../../utils/localise";
+import { getLoggedInAcspNumber } from "../../common/__utils/session";
+import { MUST_BE_AUTHORISED_AGENT, UPDATE_ACSP_DETAILS_BASE_URL } from "../../types/pageURL";
+
+export const updateAcspUserIsPartOfAcspMiddleware = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const lang = selectLang(req.query.lang);
+        const acspNumber: string = getLoggedInAcspNumber(req.session);
+        if (!acspNumber) {
+            if (!req.originalUrl.includes(MUST_BE_AUTHORISED_AGENT)) {
+                res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + MUST_BE_AUTHORISED_AGENT, lang));
+                return;
+            }
+        }
+
+        next();
+    } catch (error) {
+        next(error);
+    }
+};

--- a/src/middleware/update-acsp/update_acsp_user_is_part_of_acsp_middleware.ts
+++ b/src/middleware/update-acsp/update_acsp_user_is_part_of_acsp_middleware.ts
@@ -7,11 +7,9 @@ export const updateAcspUserIsPartOfAcspMiddleware = async (req: Request, res: Re
     try {
         const lang = selectLang(req.query.lang);
         const acspNumber: string = getLoggedInAcspNumber(req.session);
-        if (!acspNumber) {
-            if (!req.originalUrl.includes(MUST_BE_AUTHORISED_AGENT)) {
-                res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + MUST_BE_AUTHORISED_AGENT, lang));
-                return;
-            }
+        if (!acspNumber && !req.originalUrl.includes(MUST_BE_AUTHORISED_AGENT)) {
+            res.redirect(addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + MUST_BE_AUTHORISED_AGENT, lang));
+            return;
         }
 
         next();

--- a/src/routes/closeRoutesAcsp.ts
+++ b/src/routes/closeRoutesAcsp.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import * as urls from "../types/pageURL";
-import { closeIndexController, closeWhatWillHappenController, closeConfirmYouWantToCloseController, closeConfirmationAuthorisedAgentClosedController } from "../controllers";
+import { closeIndexController, closeWhatWillHappenController, closeConfirmYouWantToCloseController, closeConfirmationAuthorisedAgentClosedController, mustBeAuthorisedAgentController } from "../controllers";
 import { whatWillHappenValidator } from "../validation/whatWillHappen";
 
 const closeRoutesAcsp = Router();
@@ -15,5 +15,7 @@ closeRoutesAcsp.get(urls.CLOSE_CONFIRM_YOU_WANT_TO_CLOSE, closeConfirmYouWantToC
 closeRoutesAcsp.post(urls.CLOSE_CONFIRM_YOU_WANT_TO_CLOSE, closeConfirmYouWantToCloseController.post);
 
 closeRoutesAcsp.get(urls.CLOSE_CONFIRMATION_ACSP_CLOSED, closeConfirmationAuthorisedAgentClosedController.get);
+
+closeRoutesAcsp.get(urls.MUST_BE_AUTHORISED_AGENT, mustBeAuthorisedAgentController.get);
 
 export default closeRoutesAcsp;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -62,7 +62,8 @@ import {
     soleTraderWhatIsYourEmailAddressController,
     unincorporatedWhatIsYourEmailController,
     cannotRegisterAgainController,
-    paymentFailedController
+    paymentFailedController,
+    mustBeAuthorisedAgentController
 } from "../controllers";
 
 import * as urls from "../types/pageURL";
@@ -133,6 +134,8 @@ routes.get(urls.CANNOT_SUBMIT_ANOTHER_APPLICATION, cannotSubmitAnotherApplicatio
 routes.get(urls.CANNOT_REGISTER_AGAIN, cannotRegisterAgainController.get);
 
 routes.get(urls.PAYMENT_FAILED, paymentFailedController.get);
+
+routes.get(urls.MUST_BE_AUTHORISED_AGENT, mustBeAuthorisedAgentController.get);
 
 // SOLE_TRADER
 routes.get(urls.SOLE_TRADER_DATE_OF_BIRTH, soleTraderDateOfBirthController.get);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -62,8 +62,7 @@ import {
     soleTraderWhatIsYourEmailAddressController,
     unincorporatedWhatIsYourEmailController,
     cannotRegisterAgainController,
-    paymentFailedController,
-    mustBeAuthorisedAgentController
+    paymentFailedController
 } from "../controllers";
 
 import * as urls from "../types/pageURL";
@@ -134,8 +133,6 @@ routes.get(urls.CANNOT_SUBMIT_ANOTHER_APPLICATION, cannotSubmitAnotherApplicatio
 routes.get(urls.CANNOT_REGISTER_AGAIN, cannotRegisterAgainController.get);
 
 routes.get(urls.PAYMENT_FAILED, paymentFailedController.get);
-
-routes.get(urls.MUST_BE_AUTHORISED_AGENT, mustBeAuthorisedAgentController.get);
 
 // SOLE_TRADER
 routes.get(urls.SOLE_TRADER_DATE_OF_BIRTH, soleTraderDateOfBirthController.get);

--- a/src/routes/updateRoutesAcsp.ts
+++ b/src/routes/updateRoutesAcsp.ts
@@ -23,7 +23,8 @@ import {
     updateAmlMembershipNumberController,
     cancelAllUpdatesController,
     updateProvideAmlDetailsController,
-    yourUpdatesController
+    yourUpdatesController,
+    mustBeAuthorisedAgentController
 } from "../controllers";
 import { nameValidator } from "../validation/whatIsYourName";
 import { whereDoYouLiveValidator } from "../validation/whereDoYouLive";
@@ -109,5 +110,7 @@ updateRoutes.get(urls.UPDATE_PROVIDE_AML_DETAILS, updateProvideAmlDetailsControl
 
 updateRoutes.get(urls.UPDATE_CHECK_YOUR_UPDATES, yourUpdatesController.get);
 updateRoutes.post(urls.UPDATE_CHECK_YOUR_UPDATES, yourUpdatesValidator, yourUpdatesController.post);
+
+updateRoutes.get(urls.MUST_BE_AUTHORISED_AGENT, mustBeAuthorisedAgentController.get);
 
 export default updateRoutes;

--- a/src/types/pageURL.ts
+++ b/src/types/pageURL.ts
@@ -74,6 +74,8 @@ export const TELL_HMRC_YOUVE_STOPPED_TRADING = "https://www.gov.uk/stop-being-se
 
 export const REGISTRATION_FEEDBACK_LINK = "https://www.smartsurvey.co.uk/s/reg-as-acsp-fdbk/";
 
+export const MUST_BE_AUTHORISED_AGENT = "/must-be-authorised-agent";
+
 // sole trader journey urls
 export const SOLE_TRADER_WHAT_IS_YOUR_ROLE = SOLE_TRADER + "/what-is-your-role";
 

--- a/src/views/common/must-be-authorised-agent/must-be-authorised-agent.njk
+++ b/src/views/common/must-be-authorised-agent/must-be-authorised-agent.njk
@@ -1,0 +1,13 @@
+{% extends "layouts/default.njk" %}
+{% set title = i18n.needToBeAddedToAuthorisedAgentAccountHeading %}
+{% block backLink %}
+    {# Remove back button on this page by replacing it with nothing #}
+{% endblock %}
+{% block main_content %}
+    <h1 class="govuk-heading-l">{{ i18n.needToBeAddedToAuthorisedAgentAccountHeading }}</h1>
+    <p class="govuk-body">{{ i18n.needToAskToBeAdded }}</p>
+    <p class="govuk-body">
+        {{ i18n.applyAsAnAuthorisedAgent }}
+        <a href={{ registerAsAcspLink }}>{{ i18n.applyAsAnAuthorisedAgentLink }}</a>.
+    </p>
+{% endblock main_content %}

--- a/test/mocks/close_acsp_authentication_middleware_mock.ts
+++ b/test/mocks/close_acsp_authentication_middleware_mock.ts
@@ -6,19 +6,23 @@ import { closeAcspIsOwnerMiddleware } from "../../src/middleware/close-acsp/clos
 jest.mock("../../src/middleware/close-acsp/close_acsp_authentication_middleware");
 jest.mock("../../src/middleware/close-acsp/close_acsp_base_authentication_middleware");
 jest.mock("../../src/middleware/close-acsp/close_acsp_is_owner_middleware");
+jest.mock("../../src/middleware/close-acsp/close_acsp_user_is_part_of_acsp_middleware");
 
 // get handle on mocked function
 const mockCloseAcspAuthenticationMiddleware = closeAcspAuthMiddleware as jest.Mock;
 const mockCloseAcspBaseAuthenticationMiddleware = closeAcspBaseAuthenticationMiddleware as jest.Mock;
 const mockCloseAcspIsOwnerMiddleware = closeAcspIsOwnerMiddleware as jest.Mock;
+const mockCloseAcspUserIsPartOfAcspMiddleware = closeAcspIsOwnerMiddleware as jest.Mock;
 
 // tell the mock what to return
 mockCloseAcspAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 mockCloseAcspBaseAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 mockCloseAcspIsOwnerMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+mockCloseAcspUserIsPartOfAcspMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
 export default {
     mockCloseAcspAuthenticationMiddleware,
     mockCloseAcspBaseAuthenticationMiddleware,
-    mockCloseAcspIsOwnerMiddleware
+    mockCloseAcspIsOwnerMiddleware,
+    mockCloseAcspUserIsPartOfAcspMiddleware
 };

--- a/test/mocks/close_acsp_authentication_middleware_mock.ts
+++ b/test/mocks/close_acsp_authentication_middleware_mock.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { closeAcspAuthMiddleware } from "../../src/middleware/close-acsp/close_acsp_authentication_middleware";
 import { closeAcspBaseAuthenticationMiddleware } from "../../src/middleware/close-acsp/close_acsp_base_authentication_middleware";
 import { closeAcspIsOwnerMiddleware } from "../../src/middleware/close-acsp/close_acsp_is_owner_middleware";
+import { closeAcspUserIsPartOfAcspMiddleware } from "../../src/middleware/close-acsp/close_acsp_user_is_part_of_acsp_middleware";
 
 jest.mock("../../src/middleware/close-acsp/close_acsp_authentication_middleware");
 jest.mock("../../src/middleware/close-acsp/close_acsp_base_authentication_middleware");
@@ -12,7 +13,7 @@ jest.mock("../../src/middleware/close-acsp/close_acsp_user_is_part_of_acsp_middl
 const mockCloseAcspAuthenticationMiddleware = closeAcspAuthMiddleware as jest.Mock;
 const mockCloseAcspBaseAuthenticationMiddleware = closeAcspBaseAuthenticationMiddleware as jest.Mock;
 const mockCloseAcspIsOwnerMiddleware = closeAcspIsOwnerMiddleware as jest.Mock;
-const mockCloseAcspUserIsPartOfAcspMiddleware = closeAcspIsOwnerMiddleware as jest.Mock;
+const mockCloseAcspUserIsPartOfAcspMiddleware = closeAcspUserIsPartOfAcspMiddleware as jest.Mock;
 
 // tell the mock what to return
 mockCloseAcspAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());

--- a/test/mocks/update_acsp_authentication_middleware_mock.ts
+++ b/test/mocks/update_acsp_authentication_middleware_mock.ts
@@ -2,23 +2,28 @@ import { NextFunction, Request, Response } from "express";
 import { updateAcspAuthMiddleware } from "../../src/middleware/update-acsp/update_acsp_authentication_middleware";
 import { updateAcspBaseAuthenticationMiddleware } from "../../src/middleware/update-acsp/update_acsp_base_authentication_middleware";
 import { updateAcspIsOwnerMiddleware } from "../../src/middleware/update-acsp/update_acsp_is_owner_middleware";
+import { updateAcspUserIsPartOfAcspMiddleware } from "../../src/middleware/update-acsp/update_acsp_user_is_part_of_acsp_middleware";
 
 jest.mock("../../src/middleware/update-acsp/update_acsp_authentication_middleware");
 jest.mock("../../src/middleware/update-acsp/update_acsp_base_authentication_middleware");
 jest.mock("../../src/middleware/update-acsp/update_acsp_is_owner_middleware");
+jest.mock("../../src/middleware/update-acsp/update_acsp_user_is_part_of_acsp_middleware")
 
 // get handle on mocked function
 const mockUpdateAcspAuthenticationMiddleware = updateAcspAuthMiddleware as jest.Mock;
 const mockUpdateAcspBaseAuthenticationMiddleware = updateAcspBaseAuthenticationMiddleware as jest.Mock;
 const mockUpdateAcspIsOwnerMiddleware = updateAcspIsOwnerMiddleware as jest.Mock;
+const mockUpdateAcspUserIsPartOfAcspMiddleware = updateAcspUserIsPartOfAcspMiddleware as jest.Mock;
 
 // tell the mock what to return
 mockUpdateAcspAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 mockUpdateAcspBaseAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 mockUpdateAcspIsOwnerMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+mockUpdateAcspUserIsPartOfAcspMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
 export default {
     mockUpdateAcspAuthenticationMiddleware,
     mockUpdateAcspBaseAuthenticationMiddleware,
-    mockUpdateAcspIsOwnerMiddleware
+    mockUpdateAcspIsOwnerMiddleware,
+    mockUpdateAcspUserIsPartOfAcspMiddleware
 };

--- a/test/src/controllers/common/mustBeAuthorisedAgentController.test.ts
+++ b/test/src/controllers/common/mustBeAuthorisedAgentController.test.ts
@@ -1,6 +1,6 @@
 import mocks from "../../../mocks/all_middleware_mock";
 import supertest from "supertest";
-import { BASE_URL, MUST_BE_AUTHORISED_AGENT } from "../../../../src/types/pageURL";
+import { MUST_BE_AUTHORISED_AGENT, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../../src/types/pageURL";
 import app from "../../../../src/app";
 import * as localise from "../../../../src/utils/localise";
 
@@ -8,7 +8,7 @@ const router = supertest(app);
 
 describe("GET " + MUST_BE_AUTHORISED_AGENT, () => {
     it("should return status 200 and display the information on the screen", async () => {
-        const res = await router.get(BASE_URL + MUST_BE_AUTHORISED_AGENT);
+        const res = await router.get(UPDATE_ACSP_DETAILS_BASE_URL + MUST_BE_AUTHORISED_AGENT);
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
         expect(res.status).toBe(200);
         expect(res.text).toContain("You need to be added to an authorised agent account to view this page");
@@ -18,7 +18,7 @@ describe("GET " + MUST_BE_AUTHORISED_AGENT, () => {
         jest.spyOn(localise, "getLocalesService").mockImplementationOnce(() => {
             throw new Error("Test error");
         });
-        const res = await router.get(BASE_URL + MUST_BE_AUTHORISED_AGENT);
+        const res = await router.get(UPDATE_ACSP_DETAILS_BASE_URL + MUST_BE_AUTHORISED_AGENT);
         expect(res.status).toBe(500);
         expect(res.text).toContain("Sorry we are experiencing technical difficulties");
     });

--- a/test/src/controllers/common/mustBeAuthorisedAgentController.test.ts
+++ b/test/src/controllers/common/mustBeAuthorisedAgentController.test.ts
@@ -1,14 +1,24 @@
+/* eslint-disable import/first */
+process.env.FEATURE_FLAG_ENABLE_CLOSE_ACSP = "true";
+
 import mocks from "../../../mocks/all_middleware_mock";
 import supertest from "supertest";
-import { MUST_BE_AUTHORISED_AGENT, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../../src/types/pageURL";
+import { CLOSE_ACSP_BASE_URL, MUST_BE_AUTHORISED_AGENT, UPDATE_ACSP_DETAILS_BASE_URL } from "../../../../src/types/pageURL";
 import app from "../../../../src/app";
 import * as localise from "../../../../src/utils/localise";
 
 const router = supertest(app);
 
 describe("GET " + MUST_BE_AUTHORISED_AGENT, () => {
-    it("should return status 200 and display the information on the screen", async () => {
+    it("should return status 200 and display the information on the screen for update acsp", async () => {
         const res = await router.get(UPDATE_ACSP_DETAILS_BASE_URL + MUST_BE_AUTHORISED_AGENT);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        expect(res.text).toContain("You need to be added to an authorised agent account to view this page");
+    });
+
+    it("should return status 200 and display the information on the screen for close acsp", async () => {
+        const res = await router.get(CLOSE_ACSP_BASE_URL + MUST_BE_AUTHORISED_AGENT);
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
         expect(res.status).toBe(200);
         expect(res.text).toContain("You need to be added to an authorised agent account to view this page");

--- a/test/src/controllers/common/mustBeAuthorisedAgentController.test.ts
+++ b/test/src/controllers/common/mustBeAuthorisedAgentController.test.ts
@@ -1,0 +1,25 @@
+import mocks from "../../../mocks/all_middleware_mock";
+import supertest from "supertest";
+import { BASE_URL, MUST_BE_AUTHORISED_AGENT } from "../../../../src/types/pageURL";
+import app from "../../../../src/app";
+import * as localise from "../../../../src/utils/localise";
+
+const router = supertest(app);
+
+describe("GET " + MUST_BE_AUTHORISED_AGENT, () => {
+    it("should return status 200 and display the information on the screen", async () => {
+        const res = await router.get(BASE_URL + MUST_BE_AUTHORISED_AGENT);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(res.status).toBe(200);
+        expect(res.text).toContain("You need to be added to an authorised agent account to view this page");
+    });
+
+    it("should return status 500 if an error occurs", async () => {
+        jest.spyOn(localise, "getLocalesService").mockImplementationOnce(() => {
+            throw new Error("Test error");
+        });
+        const res = await router.get(BASE_URL + MUST_BE_AUTHORISED_AGENT);
+        expect(res.status).toBe(500);
+        expect(res.text).toContain("Sorry we are experiencing technical difficulties");
+    });
+});

--- a/test/src/middleware/close-acsp/close_acsp_user_is_part_of_acsp_middleware.test.ts
+++ b/test/src/middleware/close-acsp/close_acsp_user_is_part_of_acsp_middleware.test.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from "express";
+import * as sessionUtils from "../../../../src/common/__utils/session";
+import { createRequest, MockRequest } from "node-mocks-http";
+import { getSessionRequestWithPermission } from "../../../mocks/session.mock";
+import * as localise from "../../../../src/utils/localise";
+import { closeAcspUserIsPartOfAcspMiddleware } from "../../../../src/middleware/close-acsp/close_acsp_user_is_part_of_acsp_middleware";
+
+const getLoggedInAcspNumberSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getLoggedInAcspNumber");
+
+describe("userIsPartOfAcspMiddleware", () => {
+    let req: MockRequest<Request>;
+    let res: Partial<Response>;
+    const next = jest.fn();
+
+    beforeEach(() => {
+        req = createRequest({
+            method: "GET",
+            url: "/"
+        });
+        res = {
+            redirect: jest.fn()
+        };
+        const session = getSessionRequestWithPermission();
+        req.session = session;
+    });
+
+    it("should call res.redirect() if no acspNumber in session", async () => {
+        getLoggedInAcspNumberSpy.mockReturnValue(undefined);
+        closeAcspUserIsPartOfAcspMiddleware(req, res as Response, next);
+        expect(res.redirect).toHaveBeenCalledTimes(1);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it("should call next() when acspNumber is present in session", async () => {
+        getLoggedInAcspNumberSpy.mockReturnValue("ABC123");
+        closeAcspUserIsPartOfAcspMiddleware(req, res as Response, next);
+        expect(next).toHaveBeenCalled();
+        expect(res.redirect).not.toHaveBeenCalled();
+    });
+
+    it("should pass through any caught errors", async () => {
+        const error = new Error("Test error");
+        jest.spyOn(localise, "selectLang").mockImplementationOnce(() => {
+            throw error;
+        });
+
+        await closeAcspUserIsPartOfAcspMiddleware(req, res as Response, next);
+
+        expect(next).toHaveBeenCalledWith(error);
+    });
+});

--- a/test/src/middleware/update-acsp/update_acsp_user_is_part_of_acsp_middleware.test.ts
+++ b/test/src/middleware/update-acsp/update_acsp_user_is_part_of_acsp_middleware.test.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from "express";
+import * as sessionUtils from "../../../../src/common/__utils/session";
+import { createRequest, MockRequest } from "node-mocks-http";
+import { getSessionRequestWithPermission } from "../../../mocks/session.mock";
+import * as localise from "../../../../src/utils/localise";
+import { updateAcspUserIsPartOfAcspMiddleware } from "../../../../src/middleware/update-acsp/update_acsp_user_is_part_of_acsp_middleware";
+
+const getLoggedInAcspNumberSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getLoggedInAcspNumber");
+
+describe("userIsPartOfAcspMiddleware", () => {
+    let req: MockRequest<Request>;
+    let res: Partial<Response>;
+    const next = jest.fn();
+
+    beforeEach(() => {
+        req = createRequest({
+            method: "GET",
+            url: "/"
+        });
+        res = {
+            redirect: jest.fn()
+        };
+        const session = getSessionRequestWithPermission();
+        req.session = session;
+    });
+
+    it("should call res.redirect() if no acspNumber in session", async () => {
+        getLoggedInAcspNumberSpy.mockReturnValue(undefined);
+        updateAcspUserIsPartOfAcspMiddleware(req, res as Response, next);
+        expect(res.redirect).toHaveBeenCalledTimes(1);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it("should call next() when acspNumber is present in session", async () => {
+        getLoggedInAcspNumberSpy.mockReturnValue("ABC123");
+        updateAcspUserIsPartOfAcspMiddleware(req, res as Response, next);
+        expect(next).toHaveBeenCalled();
+        expect(res.redirect).not.toHaveBeenCalled();
+    });
+
+    it("should pass through any caught errors", async () => {
+        const error = new Error("Test error");
+        jest.spyOn(localise, "selectLang").mockImplementationOnce(() => {
+            throw error;
+        });
+
+        await updateAcspUserIsPartOfAcspMiddleware(req, res as Response, next);
+
+        expect(next).toHaveBeenCalledWith(error);
+    });
+});


### PR DESCRIPTION
**Short description outlining key changes/additions**

Implemented middleware (for update-acsp and close-acsp) that checks if a user is part of an ACSP and added tests.
Introduced JSON, njk, and ts files for new kickout screen and added tests.
Wired up new kickout screen to router and redirect call from middleware to screen.
Excluded kickout screen from middleware that errors if a user is not associated with an ACSP.

**JIRA Ticket**

https://companieshouse.atlassian.net/browse/IDVA5-2031

**Type of change**
- [ ] Bug fix
- [x]  New feature
- [ ]  Breaking change
- [ ]  Infrastructure change

**Pull request checklist**
- [x]  I have added unit tests for new code that I have added
- [x]  I have added/updated functional tests where appropriate

**An exhaustive list of peer review checks can be read** [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)