### PR TITLE
Added check for saved applications for Other Business Type screen

### DIFF
--- a/src/common/__utils/constants.ts
+++ b/src/common/__utils/constants.ts
@@ -58,3 +58,4 @@ export const REGISTRATION = "registration";
 export const UPDATE = "update";
 export const SERVICE_ADDRESS = "serviceAddress";
 export const REGISTERED_OFFICE_ADDRESS = "registeredOfficeAddress";
+export const TYPE_OF_BUSINESS_SELECTED = "typeOfBusinessSelected";

--- a/src/controllers/features/common/typeOfBusinessController.ts
+++ b/src/controllers/features/common/typeOfBusinessController.ts
@@ -4,7 +4,7 @@ import * as config from "../../../config";
 import { formatValidationError, getPageProperties } from "../../../validation/validation";
 import { selectLang, addLangToUrl, getLocalesService, getLocaleInfo } from "../../../utils/localise";
 import { TYPE_OF_BUSINESS, OTHER_TYPE_OF_BUSINESS, LIMITED_BUSINESS_MUSTBE_AML_REGISTERED_KICKOUT, SOLE_TRADER_WHAT_IS_YOUR_ROLE, BASE_URL, LIMITED_WHAT_IS_THE_COMPANY_NUMBER, UNINCORPORATED_NAME_REGISTERED_WITH_AML } from "../../../types/pageURL";
-import { SUBMISSION_ID, POST_ACSP_REGISTRATION_DETAILS_ERROR, GET_ACSP_REGISTRATION_DETAILS_ERROR, USER_DATA } from "../../../common/__utils/constants";
+import { SUBMISSION_ID, POST_ACSP_REGISTRATION_DETAILS_ERROR, GET_ACSP_REGISTRATION_DETAILS_ERROR, USER_DATA, TYPE_OF_BUSINESS_SELECTED } from "../../../common/__utils/constants";
 import logger from "../../../utils/logger";
 import { Session } from "@companieshouse/node-session-handler";
 import { saveDataInSession } from "../../../common/__utils/sessionHelper";
@@ -115,6 +115,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
                 break;
             }
         } else {
+            session.setExtraData(TYPE_OF_BUSINESS_SELECTED, true);
             res.redirect(addLangToUrl(BASE_URL + OTHER_TYPE_OF_BUSINESS, lang));
         }
     } catch (err) {


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2352

The same check which was added to Type Of Business screen, to check for saved applications and redirect user accordingly if they access the url directly, has now been added to the Other Type Of Business screen as we also create a new transaction  here.

I am using the flag TYPE_OF_BUSINESS_SELECTED which is set on Type Of Business screen to determine whether to redirect the user or not, since in some cases the redirect will be to the Type Of Business screen again creating a loop. Once they continue past the Other Type Of Business screen this is deleted from the session.