### PR TITLE
IDVA5-2197 Register an ACSP - Allow Previously Closed/ Ceased ACSPs to Access Registration Service -changing the api sdk node version in package.json, it is not picking up the latest despite configured to be as

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.271",
+        "@companieshouse/api-sdk-node": "^2.0.272",
         "@companieshouse/ch-node-utils": "^1.3.24",
         "@companieshouse/node-session-handler": "^5.1.4",
         "@companieshouse/structured-logging-node": "^1.0.8",
@@ -603,9 +603,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.271",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.271.tgz",
-      "integrity": "sha512-13v8Twt8Utdfsgl765itshp9x+YvDF4XR/cYcObMCOy9SgXgcsa6c1lsyWv2dE0c6MCGIUS9zKdnDMiuSHcmmA==",
+      "version": "2.0.272",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.272.tgz",
+      "integrity": "sha512-jxykRSloFoYb0G0M1HfbAsnFeTIBGkLY3uXGgFxYZg82/tEXXetypBABCw5mOcoI0HdlzbF0TRfbFK5oZJjssQ==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.271",
+    "@companieshouse/api-sdk-node": "^2.0.272",
     "@companieshouse/ch-node-utils": "^1.3.24",
     "@companieshouse/node-session-handler": "^5.1.4",
     "@companieshouse/structured-logging-node": "^1.0.8",


### PR DESCRIPTION
Changing the api sdk node version in package.json, it is not picking up the latest despite configured to be as