### PR TITLE
IDVA5-2397 Register an ACSP - Allow Previously Registered ACSP Member to Register a New ACSP

### DIFF
--- a/src/services/checkSavedApplicationService.ts
+++ b/src/services/checkSavedApplicationService.ts
@@ -19,7 +19,7 @@ export const getRedirectionUrl = async (savedApplications: Resource<TransactionL
         const loggedInAcspNumber: string = getLoggedInAcspNumber(session);
 
         let url = "";
-        if (!transactions.length && !loggedInAcspNumber) {
+        if (!transactions.length) {
             logger.debug("application is rejected");
             url = BASE_URL + TYPE_OF_BUSINESS;
         } else if (transactions[0].status !== CLOSED) {

--- a/src/services/checkSavedApplicationService.ts
+++ b/src/services/checkSavedApplicationService.ts
@@ -28,9 +28,7 @@ export const getRedirectionUrl = async (savedApplications: Resource<TransactionL
             session.setExtraData(SUBMISSION_ID, transactions[0].id);
             url = BASE_URL + SAVED_APPLICATION;
         } else if (transactions[0].filings![transactions[0].id + "-1"]?.status === ACCEPTED) {
-            const acspNumber = transactions[0].filings![transactions[0].id + "-1"].companyNumber;
-            const acspDetails = await getAcspFullProfile(acspNumber!);
-            if (acspDetails.status === CEASED && !loggedInAcspNumber) {
+            if (!loggedInAcspNumber) {
                 logger.debug("application is ceased and can register again");
                 url = BASE_URL + TYPE_OF_BUSINESS;
             } else {

--- a/test/src/services/checkSavedApplicationService.test.ts
+++ b/test/src/services/checkSavedApplicationService.test.ts
@@ -80,8 +80,9 @@ describe("check saved application service tests", () => {
         expect(redirectionUrl).toEqual(url);
     });
 
-    it("Should redirect to TYPE_OF_BUSINESS when application filing is accepted and acsp status is CEASED", async () => {
+    it("Should redirect to TYPE_OF_BUSINESS when application filing is accepted, acsp status is CEASED, and loggedInAcspNumber is falsy", async () => {
         mockGetAcspFullProfile.mockResolvedValueOnce({ status: "ceased" });
+        jest.spyOn(require("../../../src/common/__utils/session"), "getLoggedInAcspNumber").mockReturnValue(undefined);
         const redirectionUrl = await getRedirectionUrl(hasApprovedApplication, session);
         url = BASE_URL + TYPE_OF_BUSINESS;
         expect(redirectionUrl).toEqual(url);

--- a/test/src/services/checkSavedApplicationService.test.ts
+++ b/test/src/services/checkSavedApplicationService.test.ts
@@ -74,39 +74,37 @@ describe("check saved application service tests", () => {
         res = createResponse();
     });
 
+    it("Should redirect to correct url when the application is in rejected", async () => {
+        mockDeleteSavedApplication.mockResolvedValueOnce("200");
+        const redirectionUrl = await getRedirectionUrl(hasRejectedApplication, session);
+        url = BASE_URL + TYPE_OF_BUSINESS;
+        expect(redirectionUrl).toEqual(url);
+    });
+
     it("Should redirect to correct url when the application is open", async () => {
         const redirectionUrl = await getRedirectionUrl(hasOpenApplication, session);
         url = BASE_URL + SAVED_APPLICATION;
         expect(redirectionUrl).toEqual(url);
     });
 
-    it("Should redirect to TYPE_OF_BUSINESS when application filing is accepted, acsp status is CEASED, and loggedInAcspNumber is falsy", async () => {
-        mockGetAcspFullProfile.mockResolvedValueOnce({ status: "ceased" });
+    it("Should redirect to TYPE_OF_BUSINESS when application filing is accepted loggedInAcspNumber is falsy", async () => {
         jest.spyOn(require("../../../src/common/__utils/session"), "getLoggedInAcspNumber").mockReturnValue(undefined);
         const redirectionUrl = await getRedirectionUrl(hasApprovedApplication, session);
         url = BASE_URL + TYPE_OF_BUSINESS;
         expect(redirectionUrl).toEqual(url);
-        expect(mockGetAcspFullProfile).toHaveBeenCalledWith("AP123456");
     });
 
-    it("Should redirect to CANNOT_REGISTER_AGAIN  when application filing is accepted and acsp status is not CEASED", async () => {
+    it("Should redirect to CANNOT_REGISTER_AGAIN  when application filing is accepted and has a defined loggedInAcspNumber", async () => {
         mockGetAcspFullProfile.mockResolvedValueOnce({ status: "active" });
+        jest.spyOn(require("../../../src/common/__utils/session"), "getLoggedInAcspNumber").mockReturnValue("AP123456");
         const redirectionUrl = await getRedirectionUrl(hasApprovedApplication, session);
         url = BASE_URL + CANNOT_REGISTER_AGAIN;
         expect(redirectionUrl).toEqual(url);
-        expect(mockGetAcspFullProfile).toHaveBeenCalledWith("AP123456");
     });
 
     it("Should redirect to correct url when the application is in progress", async () => {
         const redirectionUrl = await getRedirectionUrl(hasApplicationInProgress, session);
         url = BASE_URL + CANNOT_SUBMIT_ANOTHER_APPLICATION;
-        expect(redirectionUrl).toEqual(url);
-    });
-
-    it("Should redirect to correct url when the application is in rejected", async () => {
-        mockDeleteSavedApplication.mockResolvedValueOnce("200");
-        const redirectionUrl = await getRedirectionUrl(hasRejectedApplication, session);
-        url = BASE_URL + TYPE_OF_BUSINESS;
         expect(redirectionUrl).toEqual(url);
     });
 });


### PR DESCRIPTION
IDVA5-2397 Register an ACSP - Allow Previously Registered ACSP Member to Register a New ACSP
-- Modified the logic to check the existence of the acsp number from the signed in details
-- Added the tests

https://companieshouse.atlassian.net/browse/IDVA5-2397