### PR TITLE
Added a guard before GET to ensure acsp.id/transaction id is availabl…

### DIFF
--- a/src/services/acspRegistrationService.ts
+++ b/src/services/acspRegistrationService.ts
@@ -16,6 +16,16 @@ import { HttpResponse } from "@companieshouse/api-sdk-node/dist/http";
  */
 
 export const getAcspRegistration = async (session: Session, transactionId:string, acspApplicationId: string): Promise<AcspData> => {
+    logger.info(`GET - Retrieving acsp registration for transaction ID: ${transactionId} and application ID: ${acspApplicationId}`);
+    if (!transactionId) {
+        logger.error(`acsp registration GET request failed - no transaction ID provided for transaction ID: ${transactionId}`);
+        return Promise.reject(new Error("No transaction ID provided"));
+    }
+    if (!acspApplicationId) {
+        logger.error(`acsp registration GET request failed - no application ID provided for application ID: ${acspApplicationId}`);
+        return Promise.reject(new Error("No application  ID provided"));
+    }
+
     const apiClient: ApiClient = createPublicOAuthApiClient(session);
 
     logger.debug(`Retrieving acsp registration details for application ID: ${acspApplicationId}`);

--- a/test/src/services/acspRegistrationService.test.ts
+++ b/test/src/services/acspRegistrationService.test.ts
@@ -232,4 +232,13 @@ describe("acsp service tests", () => {
             await expect(deleteAcspApplication(session, TRANSACTION_ID, EMAIL_ID)).rejects.toEqual({ httpStatusCode: StatusCodes.NOT_FOUND });
         });
     });
+    describe("getAcspRegistration additional validation tests", () => {
+        it("Should throw an error when no transaction ID is provided", async () => {
+            await expect(getAcspRegistration(session, "", EMAIL_ID)).rejects.toThrow("No transaction ID provided");
+        });
+
+        it("Should throw an error when no application ID is provided", async () => {
+            await expect(getAcspRegistration(session, TRANSACTION_ID, "")).rejects.toThrow("No application  ID provided");
+        });
+    });
 });


### PR DESCRIPTION
TICKET - https://companieshouse.atlassian.net/browse/IDVA5-2208?atlOrigin=eyJpIjoiNTE3ZmRkZTRlMGI5NDZlZThiMGZkMGQ0NzQxMmRmNTYiLCJwIjoiaiJ9

Root cause
The GET was trigged too early before the PUT(create) request completed and acsp.id was assigned. This resulted in undefined IDs (transactionId, acsp.id) causing failing. The system attempting to GET ACSP registration data before the record was created in MongoDB. This lead to a 500 error and log message .

```
[31m2025-04-11T11:26:49.650+00:00 error: Http status code 500 and error {

    "httpStatusCode": 500,

    "errors": [

        {

            "message": "failed to execute http request"

        }

    ]

} - Failed to get acsp registration for application ID: undefined[39m

[31m2025-04-11T11:26:49.650+00:00 error: undefined - appError: undefined - undefined[39m
```
`error: Error retrieving transaction undefined
`
Fix
Added a guard before GET to ensure transactionId and acsp.id is available before attempting to fetch ACSP registration data

Outcome
The GET is not called if transactionId and acsp.id are undefined. 