### PR TITLE
IDVA5-2720 Move "resume application" functionality behind a new endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1806,7 +1805,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3538,8 +3536,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.8.tgz",
       "integrity": "sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/nunjucks": {
       "version": "3.1.2",
@@ -3908,7 +3905,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4646,7 +4642,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4891,7 +4886,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -5764,7 +5758,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6884,7 +6877,6 @@
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.0.tgz",
       "integrity": "sha512-RYZDEF1J6nVw5XauQGH+91qplExgHUXfXII7dtIme6I4u3eSvU59yZ0/EFKEwRgTslSqlhJODOnAi5rnQFU5Gw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -7501,9 +7493,9 @@
       "license": "ISC"
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -8022,7 +8014,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -11520,7 +11511,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11618,7 +11608,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,6 +1,7 @@
 export * as accessibilityStatementController from "./accessibilityStatementController";
 export * as healthCheckController from "./healthCheckController";
 export * as indexController from "./indexController";
+export * as startController from "./startController";
 export * as checkYourAnswersController from "./features/common/checkYourAnswers";
 export * as applicationConfirmationController from "./features/common/applicationConfirmationController";
 export * as yourResponsibilitiesController from "./features/common/yourResponsibilitiesController";

--- a/src/controllers/indexController.ts
+++ b/src/controllers/indexController.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
-import { BASE_URL, CHECK_SAVED_APPLICATION, VERIFY_IDENTITY_WITH_GOV_UK_ONE_LOGIN } from "../types/pageURL";
+import { BASE_URL, CHECK_SAVED_APPLICATION, START_URL, VERIFY_IDENTITY_WITH_GOV_UK_ONE_LOGIN } from "../types/pageURL";
 import {
     addLangToUrl,
     getLocaleInfo,
@@ -9,6 +9,7 @@ import {
 } from "../utils/localise";
 import { ACSP01_COST, PIWIK_REGISTRATION_START_GOAL_ID } from "../utils/properties";
 
+// TODO: Remove this controller and associated routes/views when the Whitehall page goes live
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
     const locales = getLocalesService();
@@ -19,7 +20,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     res.render(config.HOME, {
         ...getLocaleInfo(locales, lang),
         currentUrl: BASE_URL,
-        PIWIK_REGISTRATION_START_GOAL_ID,
+        PIWIK_REGISTRATION_START_GOAL_ID, // FIXME: Ask Matomo team to make this an implicit goal
         abilityNetAccessibilityLink,
         ACSP01_COST,
         verifyIdentityGovOneLoginLink
@@ -28,5 +29,5 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
-    res.redirect(addLangToUrl(BASE_URL + CHECK_SAVED_APPLICATION, lang));
+    res.redirect(addLangToUrl(BASE_URL + START_URL, lang));
 };

--- a/src/controllers/indexController.ts
+++ b/src/controllers/indexController.ts
@@ -9,7 +9,6 @@ import {
 } from "../utils/localise";
 import { ACSP01_COST, PIWIK_REGISTRATION_START_GOAL_ID } from "../utils/properties";
 
-// TODO: Remove this controller and associated routes/views when the Whitehall page goes live
 export const get = async (req: Request, res: Response, next: NextFunction) => {
     const lang = selectLang(req.query.lang);
     const locales = getLocalesService();
@@ -20,7 +19,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     res.render(config.HOME, {
         ...getLocaleInfo(locales, lang),
         currentUrl: BASE_URL,
-        PIWIK_REGISTRATION_START_GOAL_ID, // FIXME: Ask Matomo team to make this an implicit goal
+        PIWIK_REGISTRATION_START_GOAL_ID,
         abilityNetAccessibilityLink,
         ACSP01_COST,
         verifyIdentityGovOneLoginLink

--- a/src/controllers/indexController.ts
+++ b/src/controllers/indexController.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import * as config from "../config";
-import { BASE_URL, CHECK_SAVED_APPLICATION, START_URL, VERIFY_IDENTITY_WITH_GOV_UK_ONE_LOGIN } from "../types/pageURL";
+import { BASE_URL, START_URL, VERIFY_IDENTITY_WITH_GOV_UK_ONE_LOGIN } from "../types/pageURL";
 import {
     addLangToUrl,
     getLocaleInfo,

--- a/src/controllers/startController.ts
+++ b/src/controllers/startController.ts
@@ -5,7 +5,7 @@ import {
     selectLang
 } from "../utils/localise";
 
-export const get = async (req: Request, res: Response, next: NextFunction) => {
+export const get = async (req: Request, res: Response, _next: NextFunction) => {
     const lang = selectLang(req.query.lang);
     res.redirect(addLangToUrl(BASE_URL + CHECK_SAVED_APPLICATION, lang));
 };

--- a/src/controllers/startController.ts
+++ b/src/controllers/startController.ts
@@ -1,0 +1,11 @@
+import { NextFunction, Request, Response } from "express";
+import { BASE_URL, CHECK_SAVED_APPLICATION } from "../types/pageURL";
+import {
+    addLangToUrl,
+    selectLang
+} from "../utils/localise";
+
+export const get = async (req: Request, res: Response, next: NextFunction) => {
+    const lang = selectLang(req.query.lang);
+    res.redirect(addLangToUrl(BASE_URL + CHECK_SAVED_APPLICATION, lang));
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -62,7 +62,8 @@ import {
     soleTraderWhatIsYourEmailAddressController,
     unincorporatedWhatIsYourEmailController,
     cannotRegisterAgainController,
-    paymentFailedController
+    paymentFailedController,
+    startController
 } from "../controllers";
 
 import * as urls from "../types/pageURL";
@@ -97,6 +98,8 @@ const routes = Router();
 
 routes.get(urls.HOME_URL, indexController.get);
 routes.post(urls.HOME_URL, indexController.post);
+
+routes.get(urls.START_URL, startController.get);
 
 routes.get(urls.ACCESSIBILITY_STATEMENT, accessibilityStatementController.get);
 

--- a/src/types/pageURL.ts
+++ b/src/types/pageURL.ts
@@ -2,9 +2,9 @@ import { ACCOUNT_URL, CHS_URL } from "../utils/properties";
 
 const SEPARATOR = "/";
 
-export const START = "/"; // Domain name will go here
-
 export const HOME_URL = "";
+
+export const START_URL = "/start";
 
 export const SIGN_OUT_PAGE = `signout`;
 

--- a/test/src/controllers/common/indexController.test.ts
+++ b/test/src/controllers/common/indexController.test.ts
@@ -1,7 +1,7 @@
 import mocks from "../../../mocks/all_middleware_mock";
 import supertest from "supertest";
 import app from "../../../../src/app";
-import { BASE_URL, HOME_URL, CHECK_SAVED_APPLICATION } from "../../../../src/types/pageURL";
+import { BASE_URL, HOME_URL, START_URL } from "../../../../src/types/pageURL";
 const router = supertest(app);
 
 describe("GET " + HOME_URL, () => {
@@ -16,7 +16,7 @@ describe("POST " + HOME_URL, () => {
     it("should return status 302 after redirect", async () => {
         const res = await router.post(BASE_URL);
         expect(res.status).toBe(302);
-        expect(res.header.location).toBe(BASE_URL + CHECK_SAVED_APPLICATION + "?lang=en");
+        expect(res.header.location).toBe(BASE_URL + START_URL + "?lang=en");
         expect(mocks.mockSessionMiddleware).toHaveBeenCalledTimes(0);
     });
 });

--- a/test/src/controllers/common/startController.test.ts
+++ b/test/src/controllers/common/startController.test.ts
@@ -1,0 +1,16 @@
+import mocks from "../../../mocks/all_middleware_mock";
+import supertest from "supertest";
+import app from "../../../../src/app";
+import { BASE_URL, CHECK_SAVED_APPLICATION, START_URL } from "../../../../src/types/pageURL";
+const router = supertest(app);
+
+describe("GET " + START_URL, () => {
+    it("should return status 302 after redirect", async () => {
+        const res = await router.get(BASE_URL + START_URL);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalledTimes(1);
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalledTimes(1);
+        expect(mocks.mockCsrfProtectionMiddleware).toHaveBeenCalledTimes(1);
+        expect(res.status).toBe(302);
+        expect(res.header.location).toBe(BASE_URL + CHECK_SAVED_APPLICATION + "?lang=en");
+    });
+});


### PR DESCRIPTION
Jira ticket: https://companieshouse.atlassian.net/browse/IDVA5-2720

Adds a new `/start` endpoint before `/check-saved-application` for the upcoming Whtiehall screen to link into.

## Working example

| Action | Result |
|--------|--------|
| <img width="893" height="496" alt="Screenshot 2026-03-13 at 13 16 39" src="https://github.com/user-attachments/assets/97b9e66d-0206-44e0-a6ec-3f98e58fc138" /> User presses the "Start now" button | <img width="1130" height="298" alt="Screenshot 2026-03-13 at 13 16 56" src="https://github.com/user-attachments/assets/fada2d02-ec63-4444-a313-e5708f7d3fa6" /> Network log shows redirect chain `/register-as-companies-house-authorised-agent -> /start -> /check-saved-application -> ...` | 
| <img width="689" height="122" alt="Screenshot 2026-03-13 at 13 17 24" src="https://github.com/user-attachments/assets/68c95fc7-6227-49a5-9385-b76c1f4579c9" /> User visists http://chs.local/register-as-companies-house-authorised-agent/start  | <img width="1126" height="280" alt="Screenshot 2026-03-13 at 13 17 50" src="https://github.com/user-attachments/assets/7f7eb268-81a0-4b9b-aa0a-19da8d45aeef" /> Network log shows redirect chain `/start -> /check-saved-application -> ...` | 

**Note:** you may also be prompted to sign in during the redirect chain, I've ensured that you get redirected to the correct place after being prompted to sign in.