### PR TITLE
Prevent previously removed AML details clearing from your updates screen

### DIFF
--- a/src/controllers/features/update-acsp/addAmlSupervisorController.ts
+++ b/src/controllers/features/update-acsp/addAmlSupervisorController.ts
@@ -5,7 +5,7 @@ import { formatValidationError, getPageProperties } from "../../../validation/va
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { UPDATE_ACSP_DETAILS_BASE_URL, AML_MEMBERSHIP_NUMBER, UPDATE_YOUR_ANSWERS, UPDATE_ADD_AML_SUPERVISOR } from "../../../types/pageURL";
 import { Session } from "@companieshouse/node-session-handler";
-import { NEW_AML_BODY, ADD_AML_BODY_UPDATE, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { NEW_AML_BODY, ADD_AML_BODY_UPDATE, ACSP_DETAILS_UPDATED, AML_REMOVAL_BODY, AML_REMOVAL_INDEX } from "../../../common/__utils/constants";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { AmlSupervisoryBody } from "@companieshouse/api-sdk-node/dist/services/acsp";
 import { AMLSupervisoryBodies } from "../../../model/AMLSupervisoryBodies";
@@ -40,6 +40,11 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const lang = selectLang(req.query.lang);
         const locales = getLocalesService();
         const currentUrl = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_ADD_AML_SUPERVISOR;
+
+        // Delete the temporary AML removal index and body from the session
+        // Prevents the removed AML details from clearing on Your Updates view
+        session.deleteExtraData(AML_REMOVAL_INDEX);
+        session.deleteExtraData(AML_REMOVAL_BODY);
 
         res.render(config.UPDATE_ADD_AML_SUPERVISORY_BODY, {
             previousPage: addLangToUrl(UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_YOUR_ANSWERS, lang),

--- a/src/controllers/features/update-acsp/businessAddressAutoLookupController.ts
+++ b/src/controllers/features/update-acsp/businessAddressAutoLookupController.ts
@@ -13,7 +13,7 @@ import {
     UPDATE_ACSP_DETAILS_BASE_URL
 } from "../../../types/pageURL";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
-import { ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED, AML_REMOVAL_BODY, AML_REMOVAL_INDEX } from "../../../common/__utils/constants";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 
@@ -30,6 +30,11 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             postCode: updateInProgress ? updateInProgress.postalCode : acspUpdatedFullProfile.registeredOfficeAddress.postalCode,
             premise: updateInProgress ? updateInProgress.premises : acspUpdatedFullProfile.registeredOfficeAddress.premises
         };
+
+        // Delete the temporary AML removal index and body from the session
+        // Prevents the removed AML details from clearing on Your Updates view
+        session.deleteExtraData(AML_REMOVAL_INDEX);
+        session.deleteExtraData(AML_REMOVAL_BODY);
 
         res.render(config.UNINCORPORATED_BUSINESS_ADDRESS_LOOKUP, {
             previousPage,

--- a/src/controllers/features/update-acsp/cancelAllUpdatesController.ts
+++ b/src/controllers/features/update-acsp/cancelAllUpdatesController.ts
@@ -3,7 +3,7 @@ import * as config from "../../../config";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS, ACSP_DETAILS_UPDATED, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_UPDATE_CHANGE_DATE } from "../../../common/__utils/constants";
+import { ACSP_DETAILS, ACSP_DETAILS_UPDATED, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_UPDATE_CHANGE_DATE, AML_REMOVAL_BODY, AML_REMOVAL_INDEX } from "../../../common/__utils/constants";
 import { UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_CANCEL_ALL_UPDATES, AUTHORISED_AGENT } from "../../../types/pageURL";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -35,6 +35,8 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
         session.deleteExtraData(ACSP_UPDATE_CHANGE_DATE.CORRESPONDENCE_ADDRESS);
         session.deleteExtraData(ACSP_UPDATE_CHANGE_DATE.REGISTERED_OFFICE_ADDRESS);
         session.deleteExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS);
+        session.deleteExtraData(AML_REMOVAL_INDEX);
+        session.deleteExtraData(AML_REMOVAL_BODY);
 
         res.redirect(addLangToUrl(AUTHORISED_AGENT, selectLang(req.query.lang)));
     } catch (err) {

--- a/src/controllers/features/update-acsp/correspondenceAddressAutoLookupController.ts
+++ b/src/controllers/features/update-acsp/correspondenceAddressAutoLookupController.ts
@@ -15,7 +15,7 @@ import {
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../../../utils/localise";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED, AML_REMOVAL_BODY, AML_REMOVAL_INDEX } from "../../../common/__utils/constants";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -27,6 +27,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const currentUrl: string = UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_CORRESPONDENCE_ADDRESS_LOOKUP;
         const updateInProgress: Address | undefined = session.getExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS);
         let postCode, premise;
+
         if (updateInProgress) {
             postCode = updateInProgress.postalCode;
             premise = updateInProgress.premises;
@@ -42,6 +43,12 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             postCode,
             premise
         };
+
+        // Delete the temporary AML removal index and body from the session
+        // Prevents the removed AML details from clearing on Your Updates view
+        session.deleteExtraData(AML_REMOVAL_INDEX);
+        session.deleteExtraData(AML_REMOVAL_BODY);
+
         res.render(config.AUTO_LOOKUP_ADDRESS, {
             previousPage,
             ...getLocaleInfo(locales, lang),

--- a/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
+++ b/src/controllers/features/update-acsp/whatIsTheBusinessNameController.ts
@@ -6,7 +6,7 @@ import { getBusinessName, isLimitedBusinessType } from "../../../services/common
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_UPDATE_PREVIOUS_PAGE_URL, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_UPDATE_PREVIOUS_PAGE_URL, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED, AML_REMOVAL_BODY, AML_REMOVAL_INDEX } from "../../../common/__utils/constants";
 import { UPDATE_WHAT_IS_THE_BUSINESS_NAME, UPDATE_YOUR_ANSWERS, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_DATE_OF_THE_CHANGE, UPDATE_WHAT_IS_THE_COMPANY_NAME } from "../../../types/pageURL";
 import { CHS_URL } from "../../../utils/properties";
 
@@ -25,6 +25,11 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const payload = {
             whatIsTheBusinessName: updateInProgress || getBusinessName(acspUpdatedFullProfile.name)
         };
+
+        // Delete the temporary AML removal index and body from the session
+        // Prevents the removed AML details from clearing on Your Updates view
+        session.deleteExtraData(AML_REMOVAL_INDEX);
+        session.deleteExtraData(AML_REMOVAL_BODY);
 
         res.render(config.WHAT_IS_THE_BUSINESS_NAME, {
             typeOfBusiness: acspUpdatedFullProfile.type,

--- a/src/controllers/features/update-acsp/whatIsYourEmailAddressController.ts
+++ b/src/controllers/features/update-acsp/whatIsYourEmailAddressController.ts
@@ -4,7 +4,7 @@ import { UPDATE_WHAT_IS_YOUR_EMAIL, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_YOUR_AN
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { validationResult } from "express-validator";
 import { Session } from "@companieshouse/node-session-handler";
-import { ACSP_DETAILS, ACSP_DETAILS_UPDATED } from "../../../common/__utils/constants";
+import { ACSP_DETAILS, ACSP_DETAILS_UPDATED, AML_REMOVAL_BODY, AML_REMOVAL_INDEX } from "../../../common/__utils/constants";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 
@@ -27,6 +27,11 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
                 whatIsYourEmailInput: acspUpdatedFullProfile.email
             };
         }
+
+        // Delete the temporary AML removal index and body from the session
+        // Prevents the removed AML details from clearing on Your Updates view
+        session.deleteExtraData(AML_REMOVAL_INDEX);
+        session.deleteExtraData(AML_REMOVAL_BODY);
 
         res.render(config.UPDATE_WHAT_IS_YOUR_EMAIL, {
             ...getLocaleInfo(locales, lang),

--- a/src/controllers/features/update-acsp/whatIsYourNameController.ts
+++ b/src/controllers/features/update-acsp/whatIsYourNameController.ts
@@ -10,7 +10,7 @@ import {
 import { validationResult } from "express-validator";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { Session } from "@companieshouse/node-session-handler";
-import { ACSP_DETAILS_UPDATED, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_UPDATE_PREVIOUS_PAGE_URL } from "../../../common/__utils/constants";
+import { ACSP_DETAILS_UPDATED, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_UPDATE_PREVIOUS_PAGE_URL, AML_REMOVAL_BODY, AML_REMOVAL_INDEX } from "../../../common/__utils/constants";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { soleTraderNameDetails } from "model/SoleTraderNameDetails";
 
@@ -21,6 +21,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         const session: Session = req.session as any as Session;
         const acspUpdatedFullProfile: AcspFullProfile = session.getExtraData(ACSP_DETAILS_UPDATED)!;
         const updateInProgress: soleTraderNameDetails | undefined = session.getExtraData(ACSP_DETAILS_UPDATE_IN_PROGRESS);
+
         const payload = updateInProgress
             ? {
                 "first-name": updateInProgress.forename,
@@ -32,6 +33,12 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
                 "middle-names": acspUpdatedFullProfile.soleTraderDetails?.otherForenames,
                 "last-name": acspUpdatedFullProfile.soleTraderDetails?.surname
             };
+
+        // Delete the temporary AML removal index and body from the session
+        // Prevents the removed AML details from clearing on Your Updates view
+        session.deleteExtraData(AML_REMOVAL_INDEX);
+        session.deleteExtraData(AML_REMOVAL_BODY);
+
         res.render(config.WHAT_IS_YOUR_NAME, {
             ...getLocaleInfo(locales, lang),
             currentUrl: UPDATE_ACSP_DETAILS_BASE_URL + UPDATE_ACSP_WHAT_IS_YOUR_NAME,

--- a/test/src/controllers/updateAcspDetails/addAmlSupervisorController.test.ts
+++ b/test/src/controllers/updateAcspDetails/addAmlSupervisorController.test.ts
@@ -22,7 +22,8 @@ describe("GET" + UPDATE_ADD_AML_SUPERVISOR, () => {
 
     beforeEach(() => {
         session = {
-            getExtraData: jest.fn()
+            getExtraData: jest.fn(),
+            deleteExtraData: jest.fn()
         };
 
         req = {
@@ -77,7 +78,8 @@ describe("addAmlSupervisorController - get", () => {
     beforeEach(() => {
         sessionMock = {
             getExtraData: jest.fn(),
-            setExtraData: jest.fn()
+            setExtraData: jest.fn(),
+            deleteExtraData: jest.fn()
         };
 
         req = {

--- a/test/src/controllers/updateAcspDetails/businessAddressAutoLookupController.test.ts
+++ b/test/src/controllers/updateAcspDetails/businessAddressAutoLookupController.test.ts
@@ -35,7 +35,8 @@ describe("Business address auto look up tests", () => {
     beforeEach(() => {
         sessionMock = {
             getExtraData: jest.fn(),
-            setExtraData: jest.fn()
+            setExtraData: jest.fn(),
+            deleteExtraData: jest.fn()
         };
 
         req = {

--- a/test/src/controllers/updateAcspDetails/correspondenceAddressAutoLookupController.test.ts
+++ b/test/src/controllers/updateAcspDetails/correspondenceAddressAutoLookupController.test.ts
@@ -35,7 +35,8 @@ describe("GET" + UPDATE_CORRESPONDENCE_ADDRESS_LOOKUP, () => {
     beforeEach(() => {
         sessionMock = {
             getExtraData: jest.fn(),
-            setExtraData: jest.fn()
+            setExtraData: jest.fn(),
+            deleteExtraData: jest.fn()
         };
 
         req = {

--- a/test/src/controllers/updateAcspDetails/whatIsTheBusinessNameController.test.ts
+++ b/test/src/controllers/updateAcspDetails/whatIsTheBusinessNameController.test.ts
@@ -89,7 +89,8 @@ describe("GET" + UPDATE_WHAT_IS_THE_COMPANY_NAME, () => {
     it("should return status 200 and render page as a limited company", async () => {
         mocks.mockSessionMiddleware.mockImplementation((req, res, next) => {
             req.session = {
-                getExtraData: jest.fn().mockReturnValue(mockLimitedAcspFullProfile)
+                getExtraData: jest.fn().mockReturnValue(mockLimitedAcspFullProfile),
+                deleteExtraData: jest.fn()
             };
             next();
         });

--- a/test/src/controllers/updateAcspDetails/whatIsYourNameController.test.ts
+++ b/test/src/controllers/updateAcspDetails/whatIsYourNameController.test.ts
@@ -29,7 +29,8 @@ describe("GET" + UPDATE_ACSP_WHAT_IS_YOUR_NAME, () => {
     beforeEach(() => {
         sessionMock = {
             getExtraData: jest.fn(),
-            setExtraData: jest.fn()
+            setExtraData: jest.fn(),
+            deleteExtraData: jest.fn()
         };
 
         req = {

--- a/test/src/controllers/updateAcspDetails/whereDoYouLiveController.test.ts
+++ b/test/src/controllers/updateAcspDetails/whereDoYouLiveController.test.ts
@@ -30,7 +30,8 @@ describe("GET" + UPDATE_ACSP_WHAT_IS_YOUR_NAME, () => {
     beforeEach(() => {
         sessionMock = {
             getExtraData: jest.fn(),
-            setExtraData: jest.fn()
+            setExtraData: jest.fn(),
+            deleteExtraData: jest.fn()
         };
 
         req = {


### PR DESCRIPTION
Fix for bug:
[IDVA5-2341](https://companieshouse.atlassian.net/browse/IDVA5-2341)

- When making a update to any field (i.e. Business name) ->  removing an existing AML body then editing the previously updated field from your updates (i.e. Business name). This caused the removed AML body details to be cleared from 'Your updates' screen.
- The above bug was occurring as we had not cleared the 2 temp session variables AML_REMOVAL_INDEX, AML_REMOVAL_BODY when choosing to edit the updated field.
- Have added the deletion of these session variables to each controller screen that is called when we choose to edit an existing update to prevent the removed AML details from clearing when returning to 'Your updates'.
- Updated unit tests

[IDVA5-2341]: https://companieshouse.atlassian.net/browse/IDVA5-2341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ