### PR TITLE
Fix: Allow feedback links to open without being blocked by kickout screen

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -104,7 +104,7 @@ app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspBaseAuthenticationMiddleware);
 app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateAcspUserIsPartOfAcspMiddleware);
 app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateAcspAuthMiddleware);
 app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, getUpdateAcspProfileMiddleware);
-app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateVariablesMiddleware);
+app.use(UPDATE_ACSP_DETAILS_BASE_URL, updateVariablesMiddleware);
 app.use(`^${UPDATE_ACSP_DETAILS_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, updateAcspIsOwnerMiddleware);
 
 // Close ACSP middleware
@@ -112,7 +112,7 @@ app.use(CLOSE_ACSP_BASE_URL, closeAcspBaseAuthenticationMiddleware);
 app.use(CLOSE_ACSP_BASE_URL, closeAcspUserIsPartOfAcspMiddleware);
 app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, closeAcspAuthMiddleware);
 app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, getAcspProfileMiddleware);
-app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, closeVariablesMiddleware);
+app.use(CLOSE_ACSP_BASE_URL, closeVariablesMiddleware);
 app.use(`^${CLOSE_ACSP_BASE_URL}(?!${MUST_BE_AUTHORISED_AGENT})`, closeAcspIsOwnerMiddleware);
 
 // Company Auth redirect


### PR DESCRIPTION
**Short description outlining key changes/additions**
I have removed the REGEX that was stopping _updateVariablesMiddleware_ and _closeVariablesMiddleware_ from running whenever a user was being kicked out for not being a part of an ACSP. (I had blocked a few of the middlewares to avoid errors but this middleware is ok to run when a user is not a part of an ACSP).
This should now allow the feedback links to be set correctly for _Update an ACSP_ and _Close an ACSP_.

**JIRA Ticket**

https://companieshouse.atlassian.net/browse/IDVA5-2031

**Type of change**
- [ ] Bug fix
- [x]  New feature
- [ ]  Breaking change
- [ ]  Infrastructure change

**Pull request checklist**
- [x]  I have added unit tests for new code that I have added
- [x]  I have added/updated functional tests where appropriate

**An exhaustive list of peer review checks can be read** [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)