### PR TITLE
IDVA5-2397 Register an ACSP - Allow Previously Registered ACSP Member to Register a New ACSP - bringing the check back for the no transaction acsp profile check

### DIFF
--- a/src/services/checkSavedApplicationService.ts
+++ b/src/services/checkSavedApplicationService.ts
@@ -19,7 +19,7 @@ export const getRedirectionUrl = async (savedApplications: Resource<TransactionL
         const loggedInAcspNumber: string = getLoggedInAcspNumber(session);
 
         let url = "";
-        if (!transactions.length) {
+        if (!transactions.length && !loggedInAcspNumber) {
             logger.debug("application is rejected");
             url = BASE_URL + TYPE_OF_BUSINESS;
         } else if (transactions[0].status !== CLOSED) {


### PR DESCRIPTION
IDVA5-2397 Register an ACSP - Allow Previously Registered ACSP Member to Register a New ACSP

-- Added back the check for the newly added user(s), who WILL NOT have a transaction but WILL have a acsp profile associated to them


https://companieshouse.atlassian.net/browse/IDVA5-2397
