### PR TITLE
Blocking endash from list of allowed characters name and address fields

### DIFF
--- a/src/validation/regexParts.ts
+++ b/src/validation/regexParts.ts
@@ -7,7 +7,7 @@ export const WHITESPACE = "\\s";
 export const BUSINESS_NAME_EXCLUDED_CHARS = "\\^|~Ǻǻƒ";
 
 // Commmon allowed characters for name and business address/correspondence address
-export const ALLOWED_TEXT_CHARS_SUFFIX = "'\\s–-";
+export const ALLOWED_TEXT_CHARS_SUFFIX = "'\\s-";
 const ALLOWED_TEXT_CHARS_BASE = "A-ZŒÆæÀàÈèÌìÒòÙùẀẁỲỳÁáćǼǽÉéģÍíĹĺŃńÓóŔŕŚśÚúẂẃÝýŹźÂâĉÊêĜĝĤĥÎîĴĵÔôŜŝÛûŴŵŶŷÃãĨĩÑñÕõŨũÄäËëÏïÖöÜüẄẅŸÿÅåŮůa-zœçŊŋŞşŢţĢĶķĻļŅņŖŗĐĦħŦŧǾǿ";
 export const ALLOWED_TEXT_CHARS = `${ALLOWED_TEXT_CHARS_BASE}${ALLOWED_TEXT_CHARS_SUFFIX}`;
 

--- a/test/src/controllers/soleTrader/correspondenceAddressManualController.test.ts
+++ b/test/src/controllers/soleTrader/correspondenceAddressManualController.test.ts
@@ -132,6 +132,16 @@ describe("POST" + SOLE_TRADER_MANUAL_CORRESPONDENCE_ADDRESS, () => {
         expect(res.text).toContain("Address line 2 must only include letters a to z, numbers and common special characters");
     });
 
+    // Test for incorrect addressPropertyDetails, addressLine1 and addressLine2 Format entered endash (–), will return 400.
+    it("should return status 400", async () => {
+        const res = await router.post(BASE_URL + SOLE_TRADER_MANUAL_CORRESPONDENCE_ADDRESS)
+            .send({ addressPropertyDetails: "–", addressLine1: "–", addressLine2: "–", addressTown: "lmn", addressCounty: "lmnop", countryInput: "England", addressPostcode: "MK9 3GB" });
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("Address line 1 must only include letters a to z, numbers and common special characters");
+        expect(res.text).toContain("Property name or number must only include letters a to z, numbers and common special characters");
+        expect(res.text).toContain("Address line 2 must only include letters a to z, numbers and common special characters");
+    });
+
     // Test for incorrect addressLine2 Length entered, will return 400.
     it("should return status 400", async () => {
         const res = await router.post(BASE_URL + SOLE_TRADER_MANUAL_CORRESPONDENCE_ADDRESS)

--- a/test/src/controllers/soleTrader/nameController.test.ts
+++ b/test/src/controllers/soleTrader/nameController.test.ts
@@ -75,7 +75,7 @@ describe("POST" + SOLE_TRADER_WHAT_IS_YOUR_NAME, () => {
             .send({
                 "first-name": "John-Paul",
                 "middle-names": "O'Connor",
-                "last-name": "Smith–Jones"
+                "last-name": "Smith-Jones"
             });
         expect(res.status).toBe(302);
         expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
@@ -108,6 +108,20 @@ describe("POST" + SOLE_TRADER_WHAT_IS_YOUR_NAME, () => {
                 "first-name": "John123",
                 "middle-names": "Test%Middle",
                 "last-name": "$Doe"
+            });
+        expect(res.status).toBe(400);
+        expect(res.text).toContain("First name must only include letters a to z, and common special characters");
+        expect(res.text).toContain("Middle name or names must only include letters a to z, and common special characters");
+        expect(res.text).toContain("Last name must only include letters a to z, and common special characters");
+    });
+
+    it("should return status 400 for names containing invalid character endash (–)", async () => {
+        mockGetAcspRegistration.mockResolvedValueOnce(acspData);
+        const res = await router.post(BASE_URL + SOLE_TRADER_WHAT_IS_YOUR_NAME)
+            .send({
+                "first-name": "–",
+                "middle-names": "–",
+                "last-name": "–"
             });
         expect(res.status).toBe(400);
         expect(res.text).toContain("First name must only include letters a to z, and common special characters");


### PR DESCRIPTION
Update for ticket:
[IDVA5-2426](https://companieshouse.atlassian.net/browse/IDVA5-2426?atlOrigin=eyJpIjoiZDRjNjdkN2ZmZGYwNDkwOThlZjVhNWRjYzE1NTVhOTkiLCJwIjoiaiJ9)

Updating regex pattern for name and address fields to block endash '–' as an allowed character, as this fires a rule within the CHIPs environment.

Screenshot evidence of the fix has been added to the comments of this ticket.

Added in unit tests to specifically test for endash in the relevant fields, which now triggers the validation rule set for incorrect character sets

[IDVA5-2426]: https://companieshouse.atlassian.net/browse/IDVA5-2426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ