### PR TITLE
Updating allowed character set for sole trader unincorp name fields

### DIFF
--- a/locales/cy/what-is-your-name.json
+++ b/locales/cy/what-is-your-name.json
@@ -6,9 +6,9 @@
     
     "error-enterFirstName" : "Cofnodwch eich enw cyntaf",
     "error-enterLastName": "Cofnodwch eich cyfenw",
-    "error-invalidFirstNameFormat": "Rhaid i'r enw cyntaf gynnwys llythrennau a i z yn unig, a nodau arbennig cyffredin fel cysylltnodau, bylchau a chollnodau",
-    "error-invalidMiddleNameFormat": "Rhaid i'r enw neu enwau canol gynnwys llythrennau a i z yn unig, a nodau arbennig cyffredin fel cysylltnodau, bylchau a chollnodau",
-    "error-invalidLastNameFormat": "Rhaid i'r cyfenw gynnwys llythrennau a i z yn unig, a nodau arbennig cyffredin fel cysylltnodau, bylchau a chollnodau",
+    "error-invalidFirstNameFormat": "[CY] First name must only include letters a to z, and common special characters",
+    "error-invalidMiddleNameFormat": "[CY] Middle name or names must only include letters a to z, and common special characters",
+    "error-invalidLastNameFormat": "[CY] Last name must only include letters a to z, and common special characters",
     "error-invalidFirstNameLength": "Rhaid i'r enw cyntaf fod yn 50 nod neu lai",
     "error-invalidMiddleNameLength": "Rhaid i'r enwau canol fod yn 50 nod neu lai",
     "error-invalidLastNameLength": "Rhaid i'r cyfenw fod yn 160 nod neu lai",

--- a/locales/en/what-is-your-name.json
+++ b/locales/en/what-is-your-name.json
@@ -6,9 +6,9 @@
     
     "error-enterFirstName" : "Enter your first name",
     "error-enterLastName": "Enter your last name",
-    "error-invalidFirstNameFormat": "First name must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes",
-    "error-invalidMiddleNameFormat": "Middle name or names must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes",
-    "error-invalidLastNameFormat": "Last name must only include letters a to z, and common special characters such as hyphens, spaces and apostrophes",
+    "error-invalidFirstNameFormat": "First name must only include letters a to z, and common special characters",
+    "error-invalidMiddleNameFormat": "Middle name or names must only include letters a to z, and common special characters",
+    "error-invalidLastNameFormat": "Last name must only include letters a to z, and common special characters",
     "error-invalidFirstNameLength": "First name must be 50 characters or less",
     "error-invalidMiddleNameLength": "Middle names must be 50 characters or less",
     "error-invalidLastNameLength": "Last name must be 160 characters or less",

--- a/src/validation/regexParts.ts
+++ b/src/validation/regexParts.ts
@@ -5,3 +5,6 @@ export const PUNCTUATION = "\\p{P}";
 export const SYMBOLS = "\\p{S}";
 export const WHITESPACE = "\\s";
 export const BUSINESS_NAME_EXCLUDED_CHARS = "\\^|~Ǻǻƒ";
+
+// Allowed characters for name and address fields
+export const ALLOWED_TEXT_CHARS = "A-ZŒÆæÀàÈèÌìÒòÙùẀẁỲỳÁáćǼǽÉéģÍíĹĺŃńÓóŔŕŚśÚúẂẃÝýŹźÂâĉÊêĜĝĤĥÎîĴĵÔôŜŝÛûŴŵŶŷÃãĨĩÑñÕõŨũÄäËëÏïÖöÜüẄẅŸÿÅåŮůa-zœçŊŋŞşŢţĢĶķĻļŅņŖŗĐĦħŦŧǾǿ'\\s–-";

--- a/src/validation/whatIsYourName.ts
+++ b/src/validation/whatIsYourName.ts
@@ -3,8 +3,9 @@ import { ACSP_DETAILS } from "../common/__utils/constants";
 import { body } from "express-validator";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
 import { trimAndLowercaseString } from "../services/common";
+import { ALLOWED_TEXT_CHARS } from "./regexParts";
 
-const nameFormat: RegExp = /^[a-zA-Z \-']*$/ig;
+const nameFormat = new RegExp(`^[${ALLOWED_TEXT_CHARS}]*$`);
 
 export const nameValidator = [
     body("first-name").trim().notEmpty().withMessage("enterFirstName").bail().matches(nameFormat).withMessage("invalidFirstNameFormat").bail().isLength({ max: 50 })

--- a/test/src/controllers/soleTrader/nameController.test.ts
+++ b/test/src/controllers/soleTrader/nameController.test.ts
@@ -69,10 +69,50 @@ describe("POST" + SOLE_TRADER_WHAT_IS_YOUR_NAME, () => {
         expect(mocks.mockAuthenticationMiddlewareForSoleTrader).toHaveBeenCalled();
     });
 
+    it("should accept names with allowed special characters", async () => {
+        mockGetAcspRegistration.mockResolvedValueOnce(acspData);
+        const res = await router.post(BASE_URL + SOLE_TRADER_WHAT_IS_YOUR_NAME)
+            .send({
+                "first-name": "John-Paul",
+                "middle-names": "O'Connor",
+                "last-name": "Smith–Jones"
+            });
+        expect(res.status).toBe(302);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddlewareForSoleTrader).toHaveBeenCalled();
+    });
+
+    it("should accept name with various allowed characters", async () => {
+        mockGetAcspRegistration.mockResolvedValueOnce(acspData);
+        const res = await router.post(BASE_URL + SOLE_TRADER_WHAT_IS_YOUR_NAME)
+            .send({
+                "first-name": "Jõsé-María",
+                "middle-names": "Œdïpǿs",
+                "last-name": "Sņîţǽh"
+            });
+        expect(res.status).toBe(302);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddlewareForSoleTrader).toHaveBeenCalled();
+    });
+
     // Test for incorrect form details entered, will return 400.
     it("should return status 400 after incorrect data entered", async () => {
         const res = await router.post(BASE_URL + SOLE_TRADER_WHAT_IS_YOUR_NAME);
         expect(res.status).toBe(400);
+    });
+
+    it("should return status 400 for names containing invalid characters", async () => {
+        mockGetAcspRegistration.mockResolvedValueOnce(acspData);
+        const res = await router.post(BASE_URL + SOLE_TRADER_WHAT_IS_YOUR_NAME)
+            .send({
+                "first-name": "John123",
+                "middle-names": "Test%Middle",
+                "last-name": "$Doe"
+            });
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("First name must only include letters a to z, and common special characters");
+        expect(res.text).toContain("Middle name or names must only include letters a to z, and common special characters");
+        expect(res.text).toContain("Last name must only include letters a to z, and common special characters");
     });
 
     it("should show the error page if an error occurs during PUT request", async () => {

--- a/test/src/controllers/unincorporated/whatisYourNameController.test.ts
+++ b/test/src/controllers/unincorporated/whatisYourNameController.test.ts
@@ -47,6 +47,17 @@ describe("POST" + UNINCORPORATED_WHAT_IS_YOUR_NAME, () => {
         expect(response.header.location).toBe(BASE_URL + UNINCORPORATED_WHAT_IS_THE_BUSINESS_NAME + "?lang=en");
     });
 
+    it("should accept name with various allowed characters", async () => {
+        const formData = {
+            "first-name": "Jõsé-María",
+            "middle-names": "Œd'ïpǿs",
+            "last-name": "Sņîţǽh"
+        };
+        const response = await router.post(BASE_URL + UNINCORPORATED_WHAT_IS_YOUR_NAME).send(formData);
+        expect(response.status).toBe(302);
+        expect(response.header.location).toBe(BASE_URL + UNINCORPORATED_WHAT_IS_THE_BUSINESS_NAME + "?lang=en");
+    });
+
     it("should return status 400 for no data entered", async () => {
         const formData = {
             "first-name": "",
@@ -82,6 +93,20 @@ describe("POST" + UNINCORPORATED_WHAT_IS_YOUR_NAME, () => {
         const response = await router.post(BASE_URL + UNINCORPORATED_WHAT_IS_YOUR_NAME).send(formData);
         expect(response.status).toBe(400);
         expect(response.text).toContain("Enter your last name");
+    });
+
+    it("should return status 400 for names containing invalid characters", async () => {
+        const formData = {
+            "first-name": "John£123",
+            "middle-names": "Test,Middle",
+            "last-name": "Őzols"
+        };
+
+        const response = await router.post(BASE_URL + UNINCORPORATED_WHAT_IS_YOUR_NAME).send(formData);
+        expect(response.status).toBe(400);
+        expect(response.text).toContain("First name must only include letters a to z, and common special characters");
+        expect(response.text).toContain("Middle name or names must only include letters a to z, and common special characters");
+        expect(response.text).toContain("Last name must only include letters a to z, and common special characters");
     });
 
     it("should show the error page if an error occurs during PUT request", async () => {


### PR DESCRIPTION
Ticket:
[IDVA5-2426](https://companieshouse.atlassian.net/browse/IDVA5-2426?atlOrigin=eyJpIjoiODQwMjc0YTQ2YWFhNDYyMzk2NTE0ZGMxMDI0YmJkNzkiLCJwIjoiaiJ9)

- Updating regex pattern for allowed special characters in sole traders and unincorporated first/middle/last name fields
- Added unit tests

[IDVA5-2426]: https://companieshouse.atlassian.net/browse/IDVA5-2426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ