### PR TITLE
IDVA5-2592 Tidying up urls and using env values for http and https protocols

### DIFF
--- a/src/middleware/content_security_policy_middleware_config.ts
+++ b/src/middleware/content_security_policy_middleware_config.ts
@@ -61,18 +61,22 @@ export const prepareCSPConfigHomePage = (nonce: string) : HelmetOptions => {
 };
 
 const formActionDirectiveHomePage = () => {
-    const ACCOUNT_URL = "https://account.cidev.aws.chdev.org/";
-    const HTTP_ACCOUNT_URL = ACCOUNT_URL.replace(/^https:\/\//, "http://");
+    const HTTP = "http://";
+    const HTTPS = "https://";
+
+    // Allows redirect to both https:// and http:// CHS urls
     const CHS_URL = process.env.CHS_URL as string;
     const HTTP_CHS_URL: string = CHS_URL.replace(/^https:\/\//, "http://");
+
+    // Allows redirect to  https://oidc.integration.account.gov.uk/logout when signing out
     const GOV_UK = "https://*.gov.uk";
+
     return [
         SELF,
-        PIWIK_CHS_DOMAIN,
+        HTTP + PIWIK_CHS_DOMAIN,
+        HTTPS + PIWIK_CHS_DOMAIN,
         CHS_URL,
         HTTP_CHS_URL,
-        ACCOUNT_URL,
-        HTTP_ACCOUNT_URL,
         GOV_UK
     ];
 };


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IDVA5-2592

Finalising URLs for formActionDirectiveHomePage function. These replace hardcoded values and use env variables to allow for testing in cidiv and staging.

These cover the http:// redirect to account. url and also gov.uk urls to cover sign out redirects.