### PR TITLE
Adding section break to relevant screens and updating welsh

### DIFF
--- a/locales/cy/cookie-consent-banner.json
+++ b/locales/cy/cookie-consent-banner.json
@@ -4,11 +4,11 @@
   "cookiesBanner2": "Hoffem hefyd ddefnyddio cwcis dadansoddol fel y gallwn ddeall sut rydych yn defnyddio ein gwasanaethau ac i wneud gwelliannau.",
   "acceptAnalyticCookies": "Derbyn cwcis dadansoddol",
   "rejectAnalyticCookies": "Gwrthod cwcis dadansoddol",
-  "viewCookies": "Gweld cwcis",
+  "viewCookies": "Gweld cwcis ({OPEN_IN_NEW_TAB})",
   "acceptedAnalyticsCookies": "Rydych wedi derbyn cwcis dadansoddol.",
   "rejectedAnalyticsCookies": "Rydych wedi gwrthod cwcis dadansoddol.",
   "changeCookie1": "Gallwch",
-  "changeCookie2": "newid eich gosodiadau cwcis",
+  "changeCookie2": "newid eich gosodiadau cwcis ({OPEN_IN_NEW_TAB})",
   "changeCookie3": "ar unrhyw adeg.",
   "cookieNoJS": "Rydym yn defnyddio cwcis i wneud i'n gwasanaethau weithio a chasglu gwybodaeth ddadansoddol. I dderbyn neu wrthod cwcis dadansoddol, trowch JavaScript ymlaen yn osodiadau eich porwr ac ail-lwytho'r dudalen hon.",
   "cookieHide": "Cuddio'r neges hon"

--- a/src/views/common/application-confirmation/application-confirmation.njk
+++ b/src/views/common/application-confirmation/application-confirmation.njk
@@ -7,6 +7,7 @@
 {% block backLink %}
   {# Remove back button on this page by replacing it empty div to keep the nav bar underline correct #}
   <div class="back-link-removed-div"></div>
+  <hr class="govuk-section-break">
 {% endblock %}
 {% set title = i18n.applicationSubmittedTitle %}
 {% block main_content %}

--- a/src/views/common/payment-failed/payment-failed.njk
+++ b/src/views/common/payment-failed/payment-failed.njk
@@ -3,6 +3,7 @@
 {% block backLink %}
   {# Remove back button on this page by replacing it empty div to keep the nav bar underline correct #}
   <div class="back-link-removed-div"></div>
+  <hr class="govuk-section-break">
 {% endblock %}
 {% block main_content %}
     <h1 class="govuk-heading-l">{{ i18n.paymentFailedHeading }}</h1>

--- a/src/views/common/stop-not-relevant-officer/stop-not-relevant-officer.njk
+++ b/src/views/common/stop-not-relevant-officer/stop-not-relevant-officer.njk
@@ -3,6 +3,7 @@
 {% block backLink %}
   {# Remove back button on this page by replacing it empty div to keep the nav bar underline correct #}
   <div class="back-link-removed-div"></div>
+  <hr class="govuk-section-break">
   {% endblock %}
 {% set title = i18n.cannotUseServiceTitle %}
 {% block main_content %}

--- a/src/views/features/limited/business-mustbe-aml-registered/business-mustbe-aml-registered.njk
+++ b/src/views/features/limited/business-mustbe-aml-registered/business-mustbe-aml-registered.njk
@@ -6,6 +6,7 @@
 {% block backLink %}
   {# Remove back button on this page by replacing it empty div to keep the nav bar underline correct #}
   <div class="back-link-removed-div"></div>
+  <hr class="govuk-section-break">
   {% endblock %}
 {% set title = i18n.amlInterruptTitle %}
 {% block main_content %}

--- a/src/views/features/limited/company-inactive/company-inactive.njk
+++ b/src/views/features/limited/company-inactive/company-inactive.njk
@@ -3,6 +3,7 @@
 {% block backLink %}
   {# Remove back button on this page by replacing it empty div to keep the nav bar underline correct #}
   <div class="back-link-removed-div"></div>
+  <hr class="govuk-section-break">
   {% endblock %}
 {% set title = i18n.companyInactiveTitle %}
 {% block main_content %}

--- a/src/views/partials/error_400.njk
+++ b/src/views/partials/error_400.njk
@@ -3,6 +3,7 @@
 {% block backLink %}
   {# Remove back button on this page by replacing it empty div to keep the nav bar underline correct #}
   <div class="back-link-removed-div"></div>
+  <hr class="govuk-section-break">
 {% endblock %}
 
 {% block main_content %}	

--- a/src/views/partials/error_404.njk
+++ b/src/views/partials/error_404.njk
@@ -3,6 +3,7 @@
 {% block backLink %}
   {# Remove back button on this page by replacing it empty div to keep the nav bar underline correct #}
   <div class="back-link-removed-div"></div>
+  <hr class="govuk-section-break">
 {% endblock %}
 
 {% block main_content %}	

--- a/src/views/partials/error_500.njk
+++ b/src/views/partials/error_500.njk
@@ -2,6 +2,7 @@
 {% block backLink %}
   {# Remove back button on this page by replacing it empty div to keep the nav bar underline correct #}
   <div class="back-link-removed-div"></div>
+  <hr class="govuk-section-break">
   {% endblock %}
 
 {% block main_content %}


### PR DESCRIPTION
Update linked to ticket:
[IDVA5-2454](https://companieshouse.atlassian.net/browse/IDVA5-2454)

- Updating Welsh for cookie banner content -> (opens in new tab) -> matches en content for this banner
- Adding visual section break back into relevant screens as this has been moved from the signout_bar.njk file -> backlink.njk

[IDVA5-2454]: https://companieshouse.atlassian.net/browse/IDVA5-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ