### PR TITLE
IDVA5-2592 CSP fix for acsp-web zap testing

### DIFF
--- a/src/middleware/content_security_policy_middleware_config.ts
+++ b/src/middleware/content_security_policy_middleware_config.ts
@@ -1,5 +1,5 @@
 import { HelmetOptions } from "helmet";
-import { CDN_HOST, PIWIK_URL, PIWIK_CHS_DOMAIN, CHS_URL } from "../utils/properties";
+import { CDN_HOST, PIWIK_URL, PIWIK_CHS_DOMAIN, CHS_URL, ENV_SUBDOMAIN } from "../utils/properties";
 
 const SELF = `'self'`;
 const ONE_YEAR_SECONDS = 31536000;
@@ -57,9 +57,14 @@ export const prepareCSPConfigHomePage = (nonce: string) : HelmetOptions => {
 };
 
 const formActionDirective = (ishomepage: boolean) => {
-    const ALL_CHS_URLS = "*";
+
     if (ishomepage) {
-        return [ALL_CHS_URLS];
+        return [
+            ENV_SUBDOMAIN,
+            SELF,
+            PIWIK_CHS_DOMAIN,
+            CHS_URL
+        ];
     } else {
         return [SELF, PIWIK_CHS_DOMAIN, CHS_URL];
     }

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -32,6 +32,8 @@ export const ANY_PROTOCOL_CDN_HOST = getEnvironmentValue("ANY_PROTOCOL_CDN_HOST"
 
 export const CHS_MONITOR_GUI_URL = getEnvironmentValue("CHS_MONITOR_GUI_URL");
 
+export const ENV_SUBDOMAIN = getEnvironmentVariable("ENV_SUBDOMAIN", "false");
+
 // API Keys and Secrets
 
 export const CHS_API_KEY = getEnvironmentValue("CHS_API_KEY", "chs.api.key");


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2592

Applying CSP change to allow subdomains from ENV_SUBDOMAIN env var in ecs-config. This fixes the risk raised in zap testing report.