### PR TITLE
IDVA5-2592 Adding http:// url to CSP

### DIFF
--- a/src/middleware/content_security_policy_middleware_config.ts
+++ b/src/middleware/content_security_policy_middleware_config.ts
@@ -17,7 +17,7 @@ export const prepareCSPConfig = (nonce: string) : HelmetOptions => {
                 imgSrc: [CDN_HOST],
                 styleSrc: [NONCE, CDN_HOST],
                 connectSrc: [SELF, PIWIK_URL, CHS_URL],
-                formAction: formActionDirective(),
+                formAction: formActionDirectiveDefault(),
                 scriptSrc: [NONCE, CDN_HOST, PIWIK_URL, DS_SCRIPT_HASH],
                 manifestSrc: [CDN_HOST],
                 objectSrc: [`'none'`]
@@ -44,8 +44,9 @@ export const prepareCSPConfigHomePage = (nonce: string) : HelmetOptions => {
                 imgSrc: [CDN_HOST],
                 styleSrc: [NONCE, CDN_HOST],
                 connectSrc: [SELF, PIWIK_URL, CHS_URL],
-                formAction: formActionDirective(),
+                formAction: formActionDirectiveHomePage(),
                 scriptSrc: [NONCE, CDN_HOST, PIWIK_URL, DS_SCRIPT_HASH],
+                manifestSrc: [CDN_HOST],
                 objectSrc: [`'none'`]
             }
         },
@@ -59,13 +60,14 @@ export const prepareCSPConfigHomePage = (nonce: string) : HelmetOptions => {
     };
 };
 
-const formActionDirective = () => {
+const formActionDirectiveHomePage = () => {
     return [
         SELF,
         "https://*.chdev.org",
         "https://*.cidev.aws.chdev.org/",
         "https://cidev.aws.chdev.org/",
         "https://account.cidev.aws.chdev.org/",
+        "http://account.cidev.aws.chdev.org/",
         "https://identity.company-information.service.gov.uk/"
     ];
 };


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2592

Saw in the response header the location in network tab is: http://account.cidev.aws.chdev.org/oauth2/user/onelogin-required?...

So adding http:// url to CSP to test if this allows redirect