### PR TITLE
IDVA5-2592 Replace PIWIK_CHS_DOMAIN with hardcoded value with protocol added for testing

### DIFF
--- a/src/middleware/content_security_policy_middleware_config.ts
+++ b/src/middleware/content_security_policy_middleware_config.ts
@@ -67,5 +67,5 @@ const formActionDirectiveHomePage = () => {
 };
 
 const formActionDirectiveDefault = () => {
-    return [SELF, PIWIK_CHS_DOMAIN, CHS_URL];
+    return [SELF, "https://*.cidev.aws.chdev.org", CHS_URL, "https://*.company-information.service.gov.uk"];
 };


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2592

PIWIK_CHS_DOMAIN env var stores value: `*.cidev.aws.chdev.org`. Testing with hardcoded value with `https://` added.
Also adding `https://*.company-information.service.gov.uk` into the formActionDirective for other page not just homepage to test if another page needs it to redirect correctly.