### PR TITLE
Fixing display issues against govuk branding 5.11

### DIFF
--- a/locales/en/cookie-consent-banner.json
+++ b/locales/en/cookie-consent-banner.json
@@ -4,11 +4,11 @@
   "cookiesBanner2": "We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.",
   "acceptAnalyticCookies": "Accept analytics cookies",
   "rejectAnalyticCookies": "Reject analytics cookies",
-  "viewCookies": "View cookies",
+  "viewCookies": "View cookies ({OPEN_IN_NEW_TAB})",
   "acceptedAnalyticsCookies": "You've accepted analytics cookies.",
   "rejectedAnalyticsCookies": "You've rejected analytics cookies.",
   "changeCookie1": "You can",
-  "changeCookie2": "change your cookie settings",
+  "changeCookie2": "change your cookie settings ({OPEN_IN_NEW_TAB})",
   "changeCookie3": "at any time.",
   "cookieNoJS": "We use cookies to make our services work and collect analytics information. To accept or reject analytics cookies, turn on JavaScript in your browser settings and reload this page.",
   "cookieHide": "Hide this message"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@companieshouse/api-sdk-node": "^2.0.272",
-        "@companieshouse/ch-node-utils": "^2.1.8",
+        "@companieshouse/ch-node-utils": "^2.1.9",
         "@companieshouse/node-session-handler": "^5.1.4",
         "@companieshouse/structured-logging-node": "^1.0.8",
         "@companieshouse/web-security-node": "^4.3.1",
@@ -616,9 +616,9 @@
       }
     },
     "node_modules/@companieshouse/ch-node-utils": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@companieshouse/ch-node-utils/-/ch-node-utils-2.1.8.tgz",
-      "integrity": "sha512-kDRmwBgbmoPSfvy/7g9deaJfiRGm5GJj624x+JE+PGRT4oegg8RvK/wzsjUWEBpFmPF2x4Du5BX1jrMEsZvkEg==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@companieshouse/ch-node-utils/-/ch-node-utils-2.1.9.tgz",
+      "integrity": "sha512-sV3KuRGRCWL2NoELlr2b/YU31zAVgN+NKzNnMolI92Kf5+FqV10bAcHXUviuBfEBjdg970L5viwh0C3pplMVPg==",
       "license": "MIT",
       "dependencies": {
         "@companieshouse/node-session-handler": "^5.2.4",
@@ -1648,29 +1648,16 @@
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
+        "@humanwhocodes/retry": "^0.4.0"
       },
       "engines": {
         "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -603,9 +603,9 @@
       }
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.280",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.280.tgz",
-      "integrity": "sha512-tZytEagK0Q9jZEOGBdH6xMR/HWCqjvY7Qtz286I3FB14HBZNbzhAFcipp2f/vJlQCtQkhecUedVqTPKgLF7g5g==",
+      "version": "2.0.282",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.282.tgz",
+      "integrity": "sha512-8OntbRxylpk3plcDGvrHkRf3QhfloT9G/YrrJ25ILbMDGv0fLZC39Qk+YmlVqw+o47D3lx+ZijWqjGgVN4jCGA==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -1194,21 +1194,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
-      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.0.4",
+        "@emnapi/wasi-threads": "1.1.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1217,9 +1217,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
-      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1228,9 +1228,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.8.0.tgz",
+      "integrity": "sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==",
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -1700,9 +1700,9 @@
       }
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.0.tgz",
-      "integrity": "sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.1.tgz",
+      "integrity": "sha512-bYtU8avhGIcje3IhvF9aSjsa5URMZBHnwKtOvXsT4sfYy9gppW11gLPT/9oNqlJZD47yPKveQFTAFWpHjKvUoQ==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
@@ -1846,9 +1846,9 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.1.1.tgz",
-      "integrity": "sha512-f7TGqR1k4GtN5pyFrKmq+ZVndesiwLU33yDpJIGMS9aW+j6hKjue7ljeAdznBsH9kAnxUWe2Y+Y3fLV/FJt3gA==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.1.2.tgz",
+      "integrity": "sha512-BGMAxj8VRmoD0MoA/jo9alMXSRoqW8KPeqOfEo1ncxnRLatTBCpRoOwlwlEMdudp68Q6WSGwYrrLtTGOh8fLzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2036,17 +2036,17 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.1.tgz",
-      "integrity": "sha512-3ncU9peZ3D2VdgRkdZtUceTrDgX5yiDRwAFjtxNfU22IiZrpVWlv/FogzDLYSJQptQGfFo3PcHK86a2oG6WUGg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.3.tgz",
+      "integrity": "sha512-LIQz7NEDDO1+eyOA2ZmkiAyYvZuo6s1UxD/e2IHldR6D7UYogVq3arTmli07MkENLq6/3JEQjp0mA8rrHHJ8KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.1.1",
+        "@jest/console": "30.1.2",
         "@jest/pattern": "30.0.1",
-        "@jest/reporters": "30.1.1",
-        "@jest/test-result": "30.1.1",
-        "@jest/transform": "30.1.1",
+        "@jest/reporters": "30.1.3",
+        "@jest/test-result": "30.1.3",
+        "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
@@ -2055,18 +2055,18 @@
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-changed-files": "30.0.5",
-        "jest-config": "30.1.1",
+        "jest-config": "30.1.3",
         "jest-haste-map": "30.1.0",
         "jest-message-util": "30.1.0",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.0",
-        "jest-resolve-dependencies": "30.1.1",
-        "jest-runner": "30.1.1",
-        "jest-runtime": "30.1.1",
-        "jest-snapshot": "30.1.1",
+        "jest-resolve": "30.1.3",
+        "jest-resolve-dependencies": "30.1.3",
+        "jest-runner": "30.1.3",
+        "jest-runtime": "30.1.3",
+        "jest-snapshot": "30.1.2",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
-        "jest-watcher": "30.1.1",
+        "jest-watcher": "30.1.3",
         "micromatch": "^4.0.8",
         "pretty-format": "30.0.5",
         "slash": "^3.0.0"
@@ -2209,29 +2209,29 @@
       }
     },
     "node_modules/@jest/core/node_modules/jest-config": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.1.tgz",
-      "integrity": "sha512-xuPGUGDw+9fPPnGmddnLnHS/mhKUiJOW7K65vErYmglEPKq65NKwSRchkQ7iv6gqjs2l+YNEsAtbsplxozdOWg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.3.tgz",
+      "integrity": "sha512-M/f7gqdQEPgZNA181Myz+GXCe8jXcJsGjCMXUzRj22FIXsZOyHNte84e0exntOvdPaeh9tA0w+B8qlP2fAezfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
         "@jest/pattern": "30.0.1",
-        "@jest/test-sequencer": "30.1.1",
+        "@jest/test-sequencer": "30.1.3",
         "@jest/types": "30.0.5",
-        "babel-jest": "30.1.1",
+        "babel-jest": "30.1.2",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.1.1",
+        "jest-circus": "30.1.3",
         "jest-docblock": "30.0.1",
-        "jest-environment-node": "30.1.1",
+        "jest-environment-node": "30.1.2",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.0",
-        "jest-runner": "30.1.1",
+        "jest-resolve": "30.1.3",
+        "jest-runner": "30.1.3",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
         "micromatch": "^4.0.8",
@@ -2426,13 +2426,13 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.1.tgz",
-      "integrity": "sha512-yWHbU+3j7ehQE+NRpnxRvHvpUhoohIjMePBbIr8lfe0cWVb0WeTf80DNux1GPJa18CDHiIU5DtksGUfxcDE+Rw==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.2.tgz",
+      "integrity": "sha512-N8t1Ytw4/mr9uN28OnVf0SYE2dGhaIxOVYcwsf9IInBKjvofAjbFRvedvBBlyTYk2knbJTiEjEJ2PyyDIBnd9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.1.1",
+        "@jest/fake-timers": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "jest-mock": "30.0.5"
@@ -2442,14 +2442,14 @@
       }
     },
     "node_modules/@jest/expect": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.1.1.tgz",
-      "integrity": "sha512-3vHIHsF+qd3D8FU2c7U5l3rg1fhDwAYcGyHyZAi94YIlTwcJ+boNhRyJf373cl4wxbOX+0Q7dF40RTrTFTSuig==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.1.2.tgz",
+      "integrity": "sha512-tyaIExOwQRCxPCGNC05lIjWJztDwk2gPDNSDGg1zitXJJ8dC3++G/CRjE5mb2wQsf89+lsgAgqxxNpDLiCViTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "30.1.1",
-        "jest-snapshot": "30.1.1"
+        "expect": "30.1.2",
+        "jest-snapshot": "30.1.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -2469,9 +2469,9 @@
       }
     },
     "node_modules/@jest/expect/node_modules/@jest/expect-utils": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.1.tgz",
-      "integrity": "sha512-5YUHr27fpJ64dnvtu+tt11ewATynrHkGYD+uSFgRr8V2eFJis/vEXgToyLwccIwqBihVfz9jwio+Zr1ab1Zihw==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.2.tgz",
+      "integrity": "sha512-HXy1qT/bfdjCv7iC336ExbqqYtZvljrV8odNdso7dWK9bSeHtLlvwWWC3YSybSPL03Gg5rug6WLCZAZFH72m0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2551,15 +2551,15 @@
       "license": "MIT"
     },
     "node_modules/@jest/expect/node_modules/expect": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.1.tgz",
-      "integrity": "sha512-OKe7cdic4qbfWd/CcgwJvvCrNX2KWfuMZee9AfJHL1gTYmvqjBjZG1a2NwfhspBzxzlXwsN75WWpKTYfsJpBxg==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.2.tgz",
+      "integrity": "sha512-xvHszRavo28ejws8FpemjhwswGj4w/BetHIL8cU49u4sGyXDw2+p3YbeDbj6xzlxi6kWTjIRSTJ+9sNXPnF0Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.1.1",
+        "@jest/expect-utils": "30.1.2",
         "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.1.1",
+        "jest-matcher-utils": "30.1.2",
         "jest-message-util": "30.1.0",
         "jest-mock": "30.0.5",
         "jest-util": "30.0.5"
@@ -2579,9 +2579,9 @@
       }
     },
     "node_modules/@jest/expect/node_modules/jest-diff": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.1.tgz",
-      "integrity": "sha512-LUU2Gx8EhYxpdzTR6BmjL1ifgOAQJQELTHOiPv9KITaKjZvJ9Jmgigx01tuZ49id37LorpGc9dPBPlXTboXScw==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.2.tgz",
+      "integrity": "sha512-4+prq+9J61mOVXCa4Qp8ZjavdxzrWQXrI80GNxP8f4tkI2syPuPrJgdRPZRrfUTRvIoUwcmNLbqEJy9W800+NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2595,15 +2595,15 @@
       }
     },
     "node_modules/@jest/expect/node_modules/jest-matcher-utils": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.1.tgz",
-      "integrity": "sha512-SuH2QVemK48BNTqReti6FtjsMPFsSOD/ZzRxU1TttR7RiRsRSe78d03bb4Cx6D4bQC/80Q8U4VnaaAH9FlbZ9w==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.2.tgz",
+      "integrity": "sha512-7ai16hy4rSbDjvPTuUhuV8nyPBd6EX34HkBsBcBX2lENCuAQ0qKCPb/+lt8OSWUa9WWmGYLy41PrEzkwRwoGZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.1.1",
+        "jest-diff": "30.1.2",
         "pretty-format": "30.0.5"
       },
       "engines": {
@@ -2704,9 +2704,9 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.1.tgz",
-      "integrity": "sha512-fK/25dNgBNYPw3eLi2CRs57g1H04qBAFNMsUY3IRzkfx/m4THe0E1zF+yGQBOMKKc2XQVdc9EYbJ4hEm7/2UtA==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.2.tgz",
+      "integrity": "sha512-Beljfv9AYkr9K+ETX9tvV61rJTY706BhBUtiaepQHeEGfe0DbpvUA5Z3fomwc5Xkhns6NWrcFDZn+72fLieUnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2904,14 +2904,14 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.1.1.tgz",
-      "integrity": "sha512-NNUUkHT2TU/xztZl6r1UXvJL+zvCwmZsQDmK69fVHHcB9fBtlu3FInnzOve/ZoyKnWY8JXWJNT+Lkmu1+ubXUA==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.1.2.tgz",
+      "integrity": "sha512-teNTPZ8yZe3ahbYnvnVRDeOjr+3pu2uiAtNtrEsiMjVPPj+cXd5E/fr8BL7v/T7F31vYdEHrI5cC/2OoO/vM9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.1.1",
-        "@jest/expect": "30.1.1",
+        "@jest/environment": "30.1.2",
+        "@jest/expect": "30.1.2",
         "@jest/types": "30.0.5",
         "jest-mock": "30.0.5"
       },
@@ -2934,16 +2934,16 @@
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.1.tgz",
-      "integrity": "sha512-Hb2Bq80kahOC6Sv2waEaH1rEU6VdFcM6WHaRBWQF9tf30+nJHxhl/Upbgo9+25f0mOgbphxvbwSMjSgy9gW/FA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.3.tgz",
+      "integrity": "sha512-VWEQmJWfXMOrzdFEOyGjUEOuVXllgZsoPtEHZzfdNz18RmzJ5nlR6kp8hDdY8dDS1yGOXAY7DHT+AOHIPSBV0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.1.1",
-        "@jest/test-result": "30.1.1",
-        "@jest/transform": "30.1.1",
+        "@jest/console": "30.1.2",
+        "@jest/test-result": "30.1.3",
+        "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@types/node": "*",
@@ -3209,9 +3209,9 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.1.1.tgz",
-      "integrity": "sha512-TkVBc9wuN22TT8hESRFmjjg/xIMu7z0J3UDYtIRydzCqlLPTB7jK1DDBKdnTUZ4zL3z3rnPpzV6rL1Uzh87sXg==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.1.2.tgz",
+      "integrity": "sha512-vHoMTpimcPSR7OxS2S0V1Cpg8eKDRxucHjoWl5u4RQcnxqQrV3avETiFpl8etn4dqxEGarBeHbIBety/f8mLXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3316,13 +3316,13 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.1.tgz",
-      "integrity": "sha512-bMdj7fNu8iZuBPSnbVir5ezvWmVo4jrw7xDE+A33Yb3ENCoiJK9XgOLgal+rJ9XSKjsL7aPUMIo87zhN7I5o2w==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.3.tgz",
+      "integrity": "sha512-P9IV8T24D43cNRANPPokn7tZh0FAFnYS2HIfi5vK18CjRkTDR9Y3e1BoEcAJnl4ghZZF4Ecda4M/k41QkvurEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.1.1",
+        "@jest/console": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
@@ -3332,13 +3332,13 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.1.tgz",
-      "integrity": "sha512-yruRdLXSA3HYD/MTNykgJ6VYEacNcXDFRMqKVAwlYegmxICUiT/B++CNuhJnYJzKYks61iYnjVsMwbUqmmAYJg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.3.tgz",
+      "integrity": "sha512-82J+hzC0qeQIiiZDThh+YUadvshdBswi5nuyXlEmXzrhw5ZQSRHeQ5LpVMD/xc8B3wPePvs6VMzHnntxL+4E3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.1.1",
+        "@jest/test-result": "30.1.3",
         "graceful-fs": "^4.2.11",
         "jest-haste-map": "30.1.0",
         "slash": "^3.0.0"
@@ -3348,9 +3348,9 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.1.1.tgz",
-      "integrity": "sha512-PHIA2AbAASBfk6evkNifvmx9lkOSkmvaQoO6VSpuL8+kQqDMHeDoJ7RU3YP1wWAMD7AyQn9UL5iheuFYCC4lqQ==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.1.2.tgz",
+      "integrity": "sha512-UYYFGifSgfjujf1Cbd3iU/IQoSd6uwsj8XHj5DSDf5ERDcWMdJOPTkHWXj4U+Z/uMagyOQZ6Vne8C4nRIrCxqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5294,9 +5294,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz",
-      "integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
+      "integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -5429,9 +5429,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.40",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.40.tgz",
-      "integrity": "sha512-gwBNIP8ZAYev/ORDWW0QvxdwPXwxBtLsdsJgSc7eDIRt8ubP+rxUBzPsrwnu16fgEF8Bx4lh/+mvQvJzcTM6Kw==",
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
       "dev": true,
       "license": "MIT"
     },
@@ -6790,13 +6790,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/babel-jest": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.1.tgz",
-      "integrity": "sha512-1bZfC/V03qBCzASvZpNFhx3Ouj6LgOd4KFJm4br/fYOS+tSSvVCE61QmcAVbMTwq/GoB7KN4pzGMoyr9cMxSvQ==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.2.tgz",
+      "integrity": "sha512-IQCus1rt9kaSh7PQxLYRY5NmkNrNlU2TpabzwV7T2jljnpdHOcmnYYv8QmE04Li4S3a2Lj8/yXyET5pBarPr6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/transform": "30.1.1",
+        "@jest/transform": "30.1.2",
         "@types/babel__core": "^7.20.5",
         "babel-plugin-istanbul": "^7.0.0",
         "babel-preset-jest": "30.0.1",
@@ -7155,9 +7155,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.3.tgz",
-      "integrity": "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==",
+      "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
+      "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
       "dev": true,
       "funding": [
         {
@@ -7175,8 +7175,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001735",
-        "electron-to-chromium": "^1.5.204",
+        "caniuse-lite": "^1.0.30001737",
+        "electron-to-chromium": "^1.5.211",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -7335,9 +7335,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001737",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
-      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
+      "version": "1.0.30001739",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001739.tgz",
+      "integrity": "sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==",
       "dev": true,
       "funding": [
         {
@@ -7386,9 +7386,9 @@
       "license": "MIT"
     },
     "node_modules/cheerio": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.0.tgz",
-      "integrity": "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7396,16 +7396,16 @@
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
-        "encoding-sniffer": "^0.2.0",
+        "encoding-sniffer": "^0.2.1",
         "htmlparser2": "^10.0.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.10.0",
+        "undici": "^7.12.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -8228,9 +8228,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.209",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.209.tgz",
-      "integrity": "sha512-Xoz0uMrim9ZETCQt8UgM5FxQF9+imA7PBpokoGcZloA1uw2LeHzTlip5cb5KOAsXZLjh/moN2vReN3ZjJmjI9A==",
+      "version": "1.5.213",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.213.tgz",
+      "integrity": "sha512-xr9eRzSLNa4neDO0xVFrkXu3vyIzG4Ay08dApecw42Z1NbmCt+keEpXdvlYGVe0wtvY5dhW0Ay0lY0IOfsCg0Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -11931,16 +11931,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.1.tgz",
-      "integrity": "sha512-yC3JvpP/ZcAZX5rYCtXO/g9k6VTCQz0VFE2v1FpxytWzUqfDtu0XL/pwnNvptzYItvGwomh1ehomRNMOyhCJKw==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.3.tgz",
+      "integrity": "sha512-Ry+p2+NLk6u8Agh5yVqELfUJvRfV51hhVBRIB5yZPY7mU0DGBmOuFG5GebZbMbm86cdQNK0fhJuDX8/1YorISQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.1.1",
+        "@jest/core": "30.1.3",
         "@jest/types": "30.0.5",
         "import-local": "^3.2.0",
-        "jest-cli": "30.1.1"
+        "jest-cli": "30.1.3"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -12096,15 +12096,15 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.1.tgz",
-      "integrity": "sha512-M3Vd4x5wD7eSJspuTvRF55AkOOBndRxgW3gqQBDlFvbH3X+ASdi8jc+EqXEeAFd/UHulVYIlC4XKJABOhLw6UA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.3.tgz",
+      "integrity": "sha512-Yf3dnhRON2GJT4RYzM89t/EXIWNxKTpWTL9BfF3+geFetWP4XSvJjiU1vrWplOiUkmq8cHLiwuhz+XuUp9DscA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.1.1",
-        "@jest/expect": "30.1.1",
-        "@jest/test-result": "30.1.1",
+        "@jest/environment": "30.1.2",
+        "@jest/expect": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -12112,10 +12112,10 @@
         "dedent": "^1.6.0",
         "is-generator-fn": "^2.1.0",
         "jest-each": "30.1.0",
-        "jest-matcher-utils": "30.1.1",
+        "jest-matcher-utils": "30.1.2",
         "jest-message-util": "30.1.0",
-        "jest-runtime": "30.1.1",
-        "jest-snapshot": "30.1.1",
+        "jest-runtime": "30.1.3",
+        "jest-snapshot": "30.1.2",
         "jest-util": "30.0.5",
         "p-limit": "^3.1.0",
         "pretty-format": "30.0.5",
@@ -12207,9 +12207,9 @@
       }
     },
     "node_modules/jest-circus/node_modules/jest-diff": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.1.tgz",
-      "integrity": "sha512-LUU2Gx8EhYxpdzTR6BmjL1ifgOAQJQELTHOiPv9KITaKjZvJ9Jmgigx01tuZ49id37LorpGc9dPBPlXTboXScw==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.2.tgz",
+      "integrity": "sha512-4+prq+9J61mOVXCa4Qp8ZjavdxzrWQXrI80GNxP8f4tkI2syPuPrJgdRPZRrfUTRvIoUwcmNLbqEJy9W800+NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12223,15 +12223,15 @@
       }
     },
     "node_modules/jest-circus/node_modules/jest-matcher-utils": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.1.tgz",
-      "integrity": "sha512-SuH2QVemK48BNTqReti6FtjsMPFsSOD/ZzRxU1TttR7RiRsRSe78d03bb4Cx6D4bQC/80Q8U4VnaaAH9FlbZ9w==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.2.tgz",
+      "integrity": "sha512-7ai16hy4rSbDjvPTuUhuV8nyPBd6EX34HkBsBcBX2lENCuAQ0qKCPb/+lt8OSWUa9WWmGYLy41PrEzkwRwoGZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.1.1",
+        "jest-diff": "30.1.2",
         "pretty-format": "30.0.5"
       },
       "engines": {
@@ -12332,19 +12332,19 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.1.tgz",
-      "integrity": "sha512-xm9llxuh5OoI5KZaYzlMhklryHBwg9LZy/gEaaMlXlxb+cZekGNzukU0iblbDo3XOBuN6N0CgK4ykgNRYSEb6g==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.3.tgz",
+      "integrity": "sha512-G8E2Ol3OKch1DEeIBl41NP7OiC6LBhfg25Btv+idcusmoUSpqUkbrneMqbW9lVpI/rCKb/uETidb7DNteheuAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.1.1",
-        "@jest/test-result": "30.1.1",
+        "@jest/core": "30.1.3",
+        "@jest/test-result": "30.1.3",
         "@jest/types": "30.0.5",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.1.1",
+        "jest-config": "30.1.3",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
         "yargs": "^17.7.2"
@@ -12515,29 +12515,29 @@
       }
     },
     "node_modules/jest-cli/node_modules/jest-config": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.1.tgz",
-      "integrity": "sha512-xuPGUGDw+9fPPnGmddnLnHS/mhKUiJOW7K65vErYmglEPKq65NKwSRchkQ7iv6gqjs2l+YNEsAtbsplxozdOWg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.3.tgz",
+      "integrity": "sha512-M/f7gqdQEPgZNA181Myz+GXCe8jXcJsGjCMXUzRj22FIXsZOyHNte84e0exntOvdPaeh9tA0w+B8qlP2fAezfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
         "@jest/pattern": "30.0.1",
-        "@jest/test-sequencer": "30.1.1",
+        "@jest/test-sequencer": "30.1.3",
         "@jest/types": "30.0.5",
-        "babel-jest": "30.1.1",
+        "babel-jest": "30.1.2",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.1.1",
+        "jest-circus": "30.1.3",
         "jest-docblock": "30.0.1",
-        "jest-environment-node": "30.1.1",
+        "jest-environment-node": "30.1.2",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.0",
-        "jest-runner": "30.1.1",
+        "jest-resolve": "30.1.3",
+        "jest-runner": "30.1.3",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
         "micromatch": "^4.0.8",
@@ -13034,14 +13034,14 @@
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.1.1.tgz",
-      "integrity": "sha512-IaMoaA6saxnJimqCppUDqKck+LKM0Jg+OxyMUIvs1yGd2neiC22o8zXo90k04+tO+49OmgMR4jTgM5e4B0S62Q==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.1.2.tgz",
+      "integrity": "sha512-w8qBiXtqGWJ9xpJIA98M0EIoq079GOQRQUyse5qg1plShUCQ0Ek1VTTcczqKrn3f24TFAgFtT+4q3aOXvjbsuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.1.1",
-        "@jest/fake-timers": "30.1.1",
+        "@jest/environment": "30.1.2",
+        "@jest/fake-timers": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "jest-mock": "30.0.5",
@@ -13769,9 +13769,9 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.0.tgz",
-      "integrity": "sha512-hASe7D/wRtZw8Cm607NrlF7fi3HWC5wmA5jCVc2QjQAB2pTwP9eVZILGEi6OeSLNUtE1zb04sXRowsdh5CUjwA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.3.tgz",
+      "integrity": "sha512-DI4PtTqzw9GwELFS41sdMK32Ajp3XZQ8iygeDMWkxlRhm7uUTOFSZFVZABFuxr0jvspn8MAYy54NxZCsuCTSOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13789,14 +13789,14 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.1.tgz",
-      "integrity": "sha512-tRtaaoH8Ws1Gn1o/9pedt19dvVgr81WwdmvJSP9Ow3amOUOP2nN9j94u5jC9XlIfa2Q1FQKIWWQwL4ajqsjCGQ==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.3.tgz",
+      "integrity": "sha512-DNfq3WGmuRyHRHfEet+Zm3QOmVFtIarUOQHHryKPc0YL9ROfgWZxl4+aZq/VAzok2SS3gZdniP+dO4zgo59hBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "30.0.1",
-        "jest-snapshot": "30.1.1"
+        "jest-snapshot": "30.1.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -13926,16 +13926,16 @@
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.1.tgz",
-      "integrity": "sha512-ATe6372SOfJvCRExtCAr06I4rGujwFdKg44b6i7/aOgFnULwjxzugJ0Y4AnG+jeSeQi8dU7R6oqLGmsxRUbErQ==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.3.tgz",
+      "integrity": "sha512-dd1ORcxQraW44Uz029TtXj85W11yvLpDuIzNOlofrC8GN+SgDlgY4BvyxJiVeuabA1t6idjNbX59jLd2oplOGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.1.1",
-        "@jest/environment": "30.1.1",
-        "@jest/test-result": "30.1.1",
-        "@jest/transform": "30.1.1",
+        "@jest/console": "30.1.2",
+        "@jest/environment": "30.1.2",
+        "@jest/test-result": "30.1.3",
+        "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -13943,14 +13943,14 @@
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-docblock": "30.0.1",
-        "jest-environment-node": "30.1.1",
+        "jest-environment-node": "30.1.2",
         "jest-haste-map": "30.1.0",
         "jest-leak-detector": "30.1.0",
         "jest-message-util": "30.1.0",
-        "jest-resolve": "30.1.0",
-        "jest-runtime": "30.1.1",
+        "jest-resolve": "30.1.3",
+        "jest-runtime": "30.1.3",
         "jest-util": "30.0.5",
-        "jest-watcher": "30.1.1",
+        "jest-watcher": "30.1.3",
         "jest-worker": "30.1.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
@@ -14132,18 +14132,18 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.1.tgz",
-      "integrity": "sha512-7sOyR0Oekw4OesQqqBHuYJRB52QtXiq0NNgLRzVogiMSxKCMiliUd6RrXHCnG5f12Age/ggidCBiQftzcA9XKw==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.3.tgz",
+      "integrity": "sha512-WS8xgjuNSphdIGnleQcJ3AKE4tBKOVP+tKhCD0u+Tb2sBmsU8DxfbBpZX7//+XOz81zVs4eFpJQwBNji2Y07DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.1.1",
-        "@jest/fake-timers": "30.1.1",
-        "@jest/globals": "30.1.1",
+        "@jest/environment": "30.1.2",
+        "@jest/fake-timers": "30.1.2",
+        "@jest/globals": "30.1.2",
         "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.1.1",
-        "@jest/transform": "30.1.1",
+        "@jest/test-result": "30.1.3",
+        "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -14155,8 +14155,8 @@
         "jest-message-util": "30.1.0",
         "jest-mock": "30.0.5",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.0",
-        "jest-snapshot": "30.1.1",
+        "jest-resolve": "30.1.3",
+        "jest-snapshot": "30.1.2",
         "jest-util": "30.0.5",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
@@ -14385,9 +14385,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.1.1.tgz",
-      "integrity": "sha512-7/iBEzoJqEt2TjkQY+mPLHP8cbPhLReZVkkxjTMzIzoTC4cZufg7HzKo/n9cIkXKj2LG0x3mmBHsZto+7TOmFg==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.1.2.tgz",
+      "integrity": "sha512-4q4+6+1c8B6Cy5pGgFvjDy/Pa6VYRiGu0yQafKkJ9u6wQx4G5PqI2QR6nxTl43yy7IWsINwz6oT4o6tD12a8Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14396,17 +14396,17 @@
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.1.1",
+        "@jest/expect-utils": "30.1.2",
         "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.1.1",
-        "@jest/transform": "30.1.1",
+        "@jest/snapshot-utils": "30.1.2",
+        "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "babel-preset-current-node-syntax": "^1.1.0",
         "chalk": "^4.1.2",
-        "expect": "30.1.1",
+        "expect": "30.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.1.1",
-        "jest-matcher-utils": "30.1.1",
+        "jest-diff": "30.1.2",
+        "jest-matcher-utils": "30.1.2",
         "jest-message-util": "30.1.0",
         "jest-util": "30.0.5",
         "pretty-format": "30.0.5",
@@ -14418,9 +14418,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/@jest/expect-utils": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.1.tgz",
-      "integrity": "sha512-5YUHr27fpJ64dnvtu+tt11ewATynrHkGYD+uSFgRr8V2eFJis/vEXgToyLwccIwqBihVfz9jwio+Zr1ab1Zihw==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.2.tgz",
+      "integrity": "sha512-HXy1qT/bfdjCv7iC336ExbqqYtZvljrV8odNdso7dWK9bSeHtLlvwWWC3YSybSPL03Gg5rug6WLCZAZFH72m0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14500,15 +14500,15 @@
       "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/expect": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.1.tgz",
-      "integrity": "sha512-OKe7cdic4qbfWd/CcgwJvvCrNX2KWfuMZee9AfJHL1gTYmvqjBjZG1a2NwfhspBzxzlXwsN75WWpKTYfsJpBxg==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.2.tgz",
+      "integrity": "sha512-xvHszRavo28ejws8FpemjhwswGj4w/BetHIL8cU49u4sGyXDw2+p3YbeDbj6xzlxi6kWTjIRSTJ+9sNXPnF0Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.1.1",
+        "@jest/expect-utils": "30.1.2",
         "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.1.1",
+        "jest-matcher-utils": "30.1.2",
         "jest-message-util": "30.1.0",
         "jest-mock": "30.0.5",
         "jest-util": "30.0.5"
@@ -14528,9 +14528,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/jest-diff": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.1.tgz",
-      "integrity": "sha512-LUU2Gx8EhYxpdzTR6BmjL1ifgOAQJQELTHOiPv9KITaKjZvJ9Jmgigx01tuZ49id37LorpGc9dPBPlXTboXScw==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.2.tgz",
+      "integrity": "sha512-4+prq+9J61mOVXCa4Qp8ZjavdxzrWQXrI80GNxP8f4tkI2syPuPrJgdRPZRrfUTRvIoUwcmNLbqEJy9W800+NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14544,15 +14544,15 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/jest-matcher-utils": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.1.tgz",
-      "integrity": "sha512-SuH2QVemK48BNTqReti6FtjsMPFsSOD/ZzRxU1TttR7RiRsRSe78d03bb4Cx6D4bQC/80Q8U4VnaaAH9FlbZ9w==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.2.tgz",
+      "integrity": "sha512-7ai16hy4rSbDjvPTuUhuV8nyPBd6EX34HkBsBcBX2lENCuAQ0qKCPb/+lt8OSWUa9WWmGYLy41PrEzkwRwoGZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.1.1",
+        "jest-diff": "30.1.2",
         "pretty-format": "30.0.5"
       },
       "engines": {
@@ -14962,13 +14962,13 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.1.tgz",
-      "integrity": "sha512-CrAQ73LlaS6KGQQw6NBi71g7qvP7scy+4+2c0jKX6+CWaYg85lZiig5nQQVTsS5a5sffNPL3uxXnaE9d7v9eQg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.3.tgz",
+      "integrity": "sha512-6jQUZCP1BTL2gvG9E4YF06Ytq4yMb4If6YoQGRR6PpjtqOXSP3sKe2kqwB6SQ+H9DezOfZaSLnmka1NtGm3fCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.1.1",
+        "@jest/test-result": "30.1.3",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "@companieshouse/api-sdk-node": "^2.0.272",
-    "@companieshouse/ch-node-utils": "^2.1.8",
+    "@companieshouse/ch-node-utils": "^2.1.9",
     "@companieshouse/node-session-handler": "^5.1.4",
     "@companieshouse/structured-logging-node": "^1.0.8",
     "@companieshouse/web-security-node": "^4.3.1",

--- a/src/middleware/content_security_policy_middleware_config.ts
+++ b/src/middleware/content_security_policy_middleware_config.ts
@@ -17,6 +17,7 @@ export const prepareCSPConfig = (nonce: string) : HelmetOptions => {
                 connectSrc: [SELF, PIWIK_URL, CHS_URL],
                 formAction: formActionDirectiveDefault(),
                 scriptSrc: [NONCE, CDN_HOST, PIWIK_URL],
+                manifestSrc: [CDN_HOST],
                 objectSrc: [`'none'`]
             }
         },
@@ -43,6 +44,7 @@ export const prepareCSPConfigHomePage = (nonce: string) : HelmetOptions => {
                 connectSrc: [SELF, PIWIK_URL, CHS_URL],
                 formAction: formActionDirectiveHomePage(),
                 scriptSrc: [NONCE, CDN_HOST, PIWIK_URL],
+                manifestSrc: [CDN_HOST],
                 objectSrc: [`'none'`]
             }
         },

--- a/src/middleware/content_security_policy_middleware_config.ts
+++ b/src/middleware/content_security_policy_middleware_config.ts
@@ -3,6 +3,8 @@ import { CDN_HOST, PIWIK_URL, PIWIK_CHS_DOMAIN, CHS_URL, ENV_SUBDOMAIN } from ".
 
 const SELF = `'self'`;
 const ONE_YEAR_SECONDS = 31536000;
+// Design System hash value from: https://frontend.design-system.service.gov.uk/import-javascript/#if-our-inline-javascript-snippet-is-blocked-by-a-content-security-policy
+const DS_SCRIPT_HASH = `'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='`;
 
 export const prepareCSPConfig = (nonce: string) : HelmetOptions => {
     const NONCE = `'nonce-${nonce}'`;
@@ -16,7 +18,7 @@ export const prepareCSPConfig = (nonce: string) : HelmetOptions => {
                 styleSrc: [NONCE, CDN_HOST],
                 connectSrc: [SELF, PIWIK_URL, CHS_URL],
                 formAction: formActionDirectiveDefault(),
-                scriptSrc: [NONCE, CDN_HOST, PIWIK_URL],
+                scriptSrc: [NONCE, CDN_HOST, PIWIK_URL, DS_SCRIPT_HASH],
                 manifestSrc: [CDN_HOST],
                 objectSrc: [`'none'`]
             }
@@ -43,7 +45,7 @@ export const prepareCSPConfigHomePage = (nonce: string) : HelmetOptions => {
                 styleSrc: [NONCE, CDN_HOST],
                 connectSrc: [SELF, PIWIK_URL, CHS_URL],
                 formAction: formActionDirectiveHomePage(),
-                scriptSrc: [NONCE, CDN_HOST, PIWIK_URL],
+                scriptSrc: [NONCE, CDN_HOST, PIWIK_URL, DS_SCRIPT_HASH],
                 manifestSrc: [CDN_HOST],
                 objectSrc: [`'none'`]
             }

--- a/src/views/common/sign-out-page/sign-out.njk
+++ b/src/views/common/sign-out-page/sign-out.njk
@@ -4,8 +4,6 @@
 
 {% block signoutBar %}
   {# Remove signout Bar on this page by replacing it with nothing #}
-  {# Retaining section break divider line on sign out page #}
-  <hr class="govuk-section-break">
 {% endblock %}
 
 {% set title = i18n.signoutTitle %}

--- a/src/views/features/sole-trader/where-do-you-live/where-do-you-live.njk
+++ b/src/views/features/sole-trader/where-do-you-live/where-do-you-live.njk
@@ -1,20 +1,24 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% extends "layouts/default.njk" %}
+
 {% set title = i18n.whereDoYouLiveTitle %}
+
 {% block main_content %}
   <form action="{{ currentUrl }}?lang={{ lang }}" method="post">
     {% include "partials/csrf_token.njk" %}
     {% include "partials/user_name.njk" %}
+
     {% set countryInput %}
-    <div id="typeahead-form-group" class="govuk-form-group">
-      {% set dropdownDefaultText = i18n.whereDoYouLiveDefaultDropdownText %}
-      <label class="govuk-hint" id="typeahead-hint" for="countryInput">{{ i18n.whereDoYouLiveHint }}</label>
-      <div id="my-autocomplete-container" class="autocomplete-wrapper govuk-!-width-two-thirds"></div>
-      {% set errorMessage = errors %}
-      {% include "../../../partials/country-typeahead-input.njk" %}
-    </div>
+      <div id="typeahead-form-group" class="govuk-form-group">
+        {% set dropdownDefaultText = i18n.whereDoYouLiveDefaultDropdownText %}
+        <label class="govuk-hint" id="typeahead-hint" for="countryInput">{{ i18n.whereDoYouLiveHint }}</label>
+        <div id="my-autocomplete-container" class="autocomplete-wrapper govuk-!-width-two-thirds"></div>
+        {% set errorMessage = errors %}
+        {% include "../../../partials/country-typeahead-input.njk" %}
+      </div>
     {% endset -%}
+
     {{ govukRadios({
       errorMessage: errors.whereDoYouLiveRadio if errors,
       name: "whereDoYouLiveRadio",
@@ -48,8 +52,10 @@
         },
         {
           value: "countryOutsideUK",
-          text: i18n.whereDoYouLiveText6, 
-          conditional:{ html : countryInput }
+          text: i18n.whereDoYouLiveText6,
+          conditional: { 
+            html : countryInput 
+          }
         }
       ]
     }) }}

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -8,8 +8,6 @@
 
 {% set mainClasses = 'govuk-!-padding-top-0' %}
 
-{% set bodyClasses = 'govuk-frontend-supported js-enabled' %}
-
 {% set tabTitle = "" %}
 {% if errors %}
     {% set tabTitle = i18n.error + ": " %}

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -6,8 +6,6 @@
 
 {% set mainContentId = "main-page-content" %}
 
-{% set mainClasses = 'govuk-!-padding-top-0' %}
-
 {% set tabTitle = "" %}
 {% if errors %}
     {% set tabTitle = i18n.error + ": " %}
@@ -26,45 +24,48 @@
   {% include "partials/__meta_header.njk" %}
 {% endblock %}
 
+{% block skipLink %}
+  {{ govukSkipLink({
+    text: "Skip to main content",
+    href: "#" + mainContentId
+  }) }}
+{% endblock %}
+
 {% block header %}
-  <div class="govuk-header">
-    {% include "partials/__header.njk" %}
-  </div>
-{% endblock %}
-
-{% block bodyStart %}
-  {% include "partials/cookie_consent_banner.njk" %}
-{% endblock %}
-
-{% block content %}
-    {% block skipLink %}
-      {{ govukSkipLink({
-        text: "Skip to main content",
-        href: "#" + mainContentId
-      }) }}
-    {% endblock %}
+  {% include "partials/__header.njk" %}
+  <div class="govuk-width-container">
     {% include "partials/phase_banner.njk" %}
+    {% if journeyType == "register-acsp" %}
+      {% block signoutBar %}
+        {% include "partials/nav/signout-bar.njk" %}
+      {% endblock %}
+    {% endif %}
     {% if journeyType != "register-acsp" %}
       {% include "partials/nav/navbar.njk" %}
     {% endif %}
     {% block backLink %}
       {% include "partials/nav/back_link.njk" %}
     {% endblock %}
-    {% if journeyType == "register-acsp" %}
-      {% block signoutBar %}
-        {% include "partials/nav/signout-bar.njk" %}
-      {% endblock %}
-    {% endif %}
-    {% block localesBanner %}
-      {% include "locales-banner.njk" %}
-    {% endblock %}
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third"></div>
-      <div class="govuk-grid-column-two-thirds" id="{{ mainContentId }}">
-        {% include "partials/error_summary.njk" %}
-        {% block main_content %}{% endblock %}
-      </div>
+  </div>
+  {% block localesBanner %}
+    {% include "locales-banner.njk" %}
+  {% endblock %}
+{% endblock %}
+
+
+
+{% block bodyStart %}
+  {% include "partials/cookie_consent_banner.njk" %}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third"></div>
+    <div class="govuk-grid-column-two-thirds" id="{{ mainContentId }}">
+      {% include "partials/error_summary.njk" %}
+      {% block main_content %}{% endblock %}
     </div>
+  </div>
 {% endblock %}
 
 {% block footer %}

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -2,9 +2,11 @@
 {% extends "ch-node-utils/templates/layouts/template.njk" %}
 {% import "add-lang-to-url.njk" as lang2url %}
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
-{% from "govuk/components/error-summary/macro.njk"       import govukErrorSummary %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set mainContentId = "main-page-content" %}
+
+{% set mainClasses = 'govuk-!-padding-top-0' %}
 
 {% set tabTitle = "" %}
 {% if errors %}
@@ -29,8 +31,12 @@
     {% include "partials/__header.njk" %}
   </div>
 {% endblock %}
+
+{% block bodyStart %}
+  {% include "partials/cookie_consent_banner.njk" %}
+{% endblock %}
+
 {% block content %}
-    {% include "partials/cookie_consent_banner.njk" %}
     {% block skipLink %}
       {{ govukSkipLink({
         text: "Skip to main content",
@@ -52,22 +58,21 @@
     {% block localesBanner %}
       {% include "locales-banner.njk" %}
     {% endblock %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third"></div>
+      <div class="govuk-grid-column-two-thirds" id="{{ mainContentId }}">
+        {% include "partials/error_summary.njk" %}
+        {% block main_content %}{% endblock %}
+      </div>
     </div>
-    <div class="govuk-grid-column-two-thirds" id="{{ mainContentId }}">
-      {% include "partials/error_summary.njk" %}
-      {% block main_content %}{% endblock %}
-    </div>
-  </div>
 {% endblock %}
 
 {% block footer %}
-    {% include "partials/__footer.njk" %}
-
+  {% include "partials/__footer.njk" %}
 {% endblock %}
 
 {% block bodyEnd %}
   {{ super() }}
-  <script src="path/to/app.js"></script>
+  <script type="module" src="{{ cdnHost }}/javascripts/govuk-frontend/v5.11.0/govuk-frontend-5.11.0.min.js"></script>
+  {% include "partials/__meta_footer.njk" %}
 {% endblock %}

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -8,6 +8,8 @@
 
 {% set mainClasses = 'govuk-!-padding-top-0' %}
 
+{% set bodyClasses = 'govuk-frontend-supported js-enabled' %}
+
 {% set tabTitle = "" %}
 {% if errors %}
     {% set tabTitle = i18n.error + ": " %}
@@ -73,6 +75,5 @@
 
 {% block bodyEnd %}
   {{ super() }}
-  <script type="module" src="{{ cdnHost }}/javascripts/govuk-frontend/v5.11.0/govuk-frontend-5.11.0.min.js"></script>
   {% include "partials/__meta_footer.njk" %}
 {% endblock %}

--- a/src/views/partials/__footer.njk
+++ b/src/views/partials/__footer.njk
@@ -25,15 +25,3 @@
         ]
     }
 }) }}
-<div id="templateName" data-id="{{title}}" hidden></div>
-<script type="application/javascript" nonce={{ nonce | dump | safe }}>
-  window.SERVICE_NAME = '{{ serviceName }}' + ' - '
-  window.PIWIK_URL = '{{ PIWIK_URL }}'
-  window.PIWIK_SITE_ID = '{{ PIWIK_SITE_ID }}'
-</script>
-<script src="{{ cdnHost }}/javascripts/govuk-frontend/v4.6.0/govuk-frontend-4.6.0.min.js"></script>
-<script src="{{ cdnHost }}/javascripts/app/cookie-consent/cookie-consent-1.0.0.js"></script>
-<script src="{{ cdnHost }}/javascripts/app/cookie-consent/matomo-only-cookie-consent.js"></script>
-<script src="{{ cdnHost }}/javascripts/vendor/jquery-3.5.1.min.js"></script>
-<script src="{{ cdnHost }}/javascripts/lib/navbar.js"></script>
-<script nonce={{ nonce | dump | safe }}>window.GOVUKFrontend.initAll()</script>

--- a/src/views/partials/__meta_footer.njk
+++ b/src/views/partials/__meta_footer.njk
@@ -1,4 +1,11 @@
-<script src="/js/app.min.js"></script>
+<script type="application/javascript" nonce={{ nonce | dump | safe }}>
+  window.SERVICE_NAME = '{{ serviceName }}' + ' - '
+  window.PIWIK_URL = '{{ PIWIK_URL }}'
+  window.PIWIK_SITE_ID = '{{ PIWIK_SITE_ID }}'
+</script>
+<div id="templateName" data-id="{{title}}" hidden></div>
+
 <script src="{{ cdnHost }}/javascripts/app/cookie-consent/cookie-consent-1.0.0.js"></script>
 <script src="{{ cdnHost }}/javascripts/app/cookie-consent/piwik-only-cookie-consent.js"></script>
 <script src="{{ cdnHost }}/javascripts/vendor/jquery-3.3.1.min.js"></script>
+<script src="{{ cdnHost }}/javascripts/lib/navbar.js"></script>

--- a/src/views/partials/cookie_consent_banner.njk
+++ b/src/views/partials/cookie_consent_banner.njk
@@ -1,18 +1,18 @@
 {% from "govuk/components/cookie-banner/macro.njk"  import govukCookieBanner %}
 
 {% set html %}
-<p>{{i18n.cookiesBanner1}}</p>
-<p>{{i18n.cookiesBanner2}}</p>
+<p class="govuk-body">{{i18n.cookiesBanner1}}</p>
+<p class="govuk-body">{{i18n.cookiesBanner2}}</p>
 {% endset %}
 
 {% set acceptHtml %}
- <p>{{ i18n.acceptedAnalyticsCookies }} {{ i18n.changeCookie1 }} <a class="govuk-link" target="_blank" rel="noopener noreferrer"
- href="{{ CHS_URL }}/help/cookies">{{ i18n.changeCookie2 }} {{ i18n.openInNewTab }}</a> {{ i18n.changeCookie3 }}</p>
+ <p class="govuk-body">{{ i18n.acceptedAnalyticsCookies }} {{ i18n.changeCookie1 }} <a class="govuk-link" target="_blank" rel="noopener noreferrer"
+ href="{{ CHS_URL }}/help/cookies">{{ i18n.changeCookie2 | replace ('{OPEN_IN_NEW_TAB}', i18n.openInNewTab) }}</a> {{ i18n.changeCookie3 }}</p>
 {% endset %}
 
 {% set rejectHtml %}
- <p>{{ i18n.rejectedAnalyticsCookies }} {{ i18n.changeCookie1 }} <a class="govuk-link" target="_blank" rel="noopener noreferrer" 
- href="{{ CHS_URL }}/help/cookies">{{ i18n.changeCookie2 }} {{ i18n.openInNewTab }}</a> {{ i18n.changeCookie3 }}</p>
+ <p class="govuk-body">{{ i18n.rejectedAnalyticsCookies }} {{ i18n.changeCookie1 }} <a class="govuk-link" target="_blank" rel="noopener noreferrer"
+ href="{{ CHS_URL }}/help/cookies">{{ i18n.changeCookie2 | replace ('{OPEN_IN_NEW_TAB}', i18n.openInNewTab) }}</a> {{ i18n.changeCookie3 }}</p>
 {% endset %}
 
 {{ govukCookieBanner({
@@ -49,7 +49,7 @@
       }
       },
       {
-        text: i18n.viewCookies + " " + i18n.openInNewTab,
+        text: i18n.viewCookies | replace ('{OPEN_IN_NEW_TAB}', i18n.openInNewTab),
         href: chsUrl + "/help/cookies",
         attributes: {
           target: "_blank",

--- a/src/views/partials/nav/back_link.njk
+++ b/src/views/partials/nav/back_link.njk
@@ -6,6 +6,7 @@
             href: previousPage
         })
     }}
-
-
 </span>
+{% if journeyType == "register-acsp" %}
+    <hr class="govuk-section-break">
+{% endif %}

--- a/src/views/partials/nav/navbar.njk
+++ b/src/views/partials/nav/navbar.njk
@@ -1,7 +1,5 @@
 {% from "navbar.njk" import addPredefinedNavbar %}
 
 {% if userEmail %}
-    <div class="govuk-!-padding-top-2">
-        {{ addPredefinedNavbar(userEmail, chsMonitorGuiUrl, i18n, displayAuthorisedAgent, "no", "no", accountUrl, lang) }}
-    </div>
+    {{ addPredefinedNavbar(userEmail, chsMonitorGuiUrl, i18n, displayAuthorisedAgent, "no", "no", accountUrl, lang) }}
 {% endif %}

--- a/src/views/partials/nav/signout-bar.njk
+++ b/src/views/partials/nav/signout-bar.njk
@@ -12,6 +12,5 @@
             </a>
         </li>
     </ul>
-    <hr class="govuk-section-break govuk-section-break--m">
     <script src="{{cdnHost}}/javascripts/app/session-timeout.js"></script>
 {% endif %}

--- a/src/views/partials/phase_banner.njk
+++ b/src/views/partials/phase_banner.njk
@@ -1,7 +1,7 @@
 <div class="govuk-phase-banner" role="region" aria-label="This is a new service">
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-tag--blue govuk-phase-banner__content__tag">
-      beta
+      Beta
     </strong>
     <span class="govuk-phase-banner__text">
       This is a new service – your 


### PR DESCRIPTION
Updates made to ACSP web applications against the following tickets returned from testing:
[IDVA5-2553](https://companieshouse.atlassian.net/browse/IDVA5-2553)
[IDVA5-2454](https://companieshouse.atlassian.net/browse/IDVA5-2454)

- It was flagged during testing that previously the 'beta' tag element was styled differently (bold text, all uppercase). It is now intentional by design that these tag elements no longer follow the same design (no longer bold and all uppercase):

[GDS - Tag](https://design-system.service.gov.uk/components/tag/)
[GDS - Phase Banner](https://design-system.service.gov.uk/components/phase-banner/)
<img width="979" height="460" alt="Screenshot 2025-09-02 at 13 02 43" src="https://github.com/user-attachments/assets/26ebcd88-6f67-4de1-b822-bc18e1913b8f" />

-----------------

- Fixed an issue with padding on the <main> tag element, that was causing a gap between the header and the main page content of the application.

**Update 04/09/25:**
Following the review comments on this PR, this has now been correctly implemented by restructuring the default.njk file, rather than overriding the padding set on govuk-main-wrapper class 

**Before:** 

<img width="1179" height="575" alt="Screenshot 2025-09-03 at 16 16 18" src="https://github.com/user-attachments/assets/cd8d789d-480e-42e3-b5cd-e5045fb4941a" />

**After:**

<img width="1070" height="542" alt="Screenshot 2025-09-03 at 16 23 42" src="https://github.com/user-attachments/assets/338bdbc7-c29f-4e78-b9fe-423d7a6844fc" />

-----------------


- Fixed an issue with the javascript file for 5.11.0 pointing to a placeholder within the code, this now points to the cdn repo:

<img width="1022" height="111" alt="Screenshot 2025-09-03 at 16 25 51" src="https://github.com/user-attachments/assets/e3b96363-11a5-42c7-9c40-851b8606237e" />
<img width="489" height="430" alt="Screenshot 2025-09-03 at 16 26 14" src="https://github.com/user-attachments/assets/82b67b72-39a2-407d-bac3-57a1710661b7" />

-----------------

- Refactoring and moving render location of the Cookie banner.

**Before:**

<img width="1180" height="818" alt="Screenshot 2025-09-03 at 16 27 46" src="https://github.com/user-attachments/assets/b39e5311-bbe1-4c5c-8a64-66bb7e1e26c5" />

**After:**

<img width="1147" height="951" alt="Screenshot 2025-09-03 at 16 29 53" src="https://github.com/user-attachments/assets/b4242d34-8316-4fc8-977d-24b837b6cf78" />

-----------------

- There has been a recent change made to the scripts with ch-node-utils > template.njk to allow support for nonce values to pass CSP:

[PR40](https://github.com/companieshouse/ch-node-utils/pull/40)
Dependancy now updated to match the latest tag. 
This fixes an issue with running the inline scripts for interactive elements (conditional radios buttons for example)

-----------------

- Adding the Gov.uk Design System allowed hash value from: [Frontend Design System](https://frontend.design-system.service.gov.uk/import-javascript/#if-our-inline-javascript-snippet-is-blocked-by-a-content-security-policy)
to our CSP policy to allow running inline scripts 

-----------------

- Moving section break to back_link.njk as this was causing display issues after refactoring of default.njk file -> this section break only applies to Registration service as we use the custom signout-bar.njk

<img width="1062" height="344" alt="Screenshot 2025-09-04 at 15 12 27" src="https://github.com/user-attachments/assets/1cdcfb8d-c6d9-4109-9499-1a999c2a485e" />



[IDVA5-2553]: https://companieshouse.atlassian.net/browse/IDVA5-2553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDVA5-2454]: https://companieshouse.atlassian.net/browse/IDVA5-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ