### PR TITLE
IDVA5-2592 http://*.gov.uk urls added to CSP

### DIFF
--- a/src/middleware/content_security_policy_middleware_config.ts
+++ b/src/middleware/content_security_policy_middleware_config.ts
@@ -61,7 +61,8 @@ const formActionDirectiveHomePage = () => {
         ENV_SUBDOMAIN,
         SELF,
         PIWIK_CHS_DOMAIN,
-        CHS_URL
+        CHS_URL,
+        "https://*.gov.uk"
     ];
 };
 


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2592

Console error shown in logs, so adding url to cover https://*.gov.uk urls so it can be tested in cidev