### PR TITLE
Updating start page content

### DIFF
--- a/locales/cy/start-page.json
+++ b/locales/cy/start-page.json
@@ -5,7 +5,7 @@
     "ifYouHaveAnyIssuesNotificationBanner": "Os oes gennych unrhyw broblemau wrth i ni weithio i'w wella, gallwch gysylltu â ni neu ddweud wrthym eich ",
     "feedbackLinkNotificationBanner": "adborth",
     "useThisService": "Defnyddiwch y gwasanaeth hwn i gofrestru eich hun, neu'ch busnes fel Darparwr Gwasanaeth Corfforaethol Awdurdodedig (ACSP). Gelwir Darparwr Gwasanaeth Corfforaethol Awdurdodedig hefyd yn asiantau awdurdodedig.",
-    "forNowYouOnlyNeedToRegister": "Am y tro, dim ond os ydych chi'n bwriadu gwirio hunaniaeth pobl ar gyfer Tŷ'r Cwmnïau y mae angen i chi gofrestru. Bydd y gwasanaeth i ddweud wrthym pryd rydych wedi gwirio hunaniaeth rhywun ar gael yn fuan.",
+    "forNowYouOnlyNeedToRegister": "Am y tro, dim ond os ydych chi'n bwriadu gwirio hunaniaeth pobl ar gyfer Tŷ'r Cwmnïau y mae angen i chi gofrestru.",
     "whoCanApplyHeading": "Pwy all wneud cais",
     "toRegisterYourBusiness": "I gofrestru eich busnes fel asiant awdurdodedig, rhaid i chi fod yn un o'r canlynol:",
     "directorBullet": "cyfarwyddwr",

--- a/locales/en/start-page.json
+++ b/locales/en/start-page.json
@@ -5,7 +5,7 @@
     "ifYouHaveAnyIssuesNotificationBanner": "If you have any issues while we work to improve it, you can contact us or tell us your ",
     "feedbackLinkNotificationBanner": "feedback",
     "useThisService": "Use this service to register yourself, or your business as an Authorised Corporate Service Provider (ACSP). ACSPs are also known as authorised agents.",
-    "forNowYouOnlyNeedToRegister": "For now, you only need to register if you plan to verify people's identities for Companies House. The service to tell us when you’ve verified someone’s identity will be available soon.",
+    "forNowYouOnlyNeedToRegister": "For now, you only need to register if you plan to verify people's identities for Companies House.",
     "whoCanApplyHeading": "Who can apply",
     "toRegisterYourBusiness": "To register your business as an authorised agent, you must be one of the following:",
     "directorBullet": "director",


### PR DESCRIPTION
Ticket:
[IDVA5-2658](https://companieshouse.atlassian.net/browse/IDVA5-2658)

- Removing text 'The service to tell us when you’ve verified someone’s identity will be available soon.' from Registration start screen for English and Welsh locales files

[IDVA5-2658]: https://companieshouse.atlassian.net/browse/IDVA5-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ