### PR TITLE
IDVA5-2706 (spike): Investigate save and continue functionality for start page

### DIFF
--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,6 +1,7 @@
 export * as accessibilityStatementController from "./accessibilityStatementController";
 export * as healthCheckController from "./healthCheckController";
 export * as indexController from "./indexController";
+export * as startController from "./startController";
 export * as checkYourAnswersController from "./features/common/checkYourAnswers";
 export * as applicationConfirmationController from "./features/common/applicationConfirmationController";
 export * as yourResponsibilitiesController from "./features/common/yourResponsibilitiesController";

--- a/src/controllers/indexController.ts
+++ b/src/controllers/indexController.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
-import { BASE_URL, CHECK_SAVED_APPLICATION, VERIFY_IDENTITY_WITH_GOV_UK_ONE_LOGIN } from "../types/pageURL";
+import { BASE_URL, CHECK_SAVED_APPLICATION, START_URL, VERIFY_IDENTITY_WITH_GOV_UK_ONE_LOGIN } from "../types/pageURL";
 import {
     addLangToUrl,
     getLocaleInfo,
@@ -9,6 +9,7 @@ import {
 } from "../utils/localise";
 import { ACSP01_COST, PIWIK_REGISTRATION_START_GOAL_ID } from "../utils/properties";
 
+// TODO: Remove this controller and associated routes/views when the Whitehall page goes live
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
     const locales = getLocalesService();
@@ -19,7 +20,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     res.render(config.HOME, {
         ...getLocaleInfo(locales, lang),
         currentUrl: BASE_URL,
-        PIWIK_REGISTRATION_START_GOAL_ID,
+        PIWIK_REGISTRATION_START_GOAL_ID, // FIXME: Ask Matomo team to make this an implicit goal
         abilityNetAccessibilityLink,
         ACSP01_COST,
         verifyIdentityGovOneLoginLink
@@ -28,5 +29,5 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
-    res.redirect(addLangToUrl(BASE_URL + CHECK_SAVED_APPLICATION, lang));
+    res.redirect(addLangToUrl(BASE_URL + START_URL, lang));
 };

--- a/src/controllers/startController.ts
+++ b/src/controllers/startController.ts
@@ -1,0 +1,11 @@
+import { NextFunction, Request, Response } from "express";
+import { BASE_URL, CHECK_SAVED_APPLICATION } from "../types/pageURL";
+import {
+    addLangToUrl,
+    selectLang
+} from "../utils/localise";
+
+export const get = async (req: Request, res: Response, next: NextFunction) => {
+    const lang = selectLang(req.query.lang);
+    res.redirect(addLangToUrl(BASE_URL + CHECK_SAVED_APPLICATION, lang));
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -62,7 +62,8 @@ import {
     soleTraderWhatIsYourEmailAddressController,
     unincorporatedWhatIsYourEmailController,
     cannotRegisterAgainController,
-    paymentFailedController
+    paymentFailedController,
+    startController
 } from "../controllers";
 
 import * as urls from "../types/pageURL";
@@ -97,6 +98,8 @@ const routes = Router();
 
 routes.get(urls.HOME_URL, indexController.get);
 routes.post(urls.HOME_URL, indexController.post);
+
+routes.get(urls.START_URL, startController.get);
 
 routes.get(urls.ACCESSIBILITY_STATEMENT, accessibilityStatementController.get);
 

--- a/src/types/pageURL.ts
+++ b/src/types/pageURL.ts
@@ -2,9 +2,9 @@ import { ACCOUNT_URL, CHS_URL } from "../utils/properties";
 
 const SEPARATOR = "/";
 
-export const START = "/"; // Domain name will go here
-
 export const HOME_URL = "";
+
+export const START_URL = "/start";
 
 export const SIGN_OUT_PAGE = `signout`;
 


### PR DESCRIPTION
Inserts a new route `/start` between `/` and `/check-saved-application` to facilitate moving the start screen content to Whitehall. Note that when referring to the "start screen" I mean the `/` route, not `/start`. The purpose of `/start` is just to redirect to `/check-saved-application`. Technically it's not necessary to have this `/start` endpoint, but it makes things neater because the Whitehall page can just point to `https://.../register-as-companies-house-authorised-agent/start`.

## Functionality

The following videos show a mock Whitehall page linking to the `/start` endpoint & the existing functionality being maintained.

### Redirect to OneLogin
If the user is not already signed in then they are redirected to One Login as expected. Upon signing in they are redirected to the `/start` endpoint as expected.

https://github.com/user-attachments/assets/ea4b4891-445b-44a4-8cc2-872bd43dda3a

### New application

https://github.com/user-attachments/assets/84510609-3b35-4687-82d0-c0ad43443e5a

### Resume an existing application

https://github.com/user-attachments/assets/42869a13-efac-4a49-96cb-38c27b376257

