### PR TITLE
Escaping business and company name values to allow angle bracket display

### DIFF
--- a/src/views/common/check-aml-details/check-aml-details.njk
+++ b/src/views/common/check-aml-details/check-aml-details.njk
@@ -17,9 +17,9 @@
         <label class="govuk-label govuk-label--l">{{ i18n.checkAmlDetailsTitle }}</label>
     </h1>
     {% if typeOfBusiness === "SOLE_TRADER" %}
-       <p class="govuk-body">{{ i18n.checkAmlDetailsText1 }} {{ firstName }} {{ lastName }} . {{ i18n.checkAmlDetailsText2 }}</p>
+       <p class="govuk-body">{{ i18n.checkAmlDetailsText1 }} {{ firstName }} {{ lastName }}. {{ i18n.checkAmlDetailsText2 }}</p>
     {% else %} 
-       <p class="govuk-body">{{ i18n.checkAmlDetailsText1 }} {{ businessName }} . {{ i18n.checkAmlDetailsText2 }}</p>
+       <p class="govuk-body">{{ i18n.checkAmlDetailsText1 }} {{ businessName }}. {{ i18n.checkAmlDetailsText2 }}</p>
     {% endif %}
     <p class="govuk-body">{{ i18n.checkAmlDetailsText3 }}</p>
 

--- a/src/views/common/what-is-your-role/what-is-your-role.njk
+++ b/src/views/common/what-is-your-role/what-is-your-role.njk
@@ -23,7 +23,7 @@
                 items: [
                     {
                       value: "MEMBER_OF_PARTNERSHIP",
-                      html: "<span id='partial_obliteration'>" + i18n.member + "</span>" + unincorporatedBusinessName
+                      html: "<span id='partial_obliteration'>" + i18n.member + "</span>" + (unincorporatedBusinessName | escape)
                     } if acspType == "PARTNERSHIP",
 
                     {
@@ -34,36 +34,36 @@
 
                     {
                       value: "MEMBER_OF_GOVERNING_BODY",
-                      html: "<span id='partial_obliteration'>" + i18n.memberOfGoverningBody + "</span>" + unincorporatedBusinessName,
+                      html: "<span id='partial_obliteration'>" + i18n.memberOfGoverningBody + "</span>" + (unincorporatedBusinessName | escape),
                       id: "WhatIsYourRole"
                     } if acspType == "UNINCORPORATED",
 
                     {
                       value: "EQUIVALENT_OF_DIRECTOR",
-                      html: "<span id='partial_obliteration'>" + i18n.equivalentToDirector + "</span>" + unincorporatedBusinessName + "</span>",
+                      html: "<span id='partial_obliteration'>" + i18n.equivalentToDirector + "</span>" + (unincorporatedBusinessName | escape) + "</span>",
                       id: "WhatIsYourRole"
                     } if acspType == "CORPORATE_BODY",
 
                     {
                       value: "MEMBER_OF_ENTITY",
-                      html: "<span id='partial_obliteration'>" + i18n.member + "</span>" + unincorporatedBusinessName + "</span>"
+                      html: "<span id='partial_obliteration'>" + i18n.member + "</span>" + (unincorporatedBusinessName | escape) + "</span>"
                     } if acspType == "UNINCORPORATED" or acspType == "CORPORATE_BODY",
 
                     {
                       value: "DIRECTOR",
-                      html: "<span id='partial_obliteration'>" + i18n.director + "</span>" + company.companyName + " (" + company.companyNumber + ")",
+                      html: "<span id='partial_obliteration'>" + i18n.director + "</span>" + (company.companyName | escape) + " (" + company.companyNumber + ")",
                       id: "WhatIsYourRole"
                     } if acspType == "LC",
 
                     {
                       value: "MEMBER_OF_LLP",
-                      html: "<span id='partial_obliteration'>" + i18n.member + "</span>" + company.companyName + " (" + company.companyNumber + ")",
+                      html: "<span id='partial_obliteration'>" + i18n.member + "</span>" + (company.companyName | escape) + " (" + company.companyNumber + ")",
                       id: "WhatIsYourRole"
                     } if acspType == "LLP",
 
                     {
                       value: "GENERAL_PARTNER",
-                      html: "<span id='partial_obliteration'>" + i18n.generalPartner + "</span>" + unincorporatedBusinessName,
+                      html: "<span id='partial_obliteration'>" + i18n.generalPartner + "</span>" + (unincorporatedBusinessName | escape),
                       id: "WhatIsYourRole"
                     } if acspType == "LP",
 

--- a/src/views/features/update-acsp-details/your-updates/your-updates.njk
+++ b/src/views/features/update-acsp-details/your-updates/your-updates.njk
@@ -85,7 +85,7 @@
       classes: "govuk-!-width-one-third"
     },
     value: {
-      html: yourDetails.businessName.value + "<p class='govuk-body govuk-!-static-margin-top-5'> Changed on " + yourDetails.businessName.changedDate + "</p>",
+      html: (yourDetails.businessName.value | escape) + "<p class='govuk-body govuk-!-static-margin-top-5'> Changed on " + yourDetails.businessName.changedDate + "</p>",
       classes: "govuk-!-width-one-third"
     },
     actions: {

--- a/src/views/partials/update-your-details/limited-answers.njk
+++ b/src/views/partials/update-your-details/limited-answers.njk
@@ -96,7 +96,7 @@
           classes: "govuk-!-width-one-third"
         },
         value: {
-          html: profileDetailsUpdated.businessName + updateStatusTextForBusinessName,
+          html: (profileDetailsUpdated.businessName | escape) + updateStatusTextForBusinessName,
           classes: "govuk-!-width-one-third"
         },
         actions: {

--- a/src/views/partials/update-your-details/sole-trader-answers.njk
+++ b/src/views/partials/update-your-details/sole-trader-answers.njk
@@ -146,7 +146,7 @@
           classes: "govuk-!-width-one-third"
         },
         value: {
-          html: profileDetailsUpdated.businessName+updateStatusTextForBusinessName,
+          html: (profileDetailsUpdated.businessName | escape)+updateStatusTextForBusinessName,
           classes: "govuk-!-width-one-third"
         },
         actions: {

--- a/src/views/partials/update-your-details/unincorporated-answers.njk
+++ b/src/views/partials/update-your-details/unincorporated-answers.njk
@@ -133,7 +133,7 @@
           classes: "govuk-!-width-one-third"
         },
         value: {
-          html: profileDetailsUpdated.businessName + updateStatusTextForBusinessName,
+          html: (profileDetailsUpdated.businessName | escape) + updateStatusTextForBusinessName,
           classes: "govuk-!-width-one-third"
         },
         actions: {


### PR DESCRIPTION
Fix for bug ticket:
[IDVA5-2516](https://companieshouse.atlassian.net/browse/IDVA5-2516)

This fix allows Angle brackets to be displayed in areas where we construct text using concatenated html macros.
This follows the recent changes that allows angle brackets to be accepted for business/company names.
Previously business/company names were not rendering their string values on certain screens if the business name was valid and contained angle brackets (i.e. if a company is named `<b>`, `<abc>`, `<i>` etc) as nunjucks was treating these as html values.

This includes fixes for correct display of angle brackets on the following screens.
Update ACSP Details -> Authorised agent's details (Main screen)
Update ACSP Details -> Your updates
Registration service -> What is your role -> this fixes the display of all role types using the applications (includes, if a limited company arrives into the service with their business name in angle brackets)


[IDVA5-2516]: https://companieshouse.atlassian.net/browse/IDVA5-2516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ