### PR TITLE
Fix/idva5 2553 update validation where do you live no country input

### DIFF
--- a/src/middleware/content_security_policy_middleware_config.ts
+++ b/src/middleware/content_security_policy_middleware_config.ts
@@ -46,7 +46,6 @@ export const prepareCSPConfigHomePage = (nonce: string) : HelmetOptions => {
                 connectSrc: [SELF, PIWIK_URL, CHS_URL],
                 formAction: formActionDirective(),
                 scriptSrc: [NONCE, CDN_HOST, PIWIK_URL, DS_SCRIPT_HASH],
-                manifestSrc: [CDN_HOST],
                 objectSrc: [`'none'`]
             }
         },

--- a/src/middleware/content_security_policy_middleware_config.ts
+++ b/src/middleware/content_security_policy_middleware_config.ts
@@ -46,6 +46,7 @@ export const prepareCSPConfigHomePage = (nonce: string) : HelmetOptions => {
                 connectSrc: [SELF, PIWIK_URL, CHS_URL],
                 formAction: formActionDirective(),
                 scriptSrc: [NONCE, CDN_HOST, PIWIK_URL, DS_SCRIPT_HASH],
+                manifestSrc: [CDN_HOST],
                 objectSrc: [`'none'`]
             }
         },

--- a/src/validation/whereDoYouLive.ts
+++ b/src/validation/whereDoYouLive.ts
@@ -2,7 +2,7 @@ import { Session } from "@companieshouse/node-session-handler";
 import { body } from "express-validator";
 import countryList from "../../lib/countryList";
 import { AcspFullProfile } from "private-api-sdk-node/dist/services/acsp-profile/types";
-import { ACSP_DETAILS } from "../common/__utils/constants";
+import { ACSP_DETAILS, REQ_TYPE_UPDATE_ACSP } from "../common/__utils/constants";
 import { trimAndLowercaseString } from "../services/common";
 
 const isSameAsExistingCountry = (input: string, req: any): boolean => {
@@ -12,12 +12,16 @@ const isSameAsExistingCountry = (input: string, req: any): boolean => {
     return trimAndLowercaseString(input) === existingResidentialCountry;
 };
 
+const isUpdateAcspRequest = (req: any): boolean => {
+    return req.res?.locals?.reqType === REQ_TYPE_UPDATE_ACSP;
+};
+
 export const whereDoYouLiveValidator = [
     body("countryInput", "whereDoYouLiveEmptyInput")
         .trim()
         .custom((value, { req }) => {
             if (req.body.whereDoYouLiveRadio === "countryOutsideUK") {
-                if (isSameAsExistingCountry(value, req)) {
+                if (isUpdateAcspRequest(req) && isSameAsExistingCountry(value, req)) {
                     throw new Error("whereDoYouLiveNoChangeUpdateAcsp");
                 }
 
@@ -32,7 +36,7 @@ export const whereDoYouLiveValidator = [
     body("whereDoYouLiveRadio", "whereDoYouLiveNoData")
         .notEmpty().bail()
         .custom((value, { req }) => {
-            if (isSameAsExistingCountry(value, req)) {
+            if (isUpdateAcspRequest(req) && isSameAsExistingCountry(value, req)) {
                 throw new Error("whereDoYouLiveNoChangeUpdateAcsp");
             }
             return true;

--- a/src/validation/whereDoYouLive.ts
+++ b/src/validation/whereDoYouLive.ts
@@ -12,8 +12,8 @@ const isSameAsExistingCountry = (input: string, req: any): boolean => {
     return trimAndLowercaseString(input) === existingResidentialCountry;
 };
 
-const isUpdateAcspRequest = (req: any): boolean => {
-    return req.res?.locals?.reqType === REQ_TYPE_UPDATE_ACSP;
+export const isUpdateAcspRequest = (req: any): boolean => {
+    return req.res.locals.reqType === REQ_TYPE_UPDATE_ACSP;
 };
 
 export const whereDoYouLiveValidator = [

--- a/src/views/layouts/default.njk
+++ b/src/views/layouts/default.njk
@@ -52,8 +52,6 @@
   {% endblock %}
 {% endblock %}
 
-
-
 {% block bodyStart %}
   {% include "partials/cookie_consent_banner.njk" %}
 {% endblock %}

--- a/test/src/controllers/updateAcspDetails/whereDoYouLiveController.test.ts
+++ b/test/src/controllers/updateAcspDetails/whereDoYouLiveController.test.ts
@@ -8,13 +8,14 @@ import supertest from "supertest";
 import app from "../../../../src/app";
 import { UPDATE_DATE_OF_THE_CHANGE, UPDATE_ACSP_WHAT_IS_YOUR_NAME, UPDATE_ACSP_DETAILS_BASE_URL, UPDATE_WHERE_DO_YOU_LIVE } from "../../../../src/types/pageURL";
 import { getSessionRequestWithPermission } from "../../../mocks/session.mock";
-import { ACSP_DETAILS, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED } from "../../../../src/common/__utils/constants";
+import { ACSP_DETAILS, ACSP_DETAILS_UPDATE_IN_PROGRESS, ACSP_DETAILS_UPDATED, REQ_TYPE_UPDATE_ACSP } from "../../../../src/common/__utils/constants";
 import { WhereDoYouLiveBodyService } from "../../../../src/services/where-do-you-live/whereDoYouLive";
 import { mockSoleTraderAcspFullProfile } from "../../../mocks/update_your_details.mock";
 import * as localise from "../../../../src/utils/localise";
 import { sessionMiddleware } from "../../../../src/middleware/session_middleware";
 import { dummyFullProfile } from "../../../mocks/acsp_profile.mock";
 import { Request, Response, NextFunction } from "express";
+import { isUpdateAcspRequest } from "../../../../src/validation/whereDoYouLive";
 
 jest.mock("../../../../src/services/update-acsp/updateYourDetailsService");
 jest.mock("../../../../src/services/where-do-you-live/whereDoYouLive");
@@ -188,6 +189,45 @@ describe("POST" + UPDATE_WHERE_DO_YOU_LIVE, () => {
 
         expect(res.status).toBe(400);
         expect(res.text).toContain("Select to update where you live if it’s changed or cancel the update");
+    });
+});
+
+describe("isUpdateAcspRequest", () => {
+    it("should return true when reqType is REQ_TYPE_UPDATE_ACSP", () => {
+        const mockReq = {
+            res: {
+                locals: {
+                    reqType: REQ_TYPE_UPDATE_ACSP
+                }
+            }
+        };
+
+        const result = isUpdateAcspRequest(mockReq);
+        expect(result).toBe(true);
+    });
+
+    it("should return false when reqType is not REQ_TYPE_UPDATE_ACSP", () => {
+        const mockReq = {
+            res: {
+                locals: {
+                    reqType: "OTHER_REQ_TYPE"
+                }
+            }
+        };
+
+        const result = isUpdateAcspRequest(mockReq);
+        expect(result).toBe(false);
+    });
+
+    it("should return false when reqType is undefined)", () => {
+        const mockReq = {
+            res: {
+                locals: {}
+            }
+        };
+
+        const result = isUpdateAcspRequest(mockReq);
+        expect(result).toBe(false);
     });
 });
 

--- a/test/src/controllers/updateAcspDetails/whereDoYouLiveController.test.ts
+++ b/test/src/controllers/updateAcspDetails/whereDoYouLiveController.test.ts
@@ -219,7 +219,7 @@ describe("isUpdateAcspRequest", () => {
         expect(result).toBe(false);
     });
 
-    it("should return false when reqType is undefined)", () => {
+    it("should return false when reqType is undefined", () => {
         const mockReq = {
             res: {
                 locals: {}


### PR DESCRIPTION
Fix linked to ticket:
[IDVA5-2553](https://companieshouse.atlassian.net/browse/IDVA5-2553)

- Corrects an issue where the Update ACSP validation was triggering on Registration service when selecting Country outside UK radio option and inputting no data into field input.
- Added a reqType check in to only trigger the Update ACSP validation for this field when using the relevant web service

[IDVA5-2553]: https://companieshouse.atlassian.net/browse/IDVA5-2553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ