### PR TITLE
IDVA5-2613: Remove 'Ǵ' from allowed special characters due to CHIPs issue

### DIFF
--- a/src/validation/regexParts.ts
+++ b/src/validation/regexParts.ts
@@ -8,7 +8,7 @@ export const BUSINESS_NAME_EXCLUDED_CHARS = "\\^|~Ǻǻƒ";
 
 // Commmon allowed characters for name and business address/correspondence address
 export const ALLOWED_TEXT_CHARS_SUFFIX = "'\\s-";
-const ALLOWED_TEXT_CHARS_BASE = "A-ZŒÆæÀàÈèÌìÒòÙùẀẁỲỳÁáĆćǼǽÉéǴģÍíĹĺŃńÓóŔŕŚśÚúẂẃÝýŹźÂâĈĉÊêĜĝĤĥÎîĴĵÔôŜŝÛûŴŵŶŷÃãĨĩÑñÕõŨũÄäËëÏïÖöÜüẄẅŸÿÅåŮůa-zœÇçŊŋŞşŢţĢĶķĻļŅņŖŗĐĦħŦŧǾǿ";
+const ALLOWED_TEXT_CHARS_BASE = "A-ZŒÆæÀàÈèÌìÒòÙùẀẁỲỳÁáĆćǼǽÉéģÍíĹĺŃńÓóŔŕŚśÚúẂẃÝýŹźÂâĈĉÊêĜĝĤĥÎîĴĵÔôŜŝÛûŴŵŶŷÃãĨĩÑñÕõŨũÄäËëÏïÖöÜüẄẅŸÿÅåŮůa-zœÇçŊŋŞşŢţĢĶķĻļŅņŖŗĐĦħŦŧǾǿ";
 export const ALLOWED_TEXT_CHARS = `${ALLOWED_TEXT_CHARS_BASE}${ALLOWED_TEXT_CHARS_SUFFIX}`;
 
 // Allowed characters for ONLY business address/correspondence address


### PR DESCRIPTION
**JIRA Ticket**
https://companieshouse.atlassian.net/browse/IDVA5-2613

After 'Ǵ' was added as part of #946, QA discovered that CHIPs does not accept the character. So this PR is to revert the addition of 'Ǵ' from the allowed special characters in ACSP-Web