### PR TITLE
Apply govuk-tag--blue CSS to beta tag

### DIFF
--- a/src/views/partials/phase_banner.njk
+++ b/src/views/partials/phase_banner.njk
@@ -1,6 +1,6 @@
 <div class="govuk-phase-banner" role="region" aria-label="This is a new service">
   <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag govuk-phase-banner__content__tag">
+    <strong class="govuk-tag govuk-tag--blue govuk-phase-banner__content__tag">
       beta
     </strong>
     <span class="govuk-phase-banner__text">


### PR DESCRIPTION
**Short description outlining key changes/additions**
In order to make the BETA tag more comfortable to read for low vision users, the CSS has been set to ensure the tag writing is dark blue rather than white (See comments for comparison)

**JIRA Ticket**

https://companieshouse.atlassian.net/browse/IDVA5-1908

**Type of change**
- [ ] Bug fix
- [x]  New feature
- [ ]  Breaking change
- [ ]  Infrastructure change

**Pull request checklist**
- [x]  I have added unit tests for new code that I have added
- [x]  I have added/updated functional tests where appropriate

**An exhaustive list of peer review checks can be read** [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)