### PR TITLE
Removing error text from start of events

### DIFF
--- a/src/views/partials/piwik.njk
+++ b/src/views/partials/piwik.njk
@@ -36,6 +36,13 @@
     var ignoreRadioButtonForThisPage = false;
     
     $(function() {
+
+        if (eventCategory.startsWith("Error: ")){
+          eventCategory = eventCategory.replace("Error: ", "")
+        }
+        if (eventCategory.startsWith("Gwall: ")){
+          eventCategory = eventCategory.replace("Gwall: ", "")
+        }
           //  On the button click the button details are recorded.
           $("button").click(function() {
             eventNameBtn = $(this).text().toUpperCase();


### PR DESCRIPTION
Ticket [IDVA5-1777](https://companieshouse.atlassian.net/browse/IDVA5-1777)

Removing the 'Error: ' & 'Gwall: ' text from the start of events that occur on pages with previous errors