### PR TITLE
Adding gov.uk domains to default CSP to fix signout issue

### DIFF
--- a/src/middleware/content_security_policy_middleware_config.ts
+++ b/src/middleware/content_security_policy_middleware_config.ts
@@ -65,15 +65,14 @@ const formActionDirectiveHomePage = () => {
     const HTTP_ACCOUNT_URL = ACCOUNT_URL.replace(/^https:\/\//, "http://");
     return [
         SELF,
-        "https://*.chdev.org",
-        "https://*.cidev.aws.chdev.org/",
-        "https://cidev.aws.chdev.org/",
+        PIWIK_CHS_DOMAIN,
+        CHS_URL,
         ACCOUNT_URL,
-        HTTP_ACCOUNT_URL,
-        "https://identity.company-information.service.gov.uk/"
+        HTTP_ACCOUNT_URL
     ];
 };
 
 const formActionDirectiveDefault = () => {
-    return [SELF, PIWIK_CHS_DOMAIN, CHS_URL];
+    const GOV_UK = "https://*.gov.uk";
+    return [SELF, PIWIK_CHS_DOMAIN, CHS_URL, GOV_UK];
 };


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2592

Added GOV_UK = "https://*.gov.uk" to CSP for default to allow sign out button redirect to work correctly to allow following redirect from response header:

`https://oidc.integration.account.gov.uk/logout?`